### PR TITLE
Missing default values caused errorHandlerIgnore to fail under PHP 8.0

### DIFF
--- a/tests/Zend/FilterTest.php
+++ b/tests/Zend/FilterTest.php
@@ -213,7 +213,7 @@ class Zend_FilterTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Form/Element/FileTest.php
+++ b/tests/Zend/Form/Element/FileTest.php
@@ -484,7 +484,7 @@ class Zend_Form_Element_FileTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/LocaleTest.php
+++ b/tests/Zend/LocaleTest.php
@@ -969,7 +969,7 @@ class Zend_LocaleTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/ArrayTest.php
+++ b/tests/Zend/Translate/Adapter/ArrayTest.php
@@ -341,7 +341,7 @@ class Zend_Translate_Adapter_ArrayTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/CsvTest.php
+++ b/tests/Zend/Translate/Adapter/CsvTest.php
@@ -235,7 +235,7 @@ class Zend_Translate_Adapter_CsvTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/GettextTest.php
+++ b/tests/Zend/Translate/Adapter/GettextTest.php
@@ -310,7 +310,7 @@ class Zend_Translate_Adapter_GettextTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/IniTest.php
+++ b/tests/Zend/Translate/Adapter/IniTest.php
@@ -206,7 +206,7 @@ class Zend_Translate_Adapter_IniTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/QtTest.php
+++ b/tests/Zend/Translate/Adapter/QtTest.php
@@ -240,7 +240,7 @@ class Zend_Translate_Adapter_QtTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/TbxTest.php
+++ b/tests/Zend/Translate/Adapter/TbxTest.php
@@ -244,7 +244,7 @@ class Zend_Translate_Adapter_TbxTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/TmxTest.php
+++ b/tests/Zend/Translate/Adapter/TmxTest.php
@@ -270,7 +270,7 @@ class Zend_Translate_Adapter_TmxTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/XliffTest.php
+++ b/tests/Zend/Translate/Adapter/XliffTest.php
@@ -238,7 +238,7 @@ class Zend_Translate_Adapter_XliffTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Translate/Adapter/XmlTmTest.php
+++ b/tests/Zend/Translate/Adapter/XmlTmTest.php
@@ -246,7 +246,7 @@ class Zend_Translate_Adapter_XmlTmTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext= array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/TranslateTest.php
+++ b/tests/Zend/TranslateTest.php
@@ -905,7 +905,7 @@ class Zend_TranslateTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccured = true;
     }

--- a/tests/Zend/Validate/AbstractTest.php
+++ b/tests/Zend/Validate/AbstractTest.php
@@ -286,7 +286,7 @@ class Zend_Validate_AbstractTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/Validate/CcnumTest.php
+++ b/tests/Zend/Validate/CcnumTest.php
@@ -95,7 +95,7 @@ class Zend_Validate_CcnumTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccured = true;
     }

--- a/tests/Zend/Validate/DateTest.php
+++ b/tests/Zend/Validate/DateTest.php
@@ -208,7 +208,11 @@ class Zend_Validate_DateTest extends PHPUnit_Framework_TestCase
      */
     public function testNonStringValidation()
     {
-        $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+        try {
+            $this->assertFalse($this->_validator->isValid(array(1 => 1)));
+        } catch (Error $e) {
+            $this->assertTrue($e instanceof TypeError);
+        }
     }
 
     /**
@@ -251,7 +255,7 @@ class Zend_Validate_DateTest extends PHPUnit_Framework_TestCase
      * @return void
      * @group ZF-2789
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/ValidateTest.php
+++ b/tests/Zend/ValidateTest.php
@@ -242,7 +242,7 @@ class Zend_ValidateTest extends PHPUnit_Framework_TestCase
      * @param  array   $errcontext
      * @return void
      */
-    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext)
+    public function errorHandlerIgnore($errno, $errstr, $errfile, $errline, array $errcontext = array())
     {
         $this->_errorOccurred = true;
     }

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -334,7 +334,7 @@ class Zend_View_Helper_Navigation_NavigationTest
     }
 
     private $_errorMessage;
-    public function toStringErrorHandler($code, $msg, $file, $line, array $c)
+    public function toStringErrorHandler($code, $msg, $file, $line, array $c = array())
     {
         $this->_errorMessage = $msg;
     }


### PR DESCRIPTION
The changed tests all change their errorhandlers in some tests. As the
last param ($errContext) had no default value assigned the tests would
error out.

Extracted from #32