### PR TITLE
Restore locales before calling test assertions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,8 @@ jobs:
       MYSQL_PASSWORD: "zftest"
       MYSQL_DATABASE: "zftest"
       MYSQL_HOST: "127.0.0.1"
+      # Default locales are: C C.UTF-8 POSIX en_US.utf8
+      LOCALES: "fr_FR@euro fr_FR fr_BE.UTF-8 de en_US"
 
     services:
       memcache:
@@ -81,6 +83,11 @@ jobs:
       - name: Setup environment for PHPUnit
         run: |
           cp tests/TestConfiguration.ci.php tests/TestConfiguration.php
+          echo "Existing locales"
+          locale -a
+          sudo apt-get update && sudo apt-get install tzdata locales -y && sudo locale-gen $LOCALES
+          echo "All languages..."
+          locale -a
 
       - name: "Run PHPUnit tests (Experimental: ${{ matrix.experimental }})"
         env:

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -36,6 +36,12 @@
 class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * Constant for Non-breaking space UTF-8 encoded value.
+     * https://en.wikipedia.org/wiki/Non-breaking_space
+     */
+    const NBSP = " ";
+
+    /**
      * teardown / cleanup
      */
     public function tearDown()
@@ -944,7 +950,7 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
         $myFloat = 1234.5;
         $test1 = Zend_Locale_Format::toFloat($myFloat, $params_fr);
         $test2 = Zend_Locale_Format::toFloat($myFloat, $params_en);
-        $this->assertEquals("1 234,50", $test1);
+        $this->assertEquals("1" . self::NBSP . "234,50", $test1);
         $this->assertEquals("1,234.50", $test2);
         // placing tearDown here (i.e. restoring locale) won't work, if test already failed/aborted above.
     }

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -39,7 +39,7 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
      * Constant for Non-breaking space UTF-8 encoded value.
      * https://en.wikipedia.org/wiki/Non-breaking_space
      */
-    const NBSP = " ";
+    const NBSP = "\xC2\xA0";
 
     /**
      * teardown / cleanup

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -940,9 +940,9 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
      */
     public function testToFloatSetlocale()
     {
-        setlocale(LC_ALL, 'fr_FR@euro'); // test setup
+        $locale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, 'fr_FR@euro');
 
-        //var_dump( setlocale(LC_NUMERIC, '0')); // this is the specific setting of interest
         $locale_fr = new Zend_Locale('fr_FR');
         $locale_en = new Zend_Locale('en_US');
         $params_fr = array('precision' => 2, 'locale' => $locale_fr);
@@ -950,9 +950,11 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
         $myFloat = 1234.5;
         $test1 = Zend_Locale_Format::toFloat($myFloat, $params_fr);
         $test2 = Zend_Locale_Format::toFloat($myFloat, $params_en);
+
+        setlocale(LC_ALL, $locale);
+
         $this->assertEquals("1" . self::NBSP . "234,50", $test1);
         $this->assertEquals("1,234.50", $test2);
