### PR TITLE
Add support for gd resource type change in php 8.0

### DIFF
--- a/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
+++ b/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
@@ -93,7 +93,7 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
      * Set height of the result image
      *
      * @param null|integer $value
-     * @return Zend_Image_Barcode_Abstract
+     * @return self
      * @throws Zend_Barcode_Renderer_Exception
      */
     public function setHeight($value)
@@ -151,26 +151,25 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
      * Set an image resource to draw the barcode inside
      *
      * @param $image
-     * @return Zend_Barcode_Renderer
+     * @return self
      * @throws Zend_Barcode_Renderer_Exception
      */
     public function setResource($image)
     {
-        if (gettype($image) != 'resource' || get_resource_type($image) != 'gd') {
-            // require_once 'Zend/Barcode/Renderer/Exception.php';
-            throw new Zend_Barcode_Renderer_Exception(
-                'Invalid image resource provided to setResource()'
-            );
+        if ((gettype($image) === 'resource' && get_resource_type($image) === 'gd') || get_class($image) === 'GdImage') {
+            $this->_resource = $image;
+            return $this;
         }
-        $this->_resource = $image;
-        return $this;
+        throw new Zend_Barcode_Renderer_Exception(
+            'Invalid image resource provided to setResource()'
+        );
     }
 
     /**
      * Set the image type to produce (png, jpeg, gif)
      *
      * @param string $value
-     * @return Zend_Barcode_RendererAbstract
+     * @return self
      * @throws Zend_Barcode_Renderer_Exception
      */
     public function setImageType($value)

--- a/tests/Zend/Barcode/FactoryTest.php
+++ b/tests/Zend/Barcode/FactoryTest.php
@@ -352,8 +352,12 @@ class Zend_Barcode_FactoryTest extends PHPUnit_Framework_TestCase
                     'GD extension is required to run this test');
         }
         $resource = Zend_Barcode::draw('code25', 'image');
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+            $this->assertTrue(get_resource_type($resource) == 'gd', 'Image must be a GD resource');
+        } else {
+            $this->assertTrue(get_class($resource) === 'GdImage');
+        }
     }
 
     public function testProxyBarcodeRendererDrawAsPdf()

--- a/tests/Zend/Barcode/Renderer/ImageTest.php
+++ b/tests/Zend/Barcode/Renderer/ImageTest.php
@@ -129,9 +129,13 @@ class Zend_Barcode_Renderer_ImageTest extends Zend_Barcode_Renderer_TestCommon
         $barcode = new Zend_Barcode_Object_Code39(array('text' => '0123456789'));
         $this->_renderer->setBarcode($barcode);
         $resource = $this->_renderer->draw();
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd',
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+            $this->assertTrue(get_resource_type($resource) == 'gd',
                 'Image must be a GD resource');
+        } else {
+            $this->assertTrue(get_class($resource) === 'GdImage');
+        }
     }
 
     public function testDrawWithExistantResourceReturnResource()
@@ -143,9 +147,13 @@ class Zend_Barcode_Renderer_ImageTest extends Zend_Barcode_Renderer_TestCommon
         $imageResource = imagecreatetruecolor(500, 500);
         $this->_renderer->setResource($imageResource);
         $resource = $this->_renderer->draw();
-        $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
-        $this->assertTrue(get_resource_type($resource) == 'gd',
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertTrue(gettype($resource) == 'resource', 'Image must be a resource');
+            $this->assertTrue(get_resource_type($resource) == 'gd',
                 'Image must be a GD resource');
+        } else {
+            $this->assertTrue(get_class($resource) === 'GdImage');
+        }
         $this->assertSame($resource, $imageResource);
     }
 

--- a/tests/Zend/Barcode/Renderer/TestCommon.php
+++ b/tests/Zend/Barcode/Renderer/TestCommon.php
@@ -34,7 +34,7 @@ abstract class Zend_Barcode_Renderer_TestCommon extends PHPUnit_Framework_TestCa
 {
 
     /**
-     * @var Zend_Barcode_Renderer
+     * @var Zend_Barcode_Renderer_RendererAbstract
      */
     protected $_renderer = null;
 


### PR DESCRIPTION
GD function no longer returns a resource of type gd but GdImage objects
which needed to be implemented accordingly.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32
