### PR TITLE
Make Zend_Validate_Date work as expected under PHP 8.0

### DIFF
--- a/packages/zend-validate/library/Zend/Validate/Date.php
+++ b/packages/zend-validate/library/Zend/Validate/Date.php
@@ -218,6 +218,8 @@ class Zend_Validate_Date extends Zend_Validate_Abstract
         } catch (Exception $e) {
             // Date can not be parsed
             return false;
+        } catch (Error $e) {
+            return false;
         }
 
         if (((strpos($this->_format, 'Y') !== false) or (strpos($this->_format, 'y') !== false)) and


### PR DESCRIPTION
By additionally catching an error where only an exception used to be
caught and thus returning false on Zend_Validate_Date::isValid the
validator now behaves the same under PHP8+
This also means that we don't need to catch the error in the test method
anymore.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32
