### PR TITLE
Properly format PHPDoc @method annotation

### DIFF
--- a/packages/zend-view/library/Zend/View/Helper/Navigation.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation.php
@@ -33,10 +33,10 @@
  * @subpackage Helper
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
- * @method Zend_View_Helper_Navigation_Breadcrumbs breadcrumbs
- * @method Zend_View_Helper_Navigation_Links links
- * @method Zend_View_Helper_Navigation_Menu menu
- * @method Zend_View_Helper_Navigation_Sitemap sitemap
+ * @method Zend_View_Helper_Navigation_Breadcrumbs breadcrumbs(Zend_Navigation_Container $container = null)
+ * @method Zend_View_Helper_Navigation_Links links(Zend_Navigation_Container $container = null)
+ * @method Zend_View_Helper_Navigation_Menu menu(Zend_Navigation_Container $container = null)
+ * @method Zend_View_Helper_Navigation_Sitemap sitemap(Zend_Navigation_Container $container = null)
  */
 class Zend_View_Helper_Navigation
     extends Zend_View_Helper_Navigation_HelperAbstract


### PR DESCRIPTION
Otherwise PHPStan will complain with errors like: `Call to an undefined method Zend_View_Helper_Navigation::breadcrumbs().`