### PR TITLE
Use ubuntu-16.04 by default for faster setup-php

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +27,7 @@ jobs:
         include:
           - php: "8.0"
             experimental: true
+            runs-on: ubuntu-20.04
 
     services:
       memcache:


### PR DESCRIPTION
refs:
- https://github.com/zf1s/zf1/pull/49#issuecomment-798119799
- https://github.com/shivammathur/setup-php/issues/63#issuecomment-790491111
- https://github.com/shivammathur/setup-php#github-hosted-runners

thanks, @staabm.