### PR TITLE
 zend-loader and autoloader overhaul

### DIFF
--- a/packages/zend-amf/library/Zend/Amf/Server.php
+++ b/packages/zend-amf/library/Zend/Amf/Server.php
@@ -286,6 +286,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
         if(empty($this->_loader)) {
             // require_once 'Zend/Loader/PluginLoader.php';
             $this->_loader = new Zend_Loader_PluginLoader();
+            $this->_loader->useComposerAutoloader(false);
         }
         return $this->_loader;
     }
@@ -317,7 +318,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
                     throw new Zend_Amf_Server_Exception('Can not call "' . $className . '" - use setClass()');
                 }
                 try {
-                    $this->getLoader()->load($className);
+                    $this->getLoader()->load($className, true, false);
                 } catch (Exception $e) {
                     // require_once 'Zend/Amf/Server/Exception.php';
                     throw new Zend_Amf_Server_Exception('Class "' . $className . '" does not exist: '.$e->getMessage(), 0, $e);

--- a/packages/zend-application/library/Zend/Application.php
+++ b/packages/zend-application/library/Zend/Application.php
@@ -35,6 +35,11 @@ class Zend_Application
     protected $_autoloader;
 
     /**
+     * @var bool|null
+     */
+    protected $_suppressNotFoundWarnings;
+
+    /**
      * Bootstrap
      *
      * @var Zend_Application_Bootstrap_BootstrapAbstract
@@ -77,11 +82,7 @@ class Zend_Application
     public function __construct($environment, $options = null, $suppressNotFoundWarnings = null)
     {
         $this->_environment = (string) $environment;
-
-        // see https://github.com/zf1/zend-application/pull/2 for discussion
-        // require_once 'Zend/Loader/Autoloader.php';
-        // $this->_autoloader = Zend_Loader_Autoloader::getInstance();
-        // $this->_autoloader->suppressNotFoundWarnings($suppressNotFoundWarnings);
+        $this->_suppressNotFoundWarnings = $suppressNotFoundWarnings;
 
         if (null !== $options) {
             if (is_string($options)) {
@@ -116,6 +117,11 @@ class Zend_Application
      */
     public function getAutoloader()
     {
+        if (!$this->_autoloader) {
+            $this->_autoloader = Zend_Loader_Autoloader::getInstance();
+            $this->_autoloader->suppressNotFoundWarnings($this->_suppressNotFoundWarnings);
+        }
+
         return $this->_autoloader;
     }
 

--- a/packages/zend-application/library/Zend/Application/Resource/Mail.php
+++ b/packages/zend-application/library/Zend/Application/Resource/Mail.php
@@ -112,12 +112,12 @@ class Zend_Application_Resource_Mail extends Zend_Application_Resource_ResourceA
         }
 
         $transportName = $options['type'];
