### PR TITLE
[zend-service-windowsazure]: Remove invalid unset $this operation

### DIFF
--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -105,7 +105,6 @@ class Zend_Service_WindowsAzure_Storage_Batch
         unset($this->_operations);
         $this->_storageClient->setCurrentBatch(null);
         $this->_storageClient = null;
-        unset($this);
     }
 
 	/**


### PR DESCRIPTION
I was linting all source files and came across this syntax error.

```
Fatal error: Cannot unset $this in Zend/Service/WindowsAzure/Storage/Batch.php on line 108
```

This is with PHP 7.2.34, 7.3.25 (Probably older, don't have versions at hand right now)

Update: This is a fatal error since PHP 7.1:
- https://github.com/glensc/php-zf1s/runs/1512365011