### PR TITLE
Zend-Xml php8 compatibility

### DIFF
--- a/packages/zend-xml/library/Zend/Xml/Security.php
+++ b/packages/zend-xml/library/Zend/Xml/Security.php
@@ -46,6 +46,19 @@ class Zend_Xml_Security
     }
 
     /**
+     * Wrapper for libxml_disable_entity_loader which is deprecated in PHP 8. libxml 2.9.0 disables external entity
+     * loading by default. PHP 8.0 has deprecated libxml_disable_entity_loader() method and it requires libxml 2.9.0+.
+     * @see https://github.com/php/php-src/pull/5867
+     *
+     * @param bool $disable
+     * @return bool the previous value (true = disabled)
+     */
+    private static function disableEntityLoader($disable = true)
+    {
+        return LIBXML_VERSION < 20900 ? libxml_disable_entity_loader($disable) : true;
+    }
+
+    /**
      * @param integer $errno
      * @param string $errstr
      * @param string $errfile
@@ -83,7 +96,7 @@ class Zend_Xml_Security
         }
 
         if (!self::isPhpFpm()) {
-            $loadEntities = libxml_disable_entity_loader(true);
+            $loadEntities = self::disableEntityLoader(true);
             $useInternalXmlErrors = libxml_use_internal_errors(true);
         }
 
@@ -97,7 +110,7 @@ class Zend_Xml_Security
         if (!$result) {
             // Entity load to previous setting
             if (!self::isPhpFpm()) {
-                libxml_disable_entity_loader($loadEntities);
+                self::disableEntityLoader($loadEntities);
                 libxml_use_internal_errors($useInternalXmlErrors);
             }
             return false;
@@ -117,7 +130,7 @@ class Zend_Xml_Security
 
         // Entity load to previous setting
         if (!self::isPhpFpm()) {
-            libxml_disable_entity_loader($loadEntities);
+            self::disableEntityLoader($loadEntities);
             libxml_use_internal_errors($useInternalXmlErrors);
         }
 


### PR DESCRIPTION
In Zend_Xml_Security: `libxml_disable_entity_loader()` is no longer executed when running PHP 8 or higher. It's still executed (and necessary!) on prior versions.

This restores the ability to load an XML configuration file using Zend_Config_Xml when running PHP 8. Now the deprecated warning will cause it to not load anything and throw an exception: `Zend_Config_Exception: Function libxml_disable_entity_loader() is deprecated`.

I've also renamed `Zend_Xml_Security::isPhpFpm()`  to `Zend_Xml_Security::isVulnerablePhpFpm()` in the second commit because that name better represents what the method does in my opinion.