### PR TITLE
Move MySQL testing from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,28 @@ jobs:
           - php: "8.0"
             experimental: true
 
+    env:
+      MYSQL_USER: "zftest"
+      MYSQL_PASSWORD: "zftest"
+      MYSQL_DATABASE: "zftest"
+      MYSQL_HOST: "127.0.0.1"
+
     services:
       memcache:
         image: memcached:1-alpine
         ports:
           - 11211:11211
+
+      mysql:
+        image: mysql/mysql-server:5.6
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_USER: "zftest"
+          MYSQL_PASSWORD: "zftest"
+          MYSQL_DATABASE: "zftest"
+          MYSQL_ALLOW_EMPTY_PASSWORD: "1"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Checkout Code

--- a/tests/TestConfiguration.ci.php
+++ b/tests/TestConfiguration.ci.php
@@ -42,4 +42,18 @@
 defined('TESTS_ZEND_CACHE_MEMCACHED_ENABLED') || define('TESTS_ZEND_CACHE_MEMCACHED_ENABLED', true);
 defined('TESTS_ZEND_CACHE_LIBMEMCACHED_ENABLED') || define('TESTS_ZEND_CACHE_LIBMEMCACHED_ENABLED', true);
 
+/**
+ * Zend_Db_Adapter_Pdo_Mysql and Zend_Db_Adapter_Mysqli
+ *
+ * There are separate properties to enable tests for the PDO_MYSQL adapter and
+ * the native Mysqli adapters, but the other properties are shared between the
+ * two MySQL-related Zend_Db adapters.
+ */
+defined('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED',  true);
+defined('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED',  true);
+defined('TESTS_ZEND_DB_ADAPTER_MYSQL_HOSTNAME') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_HOSTNAME', getenv('MYSQL_HOST'));
+defined('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME', getenv('MYSQL_USER'));
+defined('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD', getenv('MYSQL_PASSWORD'));
+defined('TESTS_ZEND_DB_ADAPTER_MYSQL_DATABASE') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_DATABASE', getenv('MYSQL_DATABASE'));
+
 require_once dirname(__FILE__) . '/TestConfiguration.dist.php';

--- a/tests/TestConfiguration.ci.php
+++ b/tests/TestConfiguration.ci.php
@@ -49,8 +49,10 @@ defined('TESTS_ZEND_CACHE_LIBMEMCACHED_ENABLED') || define('TESTS_ZEND_CACHE_LIB
  * the native Mysqli adapters, but the other properties are shared between the
  * two MySQL-related Zend_Db adapters.
  */
-defined('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED',  true);
-defined('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED',  true);
+// Skip testing ext/mysqli for PHP 5.4/5.5, as the error is not fixable
+// https://github.com/zf1s/zf1/pull/49/files#r565875073
+defined('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED', true);
+defined('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED', !(PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50600));
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_HOSTNAME') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_HOSTNAME', getenv('MYSQL_HOST'));
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME', getenv('MYSQL_USER'));
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD', getenv('MYSQL_PASSWORD'));

--- a/tests/TestConfiguration.travis.php
+++ b/tests/TestConfiguration.travis.php
@@ -54,8 +54,10 @@ defined('TESTS_ZEND_CACHE_SQLITE_ENABLED') || define('TESTS_ZEND_CACHE_SQLITE_EN
  * the native Mysqli adapters, but the other properties are shared between the
  * two MySQL-related Zend_Db adapters.
  */
-defined('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED',  true);
-defined('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED',  true);
+defined('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_PDO_MYSQL_ENABLED', false);
+// Testing PDO_MYSQL only for PHP 5.4/5.5, as can't test that on GitHub Actions
+// https://github.com/zf1s/zf1/pull/49/files#r565875073
+defined('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED') || define('TESTS_ZEND_DB_ADAPTER_MYSQLI_ENABLED', (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50600));
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_USERNAME', 'travis');
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_PASSWORD', '');
 defined('TESTS_ZEND_DB_ADAPTER_MYSQL_DATABASE') || define('TESTS_ZEND_DB_ADAPTER_MYSQL_DATABASE', 'zftest');


### PR DESCRIPTION
Re-created from changes of https://github.com/zf1s/zf1/pull/34

This PR moves MySQL related tests from Travis CI to GitHub Actions.