### PR TITLE
fixed Incompatiblity with standard Zend MVC, Zend module MVC

### DIFF
--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Standard.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Standard.php
@@ -212,7 +212,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
         {
             $finalClass = $this->formatClassName($this->_curModule, $className);
         }
-        if (class_exists($finalClass)) {
+        if (class_exists($finalClass, false)) {
             return true;
         }
 
@@ -346,7 +346,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
         {
             $finalClass = $this->formatClassName($this->_curModule, $className);
         }
-        if (class_exists($finalClass)) {
+        if (class_exists($finalClass, false)) {
             return $finalClass;
         }
 
@@ -456,7 +456,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
         $this->_curDirectory = $controllerDirs[$this->_defaultModule];
         if ($this->isValidModule($module)) {
             $found = false;
-            if (class_exists($default)) {
+            if (class_exists($default, false)) {
                 $found = true;
             } else {
                 $moduleDir = $controllerDirs[$module];


### PR DESCRIPTION
Hello.
Thanks for publishing this repository.
I found two bugs and fixed them, so I create a pull request.
Please consider it.

 * A request url, controller does not exist, it not got a 404 error.
 * Default/controllers/IndexController load fails when default module prefix is disabled
     * classname is IndexController
     * $front->prefixDefaultModule(false)

Regards,