### PR TITLE
Use parallel-lint for GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,14 +39,6 @@ jobs:
           ini-values: display_errors=off, log_errors=on
           extensions: :xdebug, ctype, dom, gd, iconv, ldap, mbstring, reflection, session, simplexml, spl, xml, zlib, memcache, pdo_sqlite, bcmath
 
-      - name: Lint PHP source files
-        run: |
-          # Lint All PHP source files
-          # Remove source expected to have syntax error
-          git rm tests/Zend/Loader/_files/ParseError.php
-          git ls-files '**/*.php' | while read f; do php -l "$f" > /dev/null || touch failed && echo -n .; done
-          test ! -f failed
-
       # https://github.com/zf1s/zf1/pull/6#issuecomment-495397170
       - name: Validate composer.json for all packages
         run: |
@@ -55,6 +47,10 @@ jobs:
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Lint PHP source files
+        run: |
+          composer lint
 
       - name: Setup environment for PHPUnit
         run: |

--- a/composer.json
+++ b/composer.json
@@ -204,6 +204,7 @@
         "zf1s/zend-xmlrpc": "self.version"
     },
     "scripts": {
+        "lint": "parallel-lint --exclude vendor --exclude tests/Zend/Loader/_files/ParseError.php .",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
         "ext-zlib": "*"
     },
     "require-dev": {
-        "zf1s/phpunit": "3.7.39",
-        "phpunit/dbunit": "1.3.2"
+        "php-parallel-lint/php-parallel-lint": "1.0.0",
+        "phpunit/dbunit": "1.3.2",
+        "zf1s/phpunit": "3.7.39"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Use [php-parallel-lint/php-parallel-lint](https://github.com/JakubOnderka/PHP-Parallel-Lint): Saves overall CI run time to half:
- 1m 51s: https://github.com/glensc/php-zf1s/runs/1786362689?check_suite_focus=true
- 52s: https://github.com/glensc/php-zf1s/runs/1786442294?check_suite_focus=true

Tested that all files are tested regardless of syntax error.