### PR TITLE
Ensure non-negative values for bcmath

### DIFF
--- a/packages/zend-locale/library/Zend/Locale/Math.php
+++ b/packages/zend-locale/library/Zend/Locale/Math.php
@@ -216,11 +216,12 @@ class Zend_Locale_Math
      * Fixes a problem of BCMath with numbers containing exponents
      *
      * @param integer $value Value to erase the exponent
-     * @param integer $scale (Optional) Scale to use
+     * @param int|null $scale (Optional) Scale to use
      * @return string
      */
     public static function exponent($value, $scale = null)
     {
+        $scale = max(0, $scale);
         if (!extension_loaded('bcmath')) {
             return $value;
         }
@@ -242,11 +243,18 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Add($op1, $op2, $scale = null)
     {
+        /**
+         * Before PHP8 bcmath functions could be called with a negative
+         * scale factor which was handled as if $scale were 0
+         *
+         * With PHP8 this would emit a ValueError
+         */
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
 
@@ -258,11 +266,12 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Sub($op1, $op2, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
         return bcsub($op1, $op2, $scale);
@@ -273,11 +282,12 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Pow($op1, $op2, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
         return bcpow($op1, $op2, $scale);
@@ -288,11 +298,12 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Mul($op1, $op2, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
         return bcmul($op1, $op2, $scale);
@@ -303,11 +314,12 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Div($op1, $op2, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
         return bcdiv($op1, $op2, $scale);
@@ -317,11 +329,12 @@ class Zend_Locale_Math
      * BCSqrt - fixes a problem of BCMath and exponential numbers
      *
      * @param  string  $op1
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Sqrt($op1, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         return bcsqrt($op1, $scale);
     }
@@ -345,11 +358,12 @@ class Zend_Locale_Math
      *
      * @param  string  $op1
      * @param  string  $op2
-     * @param  integer $scale
+     * @param  int|null $scale
      * @return string
      */
     public static function Comp($op1, $op2, $scale = null)
     {
+        $scale = max(0, $scale);
         $op1 = self::exponent($op1, $scale);
         $op2 = self::exponent($op2, $scale);
         return bccomp($op1, $op2, $scale);


### PR DESCRIPTION
Beginning with PHP8 supplying a negative value as an argument for scale
in the `bcmath` functions will generate a ValueError. Negative values
supplied to the Zend math functions are ignored and 0 is used generating
the same results as before.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32