### PR TITLE
composer: fill ext-* dependencies

### DIFF
--- a/packages/zend-amf/composer.json
+++ b/packages/zend-amf/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-server": "^1.13",
         "zf1s/zend-xml": "^1.13"
@@ -16,6 +17,7 @@
         }
     },
     "suggest": {
+        "ext-simplexml": "Used in special situations or with special adapters",
         "zf1s/zend-date": "Used in special situations or with special adapters",
         "zf1s/zend-loader": "Used in special situations or with special adapters"
     },

--- a/packages/zend-application/composer.json
+++ b/packages/zend-application/composer.json
@@ -15,6 +15,7 @@
         }
     },
     "suggest": {
+        "ext-date": "Used in special situations or with special adapters",
         "zf1s/zend-config": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-auth/composer.json
+++ b/packages/zend-auth/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {
@@ -14,6 +15,7 @@
         }
     },
     "suggest": {
+        "ext-hash": "Used in special situations or with special adapters",
         "zf1s/zend-db": "Used in special situations or with special adapters",
         "zf1s/zend-ldap": "Used in special situations or with special adapters",
         "zf1s/zend-openid": "Used in special situations or with special adapters",

--- a/packages/zend-cache/composer.json
+++ b/packages/zend-cache/composer.json
@@ -14,6 +14,10 @@
         }
     },
     "suggest": {
+        "ext-apc": "Used in special situations or with special adapters",
+        "ext-memcache": "Used in special situations or with special adapters",
+        "ext-memcached": "Used in special situations or with special adapters",
+        "ext-sqlite": "Used in special situations or with special adapters",
         "zf1s/zend-log": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-captcha/composer.json
+++ b/packages/zend-captcha/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-gd": "*",
         "zf1s/zend-crypt": "^1.13",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-service-recaptcha": "^1.13",

--- a/packages/zend-config/composer.json
+++ b/packages/zend-config/composer.json
@@ -14,6 +14,9 @@
             "Zend_Config": "library/"
         }
     },
+    "suggest": {
+        "ext-simplexml": "Used in special situations or with special adapters (Zend_Config_Xml)"
+    },
     "replace": {
         "zf1/zend-config": "^1.12"
     },

--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-reflection": "*",
+        "ext-session": "*",
         "zf1s/zend-config": "^1.13",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",

--- a/packages/zend-currency/composer.json
+++ b/packages/zend-currency/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-iconv": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-locale": "^1.13"
     },

--- a/packages/zend-db/composer.json
+++ b/packages/zend-db/composer.json
@@ -15,6 +15,10 @@
         }
     },
     "suggest": {
+        "ext-mysqli": "Used in special situations or with special adapters (Zend_Db_Adapter_Mysqli)",
+        "ext-pdo_mysql": "Used in special situations or with special adapters (Zend_Db_Adapter_Pdo_Mysql)",
+        "ext-pdo_pgsql": "Used in special situations or with special adapters (Zend_Db_Adapter_Pdo_Pgsql)",
+        "ext-pdo_sqlite": "Used in special situations or with special adapters (Zend_Db_Adapter_Pdo_Sqlite)",
         "zf1s/zend-registry": "Used in special situations or with special adapters",
         "zf1s/zend-wildfire": "Used in special situations or with special adapters"
     },

--- a/packages/zend-dom/composer.json
+++ b/packages/zend-dom/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-xml": "^1.13"
     },

--- a/packages/zend-feed/composer.json
+++ b/packages/zend-feed/composer.json
@@ -6,6 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
+        "ext-mbstring": "*",
+        "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-loader": "^1.13",

--- a/packages/zend-file/composer.json
+++ b/packages/zend-file/composer.json
@@ -12,6 +12,9 @@
             "Zend_File": "library/"
         }
     },
+    "suggest": {
+        "ext-apc": "Used in special situations or with special adapters"
+    },
     "replace": {
         "zf1/zend-file": "^1.12"
     },

--- a/packages/zend-filter/composer.json
+++ b/packages/zend-filter/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-reflection": "*",
         "zf1s/zend-crypt": "^1.13",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",
