### PR TITLE
[php 8.0] Add clarifying parens for nested ternary operation

### DIFF
--- a/packages/zend-service-console/library/Zend/Service/Console/Command.php
+++ b/packages/zend-service-console/library/Zend/Service/Console/Command.php
@@ -220,7 +220,7 @@ class Zend_Service_Console_Command
 
 			for ($hi = 0; $hi < count($handlers); $hi++) {
 				$handler = $handlers[$hi];
-				$handlerDescription = isset($handlerDescriptions[$hi]) ? $handlerDescriptions[$hi] : isset($handlerDescriptions[0]) ? $handlerDescriptions[0] : '';
+				$handlerDescription = isset($handlerDescriptions[$hi]) ? $handlerDescriptions[$hi] : (isset($handlerDescriptions[0]) ? $handlerDescriptions[0] : '');
 				$handlerDescription = str_replace('\r\n', "\r\n", $handlerDescription);
 				$handlerDescription = str_replace('\n', "\n", $handlerDescription);
 


### PR DESCRIPTION
Requires https://github.com/zf1s/zf1/pull/38 to be merged first.

Fixes syntax error on php 8.0:

```
PHP Fatal error:  Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`
```
- https://github.com/zf1s/zf1/pull/37#issuecomment-740449838