### PR TITLE
Remove libxml deprecations for php 8.0

### DIFF
--- a/packages/zend-feed/library/Zend/Feed/Reader.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader.php
@@ -417,10 +417,14 @@ class Zend_Feed_Reader
         }
         $responseHtml = $response->getBody();
         $libxml_errflag = libxml_use_internal_errors(true);
-        $oldValue = libxml_disable_entity_loader(true);
+        if (LIBXML_VERSION < 20900) {
+            $oldValue = libxml_disable_entity_loader(true);
+        }
         $dom = new DOMDocument;
         $status = $dom->loadHTML($responseHtml);
-        libxml_disable_entity_loader($oldValue);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($oldValue);
+        }
         libxml_use_internal_errors($libxml_errflag);
         if (!$status) {
             // Build error message

--- a/tests/Zend/Test/PHPUnit/Db/Integration/AbstractTestCase.php
+++ b/tests/Zend/Test/PHPUnit/Db/Integration/AbstractTestCase.php
@@ -48,12 +48,16 @@ abstract class Zend_Test_PHPUnit_Db_Integration_AbstractTestCase extends PHPUnit
 
     public function setUp()
     {
-        $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        if (LIBXML_VERSION < 20900) {
+            $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        }
     }
 
     public function tearDown()
     {
-        libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        }
     }
 
     public function testZendDbTableDataSet()

--- a/tests/Zend/Test/PHPUnit/Db/Operation/DeleteAllTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/DeleteAllTest.php
@@ -40,12 +40,16 @@ class Zend_Test_PHPUnit_Db_Operation_DeleteAllTest extends PHPUnit_Framework_Tes
     public function setUp()
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_DeleteAll();
-        $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        if (LIBXML_VERSION < 20900) {
+            $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        }
     }
 
     public function tearDown()
     {
-        libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        }
     }
 
     public function testDeleteAll()

--- a/tests/Zend/Test/PHPUnit/Db/Operation/InsertTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/InsertTest.php
@@ -40,12 +40,16 @@ class Zend_Test_PHPUnit_Db_Operation_InsertTest extends PHPUnit_Framework_TestCa
     public function setUp()
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_Insert();
-        $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        if (LIBXML_VERSION < 20900) {
+            $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        }
     }
 
     public function tearDown()
     {
-        libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        }
     }
 
     public function testInsertDataSetUsingAdapterInsert()

--- a/tests/Zend/Test/PHPUnit/Db/Operation/TruncateTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/TruncateTest.php
@@ -40,12 +40,16 @@ class Zend_Test_PHPUnit_Db_Operation_TruncateTest extends PHPUnit_Framework_Test
     public function setUp()
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_Truncate();
-        $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        if (LIBXML_VERSION < 20900) {
+            $this->libxmlDisableEntityLoader = libxml_disable_entity_loader(false);
+        }
     }
 
     public function tearDown()
     {
-        libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        if (LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader($this->libxmlDisableEntityLoader);
+        }
     }
 
     public function testTruncateTablesExecutesAdapterQuery()


### PR DESCRIPTION
On libxml >= 2.9 the entity loader is disabled by default. Calls to
libxml_disable_entity_loader are now performed conditionally with lower
versions.

Extracted from #32