### PR TITLE
Zend XML - fix version comparison operator

### DIFF
--- a/packages/zend-xml/library/Zend/Xml/Security.php
+++ b/packages/zend-xml/library/Zend/Xml/Security.php
@@ -169,7 +169,7 @@ class Zend_Xml_Security
         $isVulnerableVersion = (
             version_compare(PHP_VERSION, '5.5.22', 'lt')
             || (
-                version_compare(PHP_VERSION, '5.6', 'gte')
+                version_compare(PHP_VERSION, '5.6', 'ge')
                 && version_compare(PHP_VERSION, '5.6.6', 'lt')
             )
         );


### PR DESCRIPTION
This PR fixes an invalid operator. **gte** is not supported.

_If the third optional operator argument is specified, test for a particular relationship. The possible operators are: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne respectively._

https://www.php.net/manual/en/function.version-compare.php 