-        if (!Zend_Loader_Autoloader::autoload($transportName)) {
+        if (!class_exists($transportName)) {
             $transportName = ucfirst(strtolower($transportName));
 
-            if (!Zend_Loader_Autoloader::autoload($transportName)) {
+            if (!class_exists($transportName)) {
                 $transportName = 'Zend_Mail_Transport_' . $transportName;
-                if (!Zend_Loader_Autoloader::autoload($transportName)) {
+                if (!class_exists($transportName)) {
                     throw new Zend_Application_Resource_Exception(
                         "Specified Mail Transport '{$transportName}'"
                         . 'could not be found'

--- a/packages/zend-cache/library/Zend/Cache.php
+++ b/packages/zend-cache/library/Zend/Cache.php
@@ -88,7 +88,7 @@ abstract class Zend_Cache
      * @throws Zend_Cache_Exception
      * @return Zend_Cache_Core|Zend_Cache_Frontend
      */
-    public static function factory($frontend, $backend, $frontendOptions = array(), $backendOptions = array(), $customFrontendNaming = false, $customBackendNaming = false, $autoload = false)
+    public static function factory($frontend, $backend, $frontendOptions = array(), $backendOptions = array(), $customFrontendNaming = false, $customBackendNaming = false, $autoload = true)
     {
         if (is_string($backend)) {
             $backendObject = self::_makeBackend($backend, $backendOptions, $customBackendNaming, $autoload);
@@ -147,7 +147,7 @@ abstract class Zend_Cache
                 if (!(self::_isReadable($file))) {
                     self::throwException("file $file not found in include_path");
                 }
-                // require_once $file;
+                require_once $file;
             }
         }
         return new $backendClass($backendOptions);

--- a/packages/zend-cache/library/Zend/Cache/Backend/TwoLevels.php
+++ b/packages/zend-cache/library/Zend/Cache/Backend/TwoLevels.php
@@ -90,8 +90,8 @@ class Zend_Cache_Backend_TwoLevels extends Zend_Cache_Backend implements Zend_Ca
         'stats_update_factor' => 10,
         'slow_backend_custom_naming' => false,
         'fast_backend_custom_naming' => false,
-        'slow_backend_autoload' => false,
-        'fast_backend_autoload' => false,
+        'slow_backend_autoload' => true,
+        'fast_backend_autoload' => true,
         'auto_fill_fast_cache' => true,
         'auto_refresh_fast_cache' => true
     );

--- a/packages/zend-cache/library/Zend/Cache/Manager.php
+++ b/packages/zend-cache/library/Zend/Cache/Manager.php
@@ -169,7 +169,7 @@ class Zend_Cache_Manager
                 isset($this->_optionTemplates[$name]['backend']['options']) ? $this->_optionTemplates[$name]['backend']['options'] : array(),
                 isset($this->_optionTemplates[$name]['frontend']['customFrontendNaming']) ? $this->_optionTemplates[$name]['frontend']['customFrontendNaming'] : false,
                 isset($this->_optionTemplates[$name]['backend']['customBackendNaming']) ? $this->_optionTemplates[$name]['backend']['customBackendNaming'] : false,
-                isset($this->_optionTemplates[$name]['frontendBackendAutoload']) ? $this->_optionTemplates[$name]['frontendBackendAutoload'] : false
+                isset($this->_optionTemplates[$name]['frontendBackendAutoload']) ? $this->_optionTemplates[$name]['frontendBackendAutoload'] : true
             );
 
             return $this->_caches[$name];

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/Adapter/Ec2.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/Adapter/Ec2.php
@@ -371,7 +371,7 @@ class Zend_Cloud_Infrastructure_Adapter_Ec2 extends Zend_Cloud_Infrastructure_Ad
     public function zonesInstance()
     {
         if (!isset($this->ec2Zone)) {
-            $this->ec2Zone = new Zend_Service_Amazon_Ec2_AvailabilityZones($this->accessKey,$this->accessSecret,$this->region);
+            $this->ec2Zone = new Zend_Service_Amazon_Ec2_Availabilityzones($this->accessKey,$this->accessSecret,$this->region);
         }
         $this->adapterResult = $this->ec2Zone->describe();
 

--- a/packages/zend-filter/library/Zend/Filter/Encrypt.php
+++ b/packages/zend-filter/library/Zend/Filter/Encrypt.php
@@ -89,11 +89,9 @@ class Zend_Filter_Encrypt implements Zend_Filter_Interface
             $options = array();
         }
 
-        if (Zend_Loader::isReadable('Zend/Filter/Encrypt/' . ucfirst($adapter). '.php')) {
+        if (class_exists('Zend_Filter_Encrypt_' . ucfirst($adapter))) {
             $adapter = 'Zend_Filter_Encrypt_' . ucfirst($adapter);
-        }
-
-        if (!class_exists($adapter)) {
+        } elseif (!class_exists($adapter)) {
             Zend_Loader::loadClass($adapter);
         }
 

--- a/packages/zend-gdata/library/Zend/Gdata/App.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App.php
@@ -817,7 +817,7 @@ class Zend_Gdata_App
         $className='Zend_Gdata_App_Feed', $majorProtocolVersion = null,
         $minorProtocolVersion = null)
     {
-        if (!class_exists($className, false)) {
+        if (!class_exists($className)) {
           // require_once 'Zend/Loader.php';
           @Zend_Loader::loadClass($className);
         }
@@ -975,7 +975,7 @@ class Zend_Gdata_App
     public function insertEntry($data, $uri, $className='Zend_Gdata_App_Entry',
         $extraHeaders = array())
     {
-        if (!class_exists($className, false)) {
+        if (!class_exists($className)) {
           // require_once 'Zend/Loader.php';
           @Zend_Loader::loadClass($className);
         }
@@ -1016,7 +1016,7 @@ class Zend_Gdata_App
             $className = 'Zend_Gdata_App_Entry';
         }
 
-        if (!class_exists($className, false)) {
+        if (!class_exists($className)) {
           // require_once 'Zend/Loader.php';
           @Zend_Loader::loadClass($className);
         }
@@ -1055,7 +1055,10 @@ class Zend_Gdata_App
                  try {
                      // Autoloading disabled on next line for compatibility
                      // with magic factories. See ZF-6660.
-                     if (!class_exists($name . '_' . $class, false)) {
+                     Zend_Loader_Autoloader::setDisabled();
+                     $found = class_exists($name . '_' . $class);
+                     Zend_Loader_Autoloader::setDisabled(false);
+                     if (!$found) {
                         // require_once 'Zend/Loader.php';
                         @Zend_Loader::loadClass($name . '_' . $class);
                      }

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps.php
@@ -861,7 +861,10 @@ class Zend_Gdata_Gapps extends Zend_Gdata
                  try {
                      // Autoloading disabled on next line for compatibility
                      // with magic factories. See ZF-6660.
-                     if (!class_exists($name . '_' . $class, false)) {
+                     Zend_Loader_Autoloader::setDisabled();
+                     $found = class_exists($name . '_' . $class);
+                     Zend_Loader_Autoloader::setDisabled(false);
+                     if (!$found) {
                         // require_once 'Zend/Loader.php';
                         @Zend_Loader::loadClass($name . '_' . $class);
                      }

--- a/packages/zend-http/library/Zend/Http/Client.php
+++ b/packages/zend-http/library/Zend/Http/Client.php
@@ -641,7 +641,9 @@ class Zend_Http_Client
      */
     public function setCookieJar($cookiejar = true)
     {
-        Zend_Loader::loadClass('Zend_Http_CookieJar');
+        if (!class_exists('Zend_Http_CookieJar')) {
+            Zend_Loader::loadClass('Zend_Http_CookieJar');
+        }
 
         if ($cookiejar instanceof Zend_Http_CookieJar) {
             $this->cookiejar = $cookiejar;
@@ -679,7 +681,9 @@ class Zend_Http_Client
      */
     public function setCookie($cookie, $value = null)
     {
-        Zend_Loader::loadClass('Zend_Http_Cookie');
+        if (!class_exists('Zend_Http_Cookie')) {
+            Zend_Loader::loadClass('Zend_Http_Cookie');
+        }
 
         if (is_array($cookie)) {
             foreach ($cookie as $c => $v) {
@@ -924,7 +928,9 @@ class Zend_Http_Client
     {
         if (is_string($adapter)) {
             try {
-                Zend_Loader::loadClass($adapter);
+                if (!class_exists($adapter)) {
+                    Zend_Loader::loadClass($adapter);
+                }
             } catch (Zend_Exception $e) {
                 /** @see Zend_Http_Client_Exception */
                 // require_once 'Zend/Http/Client/Exception.php';

--- a/packages/zend-loader/library/Zend/Loader.php
+++ b/packages/zend-loader/library/Zend/Loader.php
@@ -51,7 +51,6 @@ class Zend_Loader
      */
     public static function loadClass($class, $dirs = null)
     {
-        return; // composer autoload should handle loading a class
         if (class_exists($class, false) || interface_exists($class, false)) {
             return;
         }

--- a/packages/zend-loader/library/Zend/Loader/Autoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/Autoloader.php
@@ -40,6 +40,11 @@ class Zend_Loader_Autoloader
     protected static $_instance;
 
     /**
+     * @var bool A flag to temporarily disable the autoloader
+     */
+    protected static $_disabled;
+
+    /**
      * @var array Concrete autoloader callback implementations
      */
     protected $_autoloaders = array();
@@ -115,6 +120,10 @@ class Zend_Loader_Autoloader
      */
     public static function autoload($class)
     {
+        if (self::$_disabled) {
+            return false;
+        }
+
         $self = self::getInstance();
 
         foreach ($self->getClassAutoloaders($class) as $autoloader) {
@@ -587,5 +596,12 @@ class Zend_Loader_Autoloader
 
         uksort($versions, 'version_compare');
         return $versions;
+    }
+
+    /**
+     * Toggle disabled flag for the autoloader
+     */
+    public static function setDisabled($flag = true) {
+        self::$_disabled = (bool)$flag;
     }
 }

--- a/packages/zend-loader/library/Zend/Loader/Autoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/Autoloader.php
@@ -65,13 +65,11 @@ class Zend_Loader_Autoloader
     protected $_internalAutoloader;
 
     /**
-     * This used to also support the ZendX pseudo namespace which wasn't
-     * really used anywhere in zendframework1.
-     *
-     * @var array Supported namespace 'Zend' by default.
+     * @var array Supported namespaces 'Zend' and 'ZendX' by default.
      */
     protected $_namespaces = array(
         'Zend_'  => true,
+        'ZendX_' => true,
     );
 
     /**

--- a/packages/zend-loader/library/Zend/Loader/ClassMapAutoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/ClassMapAutoloader.php
@@ -145,7 +145,7 @@ class Zend_Loader_ClassMapAutoloader implements Zend_Loader_SplAutoloader
     public function autoload($class)
     {
         if (isset($this->map[$class])) {
-            // require_once $this->map[$class];
+            require_once $this->map[$class];
         }
     }
 
@@ -204,16 +204,16 @@ class Zend_Loader_ClassMapAutoloader implements Zend_Loader_SplAutoloader
      */
     public static function realPharPath($path)
     {
-        if (strpos($path, 'phar:///') !== 0) {
+        if (strpos($path, 'phar://') !== 0) {
             return;
         }
         
-        $parts = explode('/', str_replace(array('/','\\'), '/', substr($path, 8)));
+        $parts = explode('/', str_replace(array('/','\\'), '/', substr($path, 7)));
+        $prependSlash = $parts && $parts[0] === '' ? '/' : '';
         $parts = array_values(array_filter($parts, array(__CLASS__, 'concatPharParts')));
 
         array_walk($parts, array(__CLASS__, 'resolvePharParentPath'), $parts);
-
-        if (file_exists($realPath = 'phar:///' . implode('/', $parts))) {
+        if (file_exists($realPath = 'phar://' . $prependSlash . implode('/', $parts))) {
             return $realPath;
         }
     }

--- a/packages/zend-loader/library/Zend/Loader/PluginLoader.php
+++ b/packages/zend-loader/library/Zend/Loader/PluginLoader.php
@@ -105,6 +105,12 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
     protected $_useStaticRegistry = null;
 
     /**
+     * Use composer autoloader
+     * @var bool
+     */
+    protected $_useComposerAutoloader = true;
+
+    /**
      * Constructor
      *
      * @param array $prefixToPaths
@@ -395,10 +401,14 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
         foreach ($registry as $prefix => $paths) {
             $className = $prefix . $name;
 
-            if (class_exists($className)) {
-                $found = true;
+            // try to autoload the class, but with Zend Autoloader disabled - use composer autoload
+            Zend_Loader_Autoloader::setDisabled();
+            $found = class_exists($className, $this->_useComposerAutoloader);
+            Zend_Loader_Autoloader::setDisabled(false);
+            if ($found) {
                 break;
             }
+
             if (!self::$_useFallbackLoader) {
                 // composer autoload should handle loading a class. class_exists call is enough
                 continue;
@@ -521,8 +531,19 @@ class Zend_Loader_PluginLoader implements Zend_Loader_PluginLoader_Interface
      *
      * @param bool $flag
      */
-    public static function useFallbackLoader($flag)
+    public static function useFallbackLoader($flag = true)
     {
         self::$_useFallbackLoader = (bool)$flag;
+    }
+
+    /**
+     * Toggle composer autoloader for this plugin loader
+     * @param bool $flag
+     * @return $this
+     */
+    public function useComposerAutoloader($flag = true)
+    {
+        $this->_useComposerAutoloader = (bool)$flag;
+        return $this;
     }
 }

--- a/packages/zend-tool/library/Zend/Tool/Framework/Client/Abstract.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Client/Abstract.php
@@ -62,7 +62,7 @@ abstract class Zend_Tool_Framework_Client_Abstract implements Zend_Tool_Framewor
     public function __construct($options = array())
     {
         // require autoloader
-        Zend_Loader_Autoloader::getInstance();
+        // Zend_Loader_Autoloader::getInstance();
 
         // this might look goofy, but this is setting up the
         // registry for dependency injection into the client

--- a/packages/zend-tool/library/Zend/Tool/Framework/Client/Storage.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Client/Storage.php
@@ -50,7 +50,9 @@ class Zend_Tool_Framework_Client_Storage
     {
         if (is_string($adapter)) {
             $storageAdapterClass = 'Zend_Tool_Framework_Client_Storage_' . ucfirst($adapter);
-            Zend_Loader::loadClass($storageAdapterClass);
+            if (!class_exists($storageAdapterClass)) {
+                Zend_Loader::loadClass($storageAdapterClass);
+            }
             $adapter = new $storageAdapterClass();
         }
         $this->_adapter = $adapter;

--- a/packages/zend-tool/library/Zend/Tool/Framework/System/Provider/Config.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/System/Provider/Config.php
@@ -197,7 +197,9 @@ class Zend_Tool_Framework_System_Provider_Config extends Zend_Tool_Framework_Pro
      */
     public function enableProvider($className)
     {
-        Zend_Loader::loadClass($className);
+        if (!class_exists($className)) {
+            Zend_Loader::loadClass($className);
+        }
         $reflClass = new ReflectionClass($className);
         if (!in_array("Zend_Tool_Framework_Provider_Interface", $reflClass->getInterfaceNames())) {
             // require_once "Zend/Tool/Framework/Exception.php";
@@ -251,7 +253,9 @@ class Zend_Tool_Framework_System_Provider_Config extends Zend_Tool_Framework_Pro
      */
     public function enableManifest($className)
     {
-        Zend_Loader::loadClass($className);
+        if (!class_exists($className)) {
+            Zend_Loader::loadClass($className);
+        }
         $reflClass = new ReflectionClass($className);
         if (!in_array("Zend_Tool_Framework_Manifest_Interface", $reflClass->getInterfaceNames())) {
             // require_once "Zend/Tool/Framework/Exception.php";

--- a/packages/zend-translate/library/Zend/Translate.php
+++ b/packages/zend-translate/library/Zend/Translate.php
@@ -127,11 +127,9 @@ class Zend_Translate {
             $options = array('adapter' => $options);
         }
 
-        if (Zend_Loader::isReadable('Zend/Translate/Adapter/' . ucfirst($options['adapter']). '.php')) {
+        if (class_exists('Zend_Translate_Adapter_' . ucfirst($options['adapter']))) {
             $options['adapter'] = 'Zend_Translate_Adapter_' . ucfirst($options['adapter']);
-        }
-
-        if (!class_exists($options['adapter'])) {
+        } elseif (!class_exists($options['adapter'])) {
             Zend_Loader::loadClass($options['adapter']);
         }
 

--- a/packages/zend-uri/library/Zend/Uri.php
+++ b/packages/zend-uri/library/Zend/Uri.php
@@ -134,7 +134,9 @@ abstract class Zend_Uri
 
         // require_once 'Zend/Loader.php';
         try {
-            Zend_Loader::loadClass($className);
+            if (!class_exists($className)) {
+                Zend_Loader::loadClass($className);
+            }
         } catch (Exception $e) {
             // require_once 'Zend/Uri/Exception.php';
             throw new Zend_Uri_Exception("\"$className\" not found");

--- a/packages/zend-validate/library/Zend/Validate.php
+++ b/packages/zend-validate/library/Zend/Validate.php
@@ -202,8 +202,9 @@ class Zend_Validate implements Zend_Validate_Interface
                 foreach($namespaces as $namespace) {
                     $nsSeparator = (false !== strpos($namespace, '\\'))?'\\':'_';
                     $class = rtrim($namespace, $nsSeparator) . $nsSeparator . $className;
-                    if (!class_exists($class)) {
-                        continue;
+                    if (class_exists($class)) {
+                        $className = $class;
+                        break;
                     }
                     /*$file  = str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
                     if (Zend_Loader::isReadable($file)) {

--- a/packages/zend-validate/library/Zend/Validate/Barcode.php
+++ b/packages/zend-validate/library/Zend/Validate/Barcode.php
@@ -131,12 +131,9 @@ class Zend_Validate_Barcode extends Zend_Validate_Abstract
     public function setAdapter($adapter, $options = null)
     {
         $adapter = ucfirst(strtolower($adapter));
-        // require_once 'Zend/Loader.php';
-        if (Zend_Loader::isReadable('Zend/Validate/Barcode/' . $adapter. '.php')) {
+        if (class_exists('Zend_Validate_Barcode_' . $adapter)) {
             $adapter = 'Zend_Validate_Barcode_' . $adapter;
-        }
-
-        if (!class_exists($adapter)) {
+        } elseif (!class_exists($adapter)) {
             Zend_Loader::loadClass($adapter);
         }
 

--- a/tests/Zend/Cache/FactoryTest.php
+++ b/tests/Zend/Cache/FactoryTest.php
@@ -97,7 +97,7 @@ class Zend_Cache_FactoryTest extends PHPUnit_Framework_TestCase
     public function testBadFrontend()
     {
         try {
-            Zend_Cache::factory('badFrontend', 'File');
+            Zend_Cache::factory('badFrontend', 'File', array(), array(), false, false, false);
         } catch (Zend_Exception $e) {
             return;
         }
@@ -107,7 +107,7 @@ class Zend_Cache_FactoryTest extends PHPUnit_Framework_TestCase
     public function testBadBackend()
     {
         try {
-            Zend_Cache::factory('Output', 'badBackend');
+            Zend_Cache::factory('Output', 'badBackend', array(), array(), false, false, false);
         } catch (Zend_Exception $e) {
             return;
         }

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -33,7 +33,7 @@
 /**
  * @see Zend_Db_Adapter_Static
  */
-// require_once 'Zend/Db/Adapter/Static.php';
+require_once 'Zend/Db/Adapter/Static.php';
 
 
 /**

--- a/tests/Zend/Db/Adapter/_files/Testnamespace/Static.php
+++ b/tests/Zend/Db/Adapter/_files/Testnamespace/Static.php
@@ -28,7 +28,7 @@
 /**
  * @see Zend_Db_Adapter_Static
  */
-// require_once 'Zend/Db/Adapter/Static.php';
+require_once 'Zend/Db/Adapter/Static.php';
 
 /**
  * Class for connecting to SQL databases and performing common operations.


### PR DESCRIPTION
- ensure full compatibility with composer autoloader
- lazy instantiate Zend_Loader_Autoloader in Zend_Application (only if necessary)
- add Zend_Loader_Autoloader::setDisabled() method for turning it off when necessary (to resolve conflicting cases with composer autoloader)
- fixes regression in Zend_Loader_ClassMapAutoloader
- fix for portability of Zend_Loader_ClassMapAutoloader::realPharPath (now works on windows as well)
- Zend_Loader_PluginLoader::useComposerAutoloader() for further sorting conflicting cases
- autoload cache frontends and backends in Zend_Cache::factory by default
- do not instantiate autoloader in Zend_Tool_Framework_Client
- fixed loading zend-translate adapters, validators, encrypt filter adapters
- fixes remaining loader & class_exists calls
- [zend-cloud] fix lettercase of loaded class Zend_Service_Amazon_Ec2_Availabilityzones
- tests - uncomment require Zend_Db_Adapter_Static 
- restore ZendX_ namespace in Zend_Loader_Autoloader - _to be removed again properly later_