### PR TITLE
Remove openssl deprecation for php 8.0

### DIFF
--- a/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
+++ b/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
@@ -144,8 +144,9 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
                         // require_once 'Zend/Filter/Exception.php';
                         throw new Zend_Filter_Exception("Public key '{$cert}' not valid");
                     }
-
-                    openssl_free_key($test);
+                    if (PHP_VERSION_ID < 80000) {
+                        openssl_free_key($test);
+                    }
                     $this->_keys['public'][$key] = $cert;
                     break;
                 case 'private':
@@ -154,8 +155,9 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
                         // require_once 'Zend/Filter/Exception.php';
                         throw new Zend_Filter_Exception("Private key '{$cert}' not valid");
                     }
-
-                    openssl_free_key($test);
+                    if (PHP_VERSION_ID < 80000) {
+                        openssl_free_key($test);
+                    }
                     $this->_keys['private'][$key] = $cert;
                     break;
                 case 'envelope':
@@ -384,9 +386,11 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
             $value    = $compress->filter($value);
         }
 
-        $crypt  = openssl_seal($value, $encrypted, $encryptedkeys, $keys);
-        foreach ($keys as $key) {
-            openssl_free_key($key);
+        $crypt  = openssl_seal($value, $encrypted, $encryptedkeys, $keys, 'RC4');
+        if (PHP_VERSION_ID < 80000) {
+            foreach ($keys as $key) {
+                openssl_free_key($key);
+            }
         }
 
         if ($crypt === false) {
@@ -462,8 +466,10 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
             $value = substr($value, $length);
         }
 
-        $crypt  = openssl_open($value, $decrypted, $envelope, $keys);
-        openssl_free_key($keys);
+        $crypt  = openssl_open($value, $decrypted, $envelope, $keys, 'RC4');
+        if (PHP_VERSION_ID < 80000) {
+            openssl_free_key($keys);
+        }
 
         if ($crypt === false) {
             // require_once 'Zend/Filter/Exception.php';


### PR DESCRIPTION
openssl_free_key has been deprecated in PHP 8.0 and is called
automatically. The explicit calls are still performed conditionally in
older PHP versions.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32
