### PR TITLE
Increase Performance in unsetting rules in ACL

### DIFF
--- a/packages/zend-acl/library/Zend/Acl.php
+++ b/packages/zend-acl/library/Zend/Acl.php
@@ -481,11 +481,7 @@ class Zend_Acl
     public function removeAll()
     {
         foreach ($this->_resources as $resourceId => $resource) {
-            foreach ($this->_rules['byResourceId'] as $resourceIdCurrent => $rules) {
-                if ($resourceId === $resourceIdCurrent) {
-                    unset($this->_rules['byResourceId'][$resourceIdCurrent]);
-                }
-            }
+            unset($this->_rules['byResourceId'][$resourceId]);
         }
 
         $this->_resources = array();


### PR DESCRIPTION
Unsetting a non-existing rule doesn't throw an error.
In our Project this change improves loading time from 55 sec to 0.5 sec
(14412 Resources, 11694 Rules)

Refs:
- https://github.com/Shardj/zf1-future/pull/134
- https://github.com/zendframework/zend-permissions-acl/pull/29
- https://github.com/zendframework/zf1/pull/737