-        // placing tearDown here (i.e. restoring locale) won't work, if test already failed/aborted above.
     }
 
     /**
@@ -1114,10 +1116,13 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
     public function testCheckDateFormatDoesNotEmitNoticeWhenNoOptionsAreNotProvided()
     {
         try {
+            $locale = setlocale(LC_ALL, 0); // read current locale
             setlocale(LC_ALL, 'en_US'); // test setup
             Zend_Locale_Format::setOptions(array('date_format' => 'yyyy-MM-dd'));
+            $checkDateFormat = Zend_Locale_Format::checkDateFormat('2011-10-21', array());
+            setlocale(LC_ALL, $locale); // restore previous locale
 
-            $this->assertTrue(Zend_Locale_Format::checkDateFormat('2011-10-21', array()));
+            $this->assertTrue($checkDateFormat);
         } catch ( PHPUnit_Framework_Error_Notice $ex ) {
             $this->fail('Zend_Locale_Format::checkDateFormat emitted unexpected E_NOTICE');
         }

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -941,20 +941,28 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
     public function testToFloatSetlocale()
     {
         $locale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, 'fr_FR@euro');
+        try {
+            setlocale(LC_ALL, 'fr_FR@euro');
 
-        $locale_fr = new Zend_Locale('fr_FR');
-        $locale_en = new Zend_Locale('en_US');
-        $params_fr = array('precision' => 2, 'locale' => $locale_fr);
-        $params_en = array('precision' => 2, 'locale' => $locale_en);
-        $myFloat = 1234.5;
-        $test1 = Zend_Locale_Format::toFloat($myFloat, $params_fr);
-        $test2 = Zend_Locale_Format::toFloat($myFloat, $params_en);
+            $locale_fr = new Zend_Locale('fr_FR');
+            $locale_en = new Zend_Locale('en_US');
+            $params_fr = array('precision' => 2, 'locale' => $locale_fr);
+            $params_en = array('precision' => 2, 'locale' => $locale_en);
+            $myFloat = 1234.5;
+            $test1 = Zend_Locale_Format::toFloat($myFloat, $params_fr);
+            $test2 = Zend_Locale_Format::toFloat($myFloat, $params_en);
 
+            $this->assertEquals("1" . self::NBSP . "234,50", $test1);
+            $this->assertEquals("1,234.50", $test2);
+
+        } catch (Exception $e) {
+            setlocale(LC_ALL, $locale);
+            throw $e;
+        } catch (Throwable $e) {
+            setlocale(LC_ALL, $locale);
+            throw $e;
+        }
         setlocale(LC_ALL, $locale);
-
-        $this->assertEquals("1" . self::NBSP . "234,50", $test1);
-        $this->assertEquals("1,234.50", $test2);
     }
 
     /**
@@ -1115,17 +1123,19 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
      */
     public function testCheckDateFormatDoesNotEmitNoticeWhenNoOptionsAreNotProvided()
     {
+        $locale = setlocale(LC_ALL, 0); // read current locale
         try {
-            $locale = setlocale(LC_ALL, 0); // read current locale
             setlocale(LC_ALL, 'en_US'); // test setup
             Zend_Locale_Format::setOptions(array('date_format' => 'yyyy-MM-dd'));
             $checkDateFormat = Zend_Locale_Format::checkDateFormat('2011-10-21', array());
-            setlocale(LC_ALL, $locale); // restore previous locale
 
             $this->assertTrue($checkDateFormat);
         } catch ( PHPUnit_Framework_Error_Notice $ex ) {
+            setlocale(LC_ALL, $locale); // restore previous locale
+
             $this->fail('Zend_Locale_Format::checkDateFormat emitted unexpected E_NOTICE');
         }
+        setlocale(LC_ALL, $locale); // restore previous locale
     }
 
     /**

--- a/tests/Zend/Validate/FloatTest.php
+++ b/tests/Zend/Validate/FloatTest.php
@@ -36,6 +36,12 @@
 class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * Constant for Non-breaking space UTF-8 encoded value.
+     * https://en.wikipedia.org/wiki/Non-breaking_space
+     */
+    const NBSP = " ";
+
+    /**
      * Zend_Validate_Float object
      *
      * @var Zend_Validate_Float
@@ -196,7 +202,7 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
         $valid = new Zend_Validate_Float('fr_FR');
         $this->assertTrue($valid->isValid('1,3'));
         $this->assertTrue($valid->isValid('1000,3'));
-        $this->assertTrue($valid->isValid('1 000,3'));
+        $this->assertTrue($valid->isValid('1' . self::NBSP . '000,3'));
         $this->assertFalse($valid->isValid('1.3'));
         $this->assertFalse($valid->isValid('1000.3'));
         $this->assertFalse($valid->isValid('1,000.3'));

--- a/tests/Zend/Validate/FloatTest.php
+++ b/tests/Zend/Validate/FloatTest.php
@@ -39,7 +39,7 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
      * Constant for Non-breaking space UTF-8 encoded value.
      * https://en.wikipedia.org/wiki/Non-breaking_space
      */
