### PR TITLE
Fix a bug in Zend_Date for PHP 8.0

### DIFF
--- a/packages/zend-locale/library/Zend/Locale/Format.php
+++ b/packages/zend-locale/library/Zend/Locale/Format.php
@@ -929,7 +929,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['day'] = false;
                         } else {
                             $result['day'] = iconv_substr($splitted[0][0], $split, 2);
@@ -945,7 +945,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['month'] = false;
                         } else {
                             $result['month'] = iconv_substr($splitted[0][0], $split, 2);
@@ -967,7 +967,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['year'] = false;
                         } else {
                             $result['year'] = iconv_substr($splitted[0][0], $split, $length);
@@ -984,7 +984,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['hour'] = false;
                         } else {
                             $result['hour'] = iconv_substr($splitted[0][0], $split, 2);
@@ -1000,7 +1000,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11 */
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['minute'] = false;
                         } else {
                             $result['minute'] = iconv_substr($splitted[0][0], $split, 2);
@@ -1016,7 +1016,7 @@ class Zend_Locale_Format
                         }
                     } else {
                         // iconv_substr changes since 7.0.11
-                        if (iconv_strlen($splitted[0][0]) === $split) {
+                        if (iconv_strlen($splitted[0][0]) <= $split) {
                             $result['second'] = false;
                         } else {
                             $result['second'] = iconv_substr($splitted[0][0], $split, 2);

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -614,6 +614,20 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
             $date->toString(DateTime::ATOM, 'php')
         );
     }
+
+    public function testIncompleteTimeData()
+    {
+        try {
+            $date = new Zend_Date();
+            $date->set(0, Zend_Date::TIMES);
+        } catch (Exception $e) {
+            $this->fail('This usually stems from iconv_substr returnvalues in Zend_Locale_Format not being handled properly');
+        } catch (Throwable $e) {
+            $this->fail('This usually stems from iconv_substr returnvalues in Zend_Locale_Format not being handled properly');
+        }
+
+        $this->assertInstanceOf('Zend_Date', $date);
+    }
 }
 
 class Zend_Date_DateObjectTestHelper extends Zend_Date


### PR DESCRIPTION
Because the return values of [`iconv_substr`](https://www.php.net/iconv_substr) changed in PHP 8.0 calling [`Zend_Date::set`](https://github.com/zf1s/zf1/blob/1.13.4/packages/zend-date/library/Zend/Date.php#L1069) could lead to `TypeError`.

Extracted from https://github.com/zf1s/zf1/pull/32