### PR TITLE
travis: validate each package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,9 @@ before_script:
   - cp ./tests/TestConfiguration.travis.php ./tests/TestConfiguration.php
 
 script:
+  # validate that every composer.json is valid
+  # https://github.com/zf1s/zf1/pull/6#issuecomment-495397170
+  - for json in packages/*/composer.json; do COMPOSER=$json composer validate; done
   - ./vendor/bin/phpunit
+
+# EOF


### PR DESCRIPTION
validates each package `composer.json`:

```
➔ for COMPOSER in packages/*/composer.json; do COMPOSER=$COMPOSER composer.phar validate; done
packages/zend-acl/composer.json is valid
packages/zend-amf/composer.json is valid
packages/zend-application/composer.json is valid
packages/zend-auth/composer.json is valid
packages/zend-barcode/composer.json is valid
packages/zend-cache/composer.json is valid
packages/zend-captcha/composer.json is valid
^C
```

https://getcomposer.org/doc/03-cli.md#composer