-    const NBSP = " ";
+    const NBSP = "\xC2\xA0";
 
     /**
      * Zend_Validate_Float object

--- a/tests/Zend/Validate/FloatTest.php
+++ b/tests/Zend/Validate/FloatTest.php
@@ -49,6 +49,11 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
     protected $_validator;
 
     /**
+     * @var string
+     */
+    private $_locale;
+
+    /**
      * Creates a new Zend_Validate_Float object for each test method
      *
      * @return void
@@ -142,10 +147,14 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
      */
     public function testNoZendLocaleButPhpLocale()
     {
+        $locale = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'de');
         $valid = new Zend_Validate_Float();
-        $this->assertTrue($valid->isValid(123,456));
-        $this->assertTrue($valid->isValid('123,456'));
+        $isValid1 = $valid->isValid(123.456);
+        $isValid2 = $valid->isValid('123,456');
+        setlocale(LC_ALL, $locale);
+        $this->assertTrue($isValid1);
+        $this->assertTrue($isValid2);
     }
 
     /**
@@ -163,9 +172,12 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
      */
     public function testPhpLocaleDeFloatType()
     {
+        $locale = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'de');
         $valid = new Zend_Validate_Float();
-        $this->assertTrue($valid->isValid(10.5));
+        $isValid = $valid->isValid(10.5);
+        setlocale(LC_ALL, $locale);
+        $this->assertTrue($isValid);
     }
 
     /**
@@ -173,9 +185,12 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
      */
     public function testPhpLocaleFrFloatType()
     {
+        $locale = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'fr');
         $valid = new Zend_Validate_Float();
-        $this->assertTrue($valid->isValid(10.5));
+        $isValid = $valid->isValid(10.5);
+        setlocale(LC_ALL, $locale);
+        $this->assertTrue($isValid);
     }
 
     /**
@@ -183,15 +198,25 @@ class Zend_Validate_FloatTest extends PHPUnit_Framework_TestCase
      */
     public function testPhpLocaleDeStringType()
     {
+        $lcAll = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'de_AT');
+        $lcNumeric = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, 'de_AT');
         $valid = new Zend_Validate_Float('de_AT');
-        $this->assertTrue($valid->isValid('1,3'));
-        $this->assertTrue($valid->isValid('1000,3'));
-        $this->assertTrue($valid->isValid('1.000,3'));
-        $this->assertFalse($valid->isValid('1.3'));
-        $this->assertFalse($valid->isValid('1000.3'));
-        $this->assertFalse($valid->isValid('1,000.3'));
+        $isValid0 = $valid->isValid('1,3');
+        $isValid1 = $valid->isValid('1000,3');
+        $isValid2 = $valid->isValid('1.000,3');
+        $isValid3 = $valid->isValid('1.3');
+        $isValid4 = $valid->isValid('1000.3');
+        $isValid5 = $valid->isValid('1,000.3');
+        setlocale(LC_ALL, $lcAll);
+        setlocale(LC_NUMERIC, $lcNumeric);
+        $this->assertTrue($isValid0);
+        $this->assertTrue($isValid1);
+        $this->assertTrue($isValid2);
+        $this->assertFalse($isValid3);
+        $this->assertFalse($isValid4);
+        $this->assertFalse($isValid5);
     }
 
     /**


### PR DESCRIPTION
Restore locales before calling assertions otherwise sql will be broken:

From https://github.com/zf1s/zf1/pull/34#issuecomment-739904178:
> seems enabling locale tests by installing needed locales, brings more trouble than needed.
> 
> the tests are not run in proper isolation, i.e global resource like locale must be restored after a test, and that is not performed, neither are tests run in isolation (i think phpunit 3.7 does not even support that), and sql queries are written with very bad style, resulting syntax error as numeric value value formatted with comma according to locale rules, gets parsed as two values in sql.
> 
> ```
> 2) Zend_Db_Table_Select_MysqliTest::testSelectWhereOr
> Zend_Db_Exception: SQL error for "INSERT INTO `zfprice` (`product_id`, `price_name`, `price_total`) VALUES (1, 'Price 1', 200,45)": Column count doesn't match value count at row 1
> ```
> 
> - https://github.com/glensc/php-zf1s/runs/1510708630?check_suite_focus=true
> 

NOTE: fixing the DB layer to be independent on locale is a legacy that zf1 carries and can't be fixed.