@@ -17,6 +18,7 @@
         }
     },
     "suggest": {
+        "ext-zlib": "Used in special situations or with special adapters (Zend_Filter_Compress)",
         "zf1s/zend-locale": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-gdata/composer.json
+++ b/packages/zend-gdata/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
+        "ext-dom": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-mime": "^1.13",

--- a/packages/zend-http/composer.json
+++ b/packages/zend-http/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",
         "zf1s/zend-uri": "^1.13"
@@ -14,6 +15,10 @@
         "psr-0": {
             "Zend_Http": "library/"
         }
+    },
+    "suggest": {
+        "ext-curl": "Used in special situations or with special adapters (Zend_Http_Client_Adapter_Curl)",
+        "ext-fileinfo": "Used in special situations or with special adapters (Zend_Http_Client)"
     },
     "replace": {
         "zf1/zend-http": "^1.12"

--- a/packages/zend-json/composer.json
+++ b/packages/zend-json/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-reflection": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",
         "zf1s/zend-server": "^1.13",
@@ -15,6 +16,9 @@
         "psr-0": {
             "Zend_Json": "library/"
         }
+    },
+    "suggest": {
+        "ext-json": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-json": "^1.12"

--- a/packages/zend-ldap/composer.json
+++ b/packages/zend-ldap/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ldap": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {

--- a/packages/zend-locale/composer.json
+++ b/packages/zend-locale/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-iconv": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-xml": "^1.13",
         "zf1s/zend-cache": "^1.13",

--- a/packages/zend-log/composer.json
+++ b/packages/zend-log/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-reflection": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {
@@ -14,6 +15,7 @@
         }
     },
     "suggest": {
+        "ext-dom": "Used in special situations or with special adapters (Zend_Log_Formatter_Xml)",
         "zf1s/zend-wildfire": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-mail/composer.json
+++ b/packages/zend-mail/composer.json
@@ -17,6 +17,9 @@
             "Zend_Mail": "library/"
         }
     },
+    "suggest": {
+        "ext-posix": "Used in special situations or with special adapters"
+    },
     "replace": {
         "zf1/zend-mail": "^1.12"
     },

--- a/packages/zend-mime/composer.json
+++ b/packages/zend-mime/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-iconv": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {

--- a/packages/zend-openid/composer.json
+++ b/packages/zend-openid/composer.json
@@ -16,6 +16,11 @@
             "Zend_OpenId": "library/"
         }
     },
+    "suggest": {
+        "ext-bcmath": "Used in special situations or with special adapters (dh key generation)",
+        "ext-gmp": "Used in special situations or with special adapters (dh key generation)",
+        "ext-openssl": "Used in special situations or with special adapters (dh key generation)"
+    },
     "replace": {
         "zf1/zend-openid": "^1.12"
     },

--- a/packages/zend-pdf/composer.json
+++ b/packages/zend-pdf/composer.json
@@ -6,6 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
+        "ext-gd": "*",
+        "ext-iconv": "*",
+        "ext-zlib": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-log": "^1.13",
         "zf1s/zend-memory": "^1.13"

--- a/packages/zend-rest/composer.json
+++ b/packages/zend-rest/composer.json
@@ -6,6 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
+        "ext-dom": "*",
+        "ext-reflection": "*",
+        "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-server": "^1.13",
         "zf1s/zend-service": "^1.13",

--- a/packages/zend-search-lucene/composer.json
+++ b/packages/zend-search-lucene/composer.json
@@ -6,6 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
+        "ext-dom": "*",
+        "ext-iconv": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-search": "^1.13",
         "zf1s/zend-xml": "^1.13"
@@ -14,6 +17,9 @@
         "psr-0": {
             "Zend_Search_Lucene": "library/"
         }
+    },
+    "suggest": {
+        "ext-bitset": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-search-lucene": "^1.12"

--- a/packages/zend-serializer/composer.json
+++ b/packages/zend-serializer/composer.json
@@ -16,6 +16,10 @@
         }
     },
     "suggest": {
+        "ext-igbinary": "Used in special situations or with special adapters (Zend_Serializer_Adapter_Igbinary)",
+        "ext-json": "Used in special situations or with special adapters (Zend_Serializer_Adapter_Json)",
+        "ext-simplexml": "Used in special situations or with special adapters (Zend_Serializer_Adapter_Wddx)",
+        "ext-wddx": "Used in special situations or with special adapters (Zend_Serializer_Adapter_Wddx)",
         "zf1s/zend-json": "Used in special situations or with special adapters",
         "zf1s/zend-amf": "Used in special situations or with special adapters"
     },

