### PR TITLE
Replace version_compare on PHP_VERSION with PHP_VERSION_ID check

### DIFF
--- a/packages/zend-db/library/Zend/Db/Adapter/Pdo/Mysql.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Pdo/Mysql.php
@@ -102,7 +102,7 @@ class Zend_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Abstract
         }
 
         if (!empty($this->_config['charset'])
-            && version_compare(PHP_VERSION, '5.3.6', '<')
+            && PHP_VERSION_ID < 50306
         ) {
             $initCommand = "SET NAMES '" . $this->_config['charset'] . "'";
             $this->_config['driver_options'][1002] = $initCommand; // 1002 = PDO::MYSQL_ATTR_INIT_COMMAND

--- a/packages/zend-loader/library/Zend/Loader/AutoloaderFactory.php
+++ b/packages/zend-loader/library/Zend/Loader/AutoloaderFactory.php
@@ -114,7 +114,7 @@ abstract class Zend_Loader_AutoloaderFactory
 
                 // unfortunately is_subclass_of is broken on some 5.3 versions
                 // additionally instanceof is also broken for this use case
-                if (version_compare(PHP_VERSION, '5.3.7', '>=')) {
+                if (PHP_VERSION_ID >= 50307) {
                         if (!is_subclass_of($class, 'Zend_Loader_SplAutoloader')) {
                         // require_once 'Exception/InvalidArgumentException.php';
                         throw new Zend_Loader_Exception_InvalidArgumentException(sprintf(

--- a/packages/zend-loader/library/Zend/Loader/StandardAutoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/StandardAutoloader.php
@@ -314,7 +314,7 @@ class Zend_Loader_StandardAutoloader implements Zend_Loader_SplAutoloader
         if ($type === self::ACT_AS_FALLBACK) {
             // create filename
             $filename = $this->transformClassNameToFilename($class, '');
-            if (version_compare(PHP_VERSION, '5.3.2', '>=')) {
+            if (PHP_VERSION_ID >= 50302) {
                 $resolvedName = stream_resolve_include_path($filename);
                 if ($resolvedName !== false) {
                     return include $resolvedName;

--- a/packages/zend-mobile/library/Zend/Mobile/Push/Apns.php
+++ b/packages/zend-mobile/library/Zend/Mobile/Push/Apns.php
@@ -313,8 +313,8 @@ class Zend_Mobile_Push_Apns extends Zend_Mobile_Push_Abstract
         foreach($message->getCustomData() as $k => $v) {
             $payload[$k] = $v;
         }
-        
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+
+        if (PHP_VERSION_ID >= 50400) {
             $payload = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         } else {
             $payload = json_encode($payload);

--- a/packages/zend-mobile/library/Zend/Mobile/Push/Message/Gcm.php
+++ b/packages/zend-mobile/library/Zend/Mobile/Push/Message/Gcm.php
@@ -268,7 +268,7 @@ class Zend_Mobile_Push_Message_Gcm extends Zend_Mobile_Push_Message_Abstract
         if ($this->_ttl !== 2419200) {
             $json['time_to_live'] = $this->_ttl;
         }
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+        if (PHP_VERSION_ID >= 50400) {
             return json_encode($json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         } else {
             return json_encode($json);

--- a/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
@@ -184,7 +184,7 @@ class Zend_Stdlib_CallbackHandler
     {
         $callback = $this->getCallback();
 
-        $isPhp54 = version_compare(PHP_VERSION, '5.4.0rc1', '>=');
+        $isPhp54 = PHP_VERSION_ID >= 50400;
 
         if ($isPhp54 && is_string($callback)) {
             $this->validateStringCallbackFor54($callback);

--- a/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -534,7 +534,7 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 
                 $spliceOffset = 2;
                 //Debug backtrace changed in PHP 7.0.0
-                if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+                if (PHP_VERSION_ID >= 70000) {
                     $spliceOffset = 1;
                 }
                 $trace = array_splice($trace, $spliceOffset);

--- a/packages/zend-xml/library/Zend/Xml/Security.php
+++ b/packages/zend-xml/library/Zend/Xml/Security.php
@@ -179,18 +179,9 @@ class Zend_Xml_Security
      */
     public static function isPhpFpm()
     {
-        $isVulnerableVersion = (
-            version_compare(PHP_VERSION, '5.5.22', 'lt')
-            || (
-                version_compare(PHP_VERSION, '5.6', 'ge')
-                && version_compare(PHP_VERSION, '5.6.6', 'lt')
-            )
-        );
+        $isVulnerableVersion = PHP_VERSION_ID < 50522 || (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50606);
 
-        if (substr(php_sapi_name(), 0, 3) === 'fpm' && $isVulnerableVersion) {
-            return true;
-        }
-        return false;
+        return $isVulnerableVersion && strpos(php_sapi_name(), 'fpm') === 0;
     }
 
     /**

--- a/tests/Zend/Amf/RequestTest.php
+++ b/tests/Zend/Amf/RequestTest.php
@@ -436,7 +436,7 @@ class Zend_Amf_RequestTest extends PHPUnit_Framework_TestCase
         // In PHP versions less than 7, get_object_vars doesn't return numerical
         // keys. In PHP 7.2+ array_key_exists on this particular object returns false
         // https://3v4l.org/ui8Fm
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->assertTrue(array_key_exists(1, get_object_vars($data[0])));
         } else {
             $this->assertTrue(array_key_exists(1, $data[0]));

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -284,7 +284,7 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         // (which was later reverted in php < 7.2.0)
         // Example of the difference: https://3v4l.org/v46rk
         // Not really something we can test the same in all versions, so doing a version_compare here.
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if (PHP_VERSION_ID >= 70200) {
             $this->assertSame( 9961716, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
             $this->assertSame(10010341, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
             $this->assertSame( 9966981, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
@@ -321,7 +321,7 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         }
 
         $date = new Zend_Date_DateObjectTestHelper(-148309884);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if (PHP_VERSION_ID >= 70200) {
             $this->assertSame(-148322626, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
             $this->assertSame(-148274784, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
             $this->assertSame(-148318143, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -3821,7 +3821,9 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         // PHP's internal sunrise/sunset calculation changed in 7.2.0
         // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal
         // This applies to all of the version_compare blocks in this test
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        $isPhp72 = PHP_VERSION_ID >= 70200;
+
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T20:09:40+05:00', $result->get(Zend_Date::W3C));
         } else {
             $this->assertSame('2002-01-04T20:09:59+05:00', $result->get(Zend_Date::W3C));
@@ -3831,7 +3833,7 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('vienna', 'civil');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T20:09:01+05:00', $result->get(Zend_Date::W3C));
         } else {
             $this->assertSame('2002-01-04T20:09:20+05:00', $result->get(Zend_Date::W3C));
@@ -3841,7 +3843,7 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('vienna', 'nautic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T20:08:15+05:00', $result->get(Zend_Date::W3C));
         } else {
             $this->assertSame('2002-01-04T20:08:34+05:00', $result->get(Zend_Date::W3C));
@@ -3851,7 +3853,7 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('vienna', 'astronomic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T20:07:30+05:00', $result->get(Zend_Date::W3C));
         } else {
             $this->assertSame('2002-01-04T20:07:49+05:00', $result->get(Zend_Date::W3C));
@@ -3861,7 +3863,7 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('BERLIN');
         $this->assertTrue(is_array($result));
         $result = $date->getSunrise($result);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T12:21:26+05:00', $result->get(Zend_Date::W3C));
         } else {
             $this->assertSame('2002-01-04T12:21:21+05:00', $result->get(Zend_Date::W3C));
@@ -3871,7 +3873,7 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $result = Zend_Date_Cities::City('London');
         $this->assertTrue(is_array($result));
         $result = $date->getSunInfo($result);
-        if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+        if ($isPhp72) {
             $this->assertSame('2002-01-04T13:10:15+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
             $this->assertSame('2002-01-04T13:10:59+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
             $this->assertSame('2002-01-04T13:11:50+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));

--- a/tests/Zend/Filter/HtmlEntitiesTest.php
+++ b/tests/Zend/Filter/HtmlEntitiesTest.php
@@ -214,7 +214,7 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testCorrectsForEncodingMismatch()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
+        if (version_compare(PHP_VERSION, '5.4', '>=')) {
             $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
         }
 
@@ -234,7 +234,7 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testStripsUnknownCharactersWhenEncodingMismatchDetected()
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
+        if (version_compare(PHP_VERSION, '5.4', '>=')) {
             $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
         }
 

--- a/tests/Zend/Filter/HtmlEntitiesTest.php
+++ b/tests/Zend/Filter/HtmlEntitiesTest.php
@@ -214,7 +214,7 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testCorrectsForEncodingMismatch()
     {
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
         }
 
@@ -234,7 +234,7 @@ class Zend_Filter_HtmlEntitiesTest extends PHPUnit_Framework_TestCase
      */
     public function testStripsUnknownCharactersWhenEncodingMismatchDetected()
     {
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             $this->markTestIncomplete('Tested feature ZF-11344 is not available because of PHP bug #63450');
         }
 

--- a/tests/Zend/Ldap/ConverterTest.php
+++ b/tests/Zend/Ldap/ConverterTest.php
@@ -112,7 +112,7 @@ class Zend_Ldap_ConverterTest extends PHPUnit_Framework_TestCase
     }
 
     public function toLdapSerializeProvider(){
-        if (getenv('CI') && version_compare(PHP_VERSION, '5.4.0', '>=')) {
+        if (getenv('CI') && PHP_VERSION_ID >= 50400) {
             return array(
                 array('N;', null),
                 array('i:1;', 1),
@@ -121,7 +121,7 @@ class Zend_Ldap_ConverterTest extends PHPUnit_Framework_TestCase
             );
         }
 
-        if (version_compare(PHP_VERSION, '5.6.0beta4', '>=')) {
+        if (PHP_VERSION_ID >= 50400) {
             return array(
                 array('N;', null),
                 array('i:1;', 1),

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -106,7 +106,7 @@ class Zend_Loader_AutoloaderFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testFactoryCatchesInvalidClasses()
     {
-        if (!version_compare(PHP_VERSION, '5.3.7', '>=')) {
+        if (PHP_VERSION_ID < 50307) {
             $this->markTestSkipped('Cannot test invalid interface loader with versions less than 5.3.7');
         }
         include dirname(__FILE__) . '/_files/InvalidInterfaceAutoloader.php';

--- a/tests/Zend/Log/Writer/AbstractTest.php
+++ b/tests/Zend/Log/Writer/AbstractTest.php
@@ -58,7 +58,7 @@ class Zend_Log_Writer_AbstractTest extends PHPUnit_Framework_TestCase
      */
     public function testSetFormatter()
     {
-        if (version_compare(PHP_VERSION, '7', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Invalid typehinting is PHP Fatal error in PHP7+');
         }
 

--- a/tests/Zend/Log/Writer/AbstractTest.php
+++ b/tests/Zend/Log/Writer/AbstractTest.php
@@ -58,7 +58,7 @@ class Zend_Log_Writer_AbstractTest extends PHPUnit_Framework_TestCase
      */
     public function testSetFormatter()
     {
-        if (version_compare(phpversion(), '7', '>=')) {
+        if (version_compare(PHP_VERSION, '7', '>=')) {
             $this->markTestSkipped('Invalid typehinting is PHP Fatal error in PHP7+');
         }
 

--- a/tests/Zend/Log/Writer/DbTest.php
+++ b/tests/Zend/Log/Writer/DbTest.php
@@ -138,7 +138,7 @@ class Zend_Log_Writer_DbTest extends PHPUnit_Framework_TestCase
      */
     public function testThrowStrictSetFormatter()
     {
-        if (version_compare(phpversion(), '7', '>=')) {
+        if (version_compare(PHP_VERSION, '7', '>=')) {
             $this->markTestSkipped('Invalid typehinting is PHP Fatal error in PHP7+');
         }
 

--- a/tests/Zend/Log/Writer/DbTest.php
+++ b/tests/Zend/Log/Writer/DbTest.php
@@ -138,7 +138,7 @@ class Zend_Log_Writer_DbTest extends PHPUnit_Framework_TestCase
      */
     public function testThrowStrictSetFormatter()
     {
-        if (version_compare(PHP_VERSION, '7', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Invalid typehinting is PHP Fatal error in PHP7+');
         }
 

--- a/tests/Zend/Serializer/Adapter/PhpCodeTest.php
+++ b/tests/Zend/Serializer/Adapter/PhpCodeTest.php
@@ -145,7 +145,7 @@ class Zend_Serializer_Adapter_PhpCodeTest extends PHPUnit_Framework_TestCase
 
     public function testUnserialzeInvalid()
     {
-        if (version_compare(PHP_VERSION, '7', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $this->markTestSkipped('Evaling of invalid input is PHP Parse error in PHP7+');
         }
         $value = 'not a serialized string';

--- a/tests/Zend/Serializer/Adapter/PhpCodeTest.php
+++ b/tests/Zend/Serializer/Adapter/PhpCodeTest.php
@@ -145,7 +145,7 @@ class Zend_Serializer_Adapter_PhpCodeTest extends PHPUnit_Framework_TestCase
 
     public function testUnserialzeInvalid()
     {
-        if (version_compare(phpversion(), '7', '>=')) {
+        if (version_compare(PHP_VERSION, '7', '>=')) {
             $this->markTestSkipped('Evaling of invalid input is PHP Parse error in PHP7+');
         }
         $value = 'not a serialized string';

--- a/tests/Zend/Soap/AllTests.php
+++ b/tests/Zend/Soap/AllTests.php
@@ -53,7 +53,7 @@ class Zend_Soap_AllTests
 
         //early exit because of segfault in this specific version
         //https://github.com/zendframework/zf1/issues/650
-        if (getenv('CI') && version_compare(PHP_VERSION, '5.4.37', '=')) {
+        if (getenv('CI') && PHP_VERSION_ID >= 50437) {
             return $suite;
         }
 


### PR DESCRIPTION
> As described in https://bugs.php.net/bug.php?id=80503 
> 
> PHP 8 doesn't support "gte' operator for version_compare() 
> 
> I have found this one triggered only in fpm mode which break several things like Zend_Currency
> https://github.com/Shardj/zf1-future/blob/c84dedf0e948d9ccaa7a2ac234cc6f6787f05d45/library/Zend/Xml/Security.php#L172
> 
> EDIT: The above problem is fixed in #26 already (1.13.4 release)

Refs:
- https://github.com/zf1s/zf1/issues/51#issuecomment-772469392
- https://github.com/Shardj/zf1-future/issues/128#issue-800217669
