### PR TITLE
php 8.0: Change call in ClassMapAutoloader to preserve original behaviour

### DIFF
--- a/packages/zend-loader/library/Zend/Loader/ClassMapAutoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/ClassMapAutoloader.php
@@ -208,7 +208,10 @@ class Zend_Loader_ClassMapAutoloader implements Zend_Loader_SplAutoloader
         $prependSlash = $parts && $parts[0] === '' ? '/' : '';
         $parts = array_values(array_filter($parts, array(__CLASS__, 'concatPharParts')));
 
-        array_walk($parts, array(__CLASS__, 'resolvePharParentPath'), $parts);
+        foreach ($parts as $key => $value) {
+            self::resolvePharParentPath($value, $key, $parts);
+        }
+
         if (file_exists($realPath = 'phar://' . $prependSlash . implode('/', $parts))) {
             return $realPath;
         }


### PR DESCRIPTION
In PHP8 the third param of array_walk ($userdata) is automatically
passed by value thus calling a function that expects pass by reference
as the third param is not possible.
Simply changing the array_walk to a foreach loop allows us to fulfill
the pass by reference signature.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32