--- a/packages/zend-server/composer.json
+++ b/packages/zend-server/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-spl": "*",
+        "ext-reflection": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {

--- a/packages/zend-service-amazon/composer.json
+++ b/packages/zend-service-amazon/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-rest": "^1.13",

--- a/packages/zend-service-audioscrobbler/composer.json
+++ b/packages/zend-service-audioscrobbler/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-iconv": "*",
+        "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-xml": "^1.13"

--- a/packages/zend-service-delicious/composer.json
+++ b/packages/zend-service-delicious/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
         "zf1s/zend-date": "^1.13",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",

--- a/packages/zend-service-flickr/composer.json
+++ b/packages/zend-service-flickr/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
+        "ext-iconv": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-xml": "^1.13"

--- a/packages/zend-service-recaptcha/composer.json
+++ b/packages/zend-service-recaptcha/composer.json
@@ -15,6 +15,9 @@
             "Zend_Service_ReCaptcha": "library/"
         }
     },
+    "suggest": {
+        "ext-mcrypt": "Used in special situations or with special adapters (Zend_Service_ReCaptcha_MailHide)"
+    },
     "replace": {
         "zf1/zend-service-recaptcha": "^1.12"
     },

--- a/packages/zend-service-yahoo/composer.json
+++ b/packages/zend-service-yahoo/composer.json
@@ -17,6 +17,7 @@
         }
     },
     "suggest": {
+        "ext-dom": "Used in special situations or with special adapters",
         "zf1s/zend-validate": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-session/composer.json
+++ b/packages/zend-session/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-session": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {

--- a/packages/zend-soap/composer.json
+++ b/packages/zend-soap/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
+        "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-server": "^1.13",
         "zf1s/zend-uri": "^1.13",

--- a/packages/zend-translate/composer.json
+++ b/packages/zend-translate/composer.json
@@ -16,6 +16,9 @@
             "Zend_Translate": "library/"
         }
     },
+    "suggest": {
+        "ext-xml": "Used in special situations or with special adapters (Zend_Translate_Adapter_Qt, Zend_Translate_Adapter_Tmx, Zend_Translate_Adapter_Xliff)"
+    },
     "replace": {
         "zf1/zend-translate": "^1.12"
     },

--- a/packages/zend-uri/composer.json
+++ b/packages/zend-uri/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",
         "zf1s/zend-locale": "^1.13",

--- a/packages/zend-validate/composer.json
+++ b/packages/zend-validate/composer.json
@@ -6,6 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-ctype": "*",
+        "ext-reflection": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",
         "zf1s/zend-locale": "^1.13"

--- a/packages/zend-view/composer.json
+++ b/packages/zend-view/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-reflection": "*",
         "zf1s/zend-controller": "^1.13",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-loader": "^1.13",

--- a/packages/zend-xml/composer.json
+++ b/packages/zend-xml/composer.json
@@ -6,6 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
+        "ext-simplexml": "*",
+        "ext-xml": "*",
         "zf1s/zend-exception": "^1.13"
     },
     "autoload": {

--- a/packages/zend-xmlrpc/composer.json
+++ b/packages/zend-xmlrpc/composer.json
@@ -6,6 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-dom": "*",
+        "ext-iconv": "*",
+        "ext-reflection": "*",
+        "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.13",
         "zf1s/zend-http": "^1.13",
         "zf1s/zend-server": "^1.13",


### PR DESCRIPTION
based on https://github.com/pld-linux/ZendFramework/blob/auto/th/ZendFramework-1.12.20-1/ZendFramework.spec

which itself is based on:
- https://github.com/pld-linux/ZendFramework/commit/a61792aa4de46796d08413c9e5767a368c482ad9
- https://framework.zend.com/manual/1.12/en/requirements.introduction.html

replaces: https://github.com/zf1s/zend-validate/pull/3

cc @falkenhawk