### PR TITLE
Allow newer php-parallel-lint/php-parallel-lint for php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/polyfill-php70": "^1.19"
     },
     "require-dev": {
-        "php-parallel-lint/php-parallel-lint": "1.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.0.0",
         "phpunit/dbunit": "1.3.2",
         "zf1s/phpunit": "3.7.39"
     },


### PR DESCRIPTION
The problem is that 5.3 can only use 1.0.0 as newer versions require newer runtime.

And 8.0.0 can't use 1.0.0 due to curly braces deprecation:

> `PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported`

Example:
- https://github.com/glensc/php-zf1s/runs/1855558100?check_suite_focus=true

Parts of the commit originally by @Megatherium