### PR TITLE
Guard file_exists call to prevent fatal error

### DIFF
--- a/packages/zend-filter/library/Zend/Filter/Compress/Bz2.php
+++ b/packages/zend-filter/library/Zend/Filter/Compress/Bz2.php
@@ -151,7 +151,8 @@ class Zend_Filter_Compress_Bz2 extends Zend_Filter_Compress_CompressAbstract
     public function decompress($content)
     {
         $archive = $this->getArchive();
-        if (@file_exists($content)) {
+        // check $content for NULL bytes or else file_exists will error out
+        if ((0 === preg_match('/\0/', $content)) && @file_exists($content)) {
             $archive = $content;
         }
 

--- a/packages/zend-filter/library/Zend/Filter/Compress/Gz.php
+++ b/packages/zend-filter/library/Zend/Filter/Compress/Gz.php
@@ -182,7 +182,8 @@ class Zend_Filter_Compress_Gz extends Zend_Filter_Compress_CompressAbstract
     {
         $archive = $this->getArchive();
         $mode    = $this->getMode();
-        if (@file_exists($content)) {
+        // check $content for NULL bytes or else file_exists will error out
+        if ((0 === preg_match('/\0/', $content)) && @file_exists($content)) {
             $archive = $content;
         }
 


### PR DESCRIPTION
Having a NULL character as an argument for file_exists will cause the
script to error out. This behaviour is prevented to validating that the
string does not contain NULL beforehand.

Extracted from #32

