### PR TITLE
Add minimal phpunit run in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,7 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
 
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit --verbose
+
 # vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
-          - "8.0"
 
     steps:
       - name: Checkout Code

--- a/tests/Zend/Cache/CommonBackendTest.php
+++ b/tests/Zend/Cache/CommonBackendTest.php
@@ -232,7 +232,7 @@ abstract class Zend_Cache_CommonBackendTest extends PHPUnit_Framework_TestCase {
     public function testCleanModeAll()
     {
         if ($this instanceof Zend_Cache_MemcachedBackendTest
-            && getenv('TRAVIS')
+            && getenv('CI')
         ) {
             $this->markTestSkipped(
                 'Test randomly fail on Travis CI.'

--- a/tests/Zend/Cache/FileBackendTest.php
+++ b/tests/Zend/Cache/FileBackendTest.php
@@ -161,7 +161,7 @@ class Zend_Cache_FileBackendTest extends Zend_Cache_CommonExtendedBackendTest {
 
     public function testSaveWithABadCacheDir()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('CI')) {
             $this->markTestSkipped(
                 'Test randomly fail on Travis CI.'
             );

--- a/tests/Zend/Ldap/ConverterTest.php
+++ b/tests/Zend/Ldap/ConverterTest.php
@@ -121,7 +121,7 @@ class Zend_Ldap_ConverterTest extends PHPUnit_Framework_TestCase
             );
         }
 
-        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (getenv('CI') && version_compare(PHP_VERSION, '5.4.0', '>=')) {
             return array(
                 array('N;', null),
                 array('i:1;', 1),

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -778,7 +778,7 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
      */
     public function testSetExpirationSeconds()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('CI')) {
             $this->markTestSkipped(
                 'Test randomly fail on Travis CI.'
             );

--- a/tests/Zend/Soap/AllTests.php
+++ b/tests/Zend/Soap/AllTests.php
@@ -53,7 +53,7 @@ class Zend_Soap_AllTests
 
         //early exit because of segfault in this specific version
         //https://github.com/zendframework/zf1/issues/650
-        if (getenv('TRAVIS') && version_compare(PHP_VERSION, '5.4.37', '=')) {
+        if (getenv('CI') && version_compare(PHP_VERSION, '5.4.37', '=')) {
             return $suite;
         }
 


### PR DESCRIPTION
Adds minimal PHPUnit invocation. Most of the tests are Skipped.

Tests PHP 5.3-7.4, PHP 8.0 is removed.

Extracted from https://github.com/zf1s/zf1/pull/34