### PR TITLE
Backport of fix for CVE-2021-3007 in Zend_Http_Response_Stream

### DIFF
--- a/packages/zend-http/library/Zend/Http/Response/Stream.php
+++ b/packages/zend-http/library/Zend/Http/Response/Stream.php
@@ -227,7 +227,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
             fclose($this->stream);
             $this->stream = null;
         }
-        if($this->_cleanup) {
+        if($this->_cleanup && is_string($this->stream_name) && file_exists($this->stream_name)) {
             @unlink($this->stream_name);
         }
     }

--- a/tests/Zend/Http/StreamObject.php
+++ b/tests/Zend/Http/StreamObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zend\Http;
+
+class StreamObject
+{
+    private $tempFile;
+
+    public function __construct($tempFile)
+    {
+        $this->tempFile = $tempFile;
+    }
+
+    public function __toString()
+    {
+        return $this->tempFile;
+    }
+}


### PR DESCRIPTION
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3007
- https://github.com/laminas/laminas-http/commit/eab608e10896270416aae7ffce36cc48072aa796

Only the actual fix was brought over as @lmcnearney didn't see an applicable unit test to extend for ZF1.

Carry https://github.com/Shardj/zf1-future/pull/127 submitted by @lmcnearney

@glensc ported unit test from https://github.com/laminas/laminas-http/commit/eab608e10896270416aae7ffce36cc48072aa796

refs:
- https://github.com/laminas/laminas-http/pull/48