### PR TITLE
Setup GitHub Actions to lint all files in the repository

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Lint PHP source files
         run: |
           # Lint All PHP source files
+          # Remove source expected to have syntax error
+          git rm tests/Zend/Loader/_files/ParseError.php
           git ls-files '**/*.php' | xargs -l1 php -l
 
 # vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,9 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
 
+      - name: Lint PHP source files
+        run: |
+          # Lint All PHP source files
+          git ls-files '**/*.php' | xargs -l1 php -l
+
 # vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
           # Lint All PHP source files
           # Remove source expected to have syntax error
           git rm tests/Zend/Loader/_files/ParseError.php
-          git ls-files '**/*.php' | xargs -l1 php -l
+          git ls-files '**/*.php' | while read f; do php -l "$f" > /dev/null || touch failed && echo -n .; done
+          test ! -f failed
 
 # vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: "Tests"
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - "5.3"
+          - "5.4"
+          - "5.5"
+          - "5.6"
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+# vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: display_errors=off, log_errors=on
 
       - name: Lint PHP source files
         run: |


### PR DESCRIPTION
Setup GitHub Actions to lint all files in the repository to catch issues like https://github.com/zf1s/zf1/pull/36

The output is very noisy, so therefore it's set up as a separate job.

Extracted base GitHub Action setup from https://github.com/zf1s/zf1/pull/34

In the future could use some other tools like:
- https://github.com/overtrue/phplint
- https://github.com/JakubOnderka/PHP-Parallel-Lint

but let's keep this simple, let's have this as a first GitHub action enabled in this repo.