### PR TITLE
Zend Search Lucene PHP 7.4 compatibility

### DIFF
--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/Term.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/Term.php
@@ -58,7 +58,7 @@ class Zend_Search_Lucene_Index_Term
     public function __construct($text, $field = null)
     {
         $this->field = ($field === null)?  Zend_Search_Lucene::getDefaultSearchField() : $field;
-        $this->text  = $text;
+        $this->text  = (string)$text;
     }
 
 


### PR DESCRIPTION
Fix for issue: "Trying to access array offset on value of type int"