### PR TITLE
Fix Zend_Db_Adapter_Pdo_Pgsql being broken on Postgres 12 that removed d.adsrc

### DIFF
--- a/packages/zend-db/library/Zend/Db/Adapter/Pdo/Pgsql.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Pdo/Pgsql.php
@@ -156,7 +156,7 @@ class Zend_Db_Adapter_Pdo_Pgsql extends Zend_Db_Adapter_Pdo_Abstract
                 t.typname AS type,
                 a.atttypmod,
                 FORMAT_TYPE(a.atttypid, a.atttypmod) AS complete_type,
-                d.adsrc AS default_value,
+                pg_get_expr(d.adbin, d.adrelid) AS default_value,
                 a.attnotnull AS notnull,
                 a.attlen AS length,
                 co.contype,


### PR DESCRIPTION
fixes https://github.com/zf1s/zf1/issues/28

cherry-picked from:
- https://github.com/Shardj/zf1-future/pull/31
- https://github.com/Shardj/zf1-future/issues/28
