### PR TITLE
[zend-locale] format+math+phpmath overhaul

### DIFF
--- a/packages/zend-locale/library/Zend/Locale/Format.php
+++ b/packages/zend-locale/library/Zend/Locale/Format.php
@@ -303,7 +303,6 @@ class Zend_Locale_Format
         // require_once 'Zend/Locale/Math.php';
 
         $value             = Zend_Locale_Math::floatalize($value);
-        $value             = Zend_Locale_Math::normalize($value);
         $options           = self::_checkOptions($options) + self::$_options;
         $options['locale'] = (string) $options['locale'];
 
@@ -319,7 +318,7 @@ class Zend_Locale_Format
             $format  = self::_seperateFormat($format, $value, $options['precision']);
 
             if ($options['precision'] !== null) {
-                $value   = Zend_Locale_Math::normalize(Zend_Locale_Math::round($value, $options['precision']));
+                $value   = Zend_Locale_Math::round($value, $options['precision']);
             }
         } else {
             // seperate negative format pattern when available
@@ -341,7 +340,6 @@ class Zend_Locale_Format
                 $value = Zend_Locale_Math::round($value, 0);
                 $options['precision'] = 0;
             }
-            $value = Zend_Locale_Math::normalize($value);
         }
 
         if (iconv_strpos($format, '0') === false) {
@@ -384,7 +382,6 @@ class Zend_Locale_Format
 
         $prec = call_user_func(Zend_Locale_Math::$sub, $value, $number, $options['precision']);
         $prec = Zend_Locale_Math::floatalize($prec);
-        $prec = Zend_Locale_Math::normalize($prec);
         if (iconv_strpos($prec, '-') !== false) {
             $prec = iconv_substr($prec, 1);
         }

--- a/packages/zend-locale/library/Zend/Locale/Math.php
+++ b/packages/zend-locale/library/Zend/Locale/Math.php
@@ -62,12 +62,13 @@ class Zend_Locale_Math
      * then try:
      *   Zend_Locale_Math::round('639.795', 2);
      */
-    public static function round($op1, $precision = 0)
+    public static function round($op1, $precision = 0, $normalize = false)
     {
         if (self::$_bcmathDisabled) {
             $op1 = round($op1, $precision);
             if (strpos((string) $op1, 'E') === false) {
-                return self::normalize(round($op1, $precision));
+                $value = round($op1, $precision);
+                return $normalize ? self::normalize($value) : $value;
             }
         }
 
@@ -75,7 +76,9 @@ class Zend_Locale_Math
             $op1 = self::floatalize($op1);
         }
 
-        $op1    = trim(self::normalize($op1));
+        if ($normalize) {
+            $op1 = trim(self::normalize($op1));
+        }
         $length = strlen($op1);
         if (($decPos = strpos($op1, '.')) === false) {
             $op1 .= '.0';
@@ -143,7 +146,13 @@ class Zend_Locale_Math
      */
     public static function floatalize($value)
     {
-        $value = strtoupper($value);
+        // https://stackoverflow.com/questions/17587581/php-locale-dependent-float-to-string-cast
+        // workaround for locale-dependent float->string conversion
+        $locale = setlocale(LC_NUMERIC, 0);
+        setlocale(LC_NUMERIC, 'C');
+        $value = strtoupper((string)$value);
+        setlocale(LC_NUMERIC, $locale);
+
         if (strpos($value, 'E') === false) {
             return $value;
         }

--- a/packages/zend-locale/library/Zend/Locale/Math/PhpMath.php
+++ b/packages/zend-locale/library/Zend/Locale/Math/PhpMath.php
@@ -66,15 +66,15 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
         $result = $op1 + $op2;
         if (is_infinite($result)  or  (abs($result - $op2 - $op1) > $precision)) {
             // require_once 'Zend/Locale/Math/Exception.php';
             throw new Zend_Locale_Math_Exception("addition overflow: $op1 + $op2 != $result", $op1, $op2, $result);
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Sub($op1, $op2, $scale = null)
@@ -89,15 +89,15 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1  = self::normalize($op1);
-        $op2  = self::normalize($op2);
+        $op1  = self::floatalize($op1);
+        $op2  = self::floatalize($op2);
         $result = $op1 - $op2;
         if (is_infinite($result)  or  (abs($result + $op2 - $op1) > $precision)) {
             // require_once 'Zend/Locale/Math/Exception.php';
             throw new Zend_Locale_Math_Exception("subtraction overflow: $op1 - $op2 != $result", $op1, $op2, $result);
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Pow($op1, $op2, $scale = null)
@@ -106,8 +106,11 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
             $scale = Zend_Locale_Math_PhpMath::$defaultScale;
         }
 
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        if (empty($op1)) {
+            $op1 = 0;
+        }
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
 
         // BCMath extension doesn't use decimal part of the power
         // Provide the same behavior
@@ -119,7 +122,7 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
             throw new Zend_Locale_Math_Exception("power overflow: $op1 ^ $op2", $op1, $op2, $result);
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Mul($op1, $op2, $scale = null)
@@ -131,15 +134,15 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
         $result = $op1 * $op2;
         if (is_infinite($result)  or  is_nan($result)) {
             // require_once 'Zend/Locale/Math/Exception.php';
             throw new Zend_Locale_Math_Exception("multiplication overflow: $op1 * $op2 != $result", $op1, $op2, $result);
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Div($op1, $op2, $scale = null)
@@ -155,15 +158,15 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
         $result = $op1 / $op2;
         if (is_infinite($result)  or  is_nan($result)) {
             // require_once 'Zend/Locale/Math/Exception.php';
             throw new Zend_Locale_Math_Exception("division overflow: $op1 / $op2 != $result", $op1, $op2, $result);
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Sqrt($op1, $scale = null)
@@ -175,13 +178,13 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1 = self::normalize($op1);
+        $op1 = self::floatalize($op1);
         $result = sqrt($op1);
         if (is_nan($result)) {
             return NULL;
         }
 
-        return self::round(self::normalize($result), $scale);
+        return self::round($result, $scale);
     }
 
     public static function Mod($op1, $op2)
@@ -192,8 +195,8 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op2)) {
             return NULL;
         }
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
         if ((int)$op2 == 0) {
             return NULL;
         }
@@ -215,8 +218,8 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
-        $op1 = self::normalize($op1);
-        $op2 = self::normalize($op2);
+        $op1 = self::floatalize($op1);
+        $op2 = self::floatalize($op2);
         if ($scale <> 0) {
             $op1 = self::round($op1, $scale);
             $op2 = self::round($op2, $scale);


### PR DESCRIPTION
- untangled normalization - removed when value is expected in already normalized form
- fix for issues with locales where e.g. thousand separator is a dot (e.g. german), i.a. https://github.com/zendframework/zf1/issues/706
- apart from zend-currency, it will also have a big impact on zend-measure package (fixing calculations)