### PR TITLE
Fixed reflection deprecations for php 8.0

### DIFF
--- a/packages/zend-amf/library/Zend/Amf/Adobe/Introspector.php
+++ b/packages/zend-amf/library/Zend/Amf/Adobe/Introspector.php
@@ -183,8 +183,10 @@ class Zend_Amf_Adobe_Introspector
                     $arg->setAttribute('name', $param->getName());
 
                     $type = $param->getType();
-                    if ($type == 'mixed' && ($pclass = $param->getClass())) {
-                        $type = $pclass->getName();
+                    if (PHP_VERSION_ID < 80000) {
+                        if ($type == 'mixed' && ($pclass = $param->getClass())) {
+                            $type = $pclass->getName();
+                        }
                     }
 
                     $ptype = $this->_registerType($type);

--- a/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Parameter.php
+++ b/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Parameter.php
@@ -74,7 +74,9 @@ class Zend_CodeGenerator_Php_Parameter extends Zend_CodeGenerator_Php_Abstract
         $param = new Zend_CodeGenerator_Php_Parameter();
         $param->setName($reflectionParameter->getName());
 
-        if($reflectionParameter->isArray()) {
+        if (PHP_VERSION_ID >= 80000) {
+            $param->setType($reflectionParameter->getType());
+        } elseif ($reflectionParameter->isArray()) {
             $param->setType('array');
         } else {
             $typeClass = $reflectionParameter->getClass();

--- a/packages/zend-reflection/library/Zend/Reflection/Parameter.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Parameter.php
@@ -58,12 +58,22 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      */
     public function getClass($reflectionClass = 'Zend_Reflection_Class')
     {
-        $phpReflection  = parent::getClass();
-        if($phpReflection == null) {
-            return null;
+        if (PHP_VERSION_ID < 80000) {
+            $phpReflection  = parent::getClass();
+            if ($phpReflection == null) {
+                return null;
+            }
+
+            $phpReflectionClassName = $phpReflection->getName();
+        } else {
+            if (!parent::hasType()) {
+                return null;
+            }
+
+            $phpReflectionClassName = parent::getType();
         }
 
-        $zendReflection = new $reflectionClass($phpReflection->getName());
+        $zendReflection = new $reflectionClass($phpReflectionClassName);
         if (!$zendReflection instanceof Zend_Reflection_Class) {
             // require_once 'Zend/Reflection/Exception.php';
             throw new Zend_Reflection_Exception('Invalid reflection class provided; must extend Zend_Reflection_Class');
@@ -109,13 +119,21 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      */
     public function getType()
     {
-        if ($docblock = $this->getDeclaringFunction()->getDocblock()) {
-            $params = $docblock->getTags('param');
+        try {
+            if ($docblock = $this->getDeclaringFunction()->getDocblock()) {
+                $params = $docblock->getTags('param');
 
-            if (isset($params[$this->getPosition()])) {
-                return $params[$this->getPosition()]->getType();
+                if (isset($params[$this->getPosition()])) {
+                    return $params[$this->getPosition()]->getType();
+                }
+
             }
-
+        } catch (Zend_Reflection_Exception $e) {
+            if (PHP_VERSION_ID >= 80000) {
+                return parent::getType();
+            } else {
+                throw $e;
+            }
         }
 
         return null;

--- a/packages/zend-server/library/Zend/Server/Reflection/Function/Abstract.php
+++ b/packages/zend-server/library/Zend/Server/Reflection/Function/Abstract.php
@@ -310,9 +310,13 @@ abstract class Zend_Server_Reflection_Function_Abstract
             // Try and auto-determine type, based on reflection
             $paramTypesTmp = array();
             foreach ($parameters as $i => $param) {
-                $paramType = 'mixed';
-                if ($param->isArray()) {
-                    $paramType = 'array';
+                if (PHP_VERSION_ID < 80000) {
+                    $paramType = 'mixed';
+                    if ($param->isArray()) {
+                        $paramType = 'array';
+                    }
+                } else {
+                    $paramType = $param->hasType() ? $param->getType() : 'mixed';
                 }
                 $paramTypesTmp[$i] = $paramType;
             }

--- a/tests/Zend/CodeGenerator/Php/ClassTest.php
+++ b/tests/Zend/CodeGenerator/Php/ClassTest.php
@@ -52,11 +52,6 @@ class Zend_CodeGenerator_Php_ClassTest extends PHPUnit_Framework_TestCase
 
     }
 
-    public function testClassDocblockAccessors()
-    {
-        $this->markTestSkipped();
-    }
-
     public function testAbstractAccessors()
     {
         $codeGenClass = new Zend_CodeGenerator_Php_Class();

--- a/tests/Zend/CodeGenerator/Php/ParameterTest.php
+++ b/tests/Zend/CodeGenerator/Php/ParameterTest.php
@@ -134,11 +134,15 @@ class Zend_CodeGenerator_Php_ParameterTest extends PHPUnit_Framework_TestCase
         $reflParam = $this->getFirstReflectionParameter('hasNativeDocTypes');
         $codeGenParam = Zend_CodeGenerator_Php_Parameter::fromReflection($reflParam);
 
-        $this->assertNotEquals('int', $codeGenParam->getType());
-        $this->assertEquals('', $codeGenParam->getType());
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertEquals('', $codeGenParam->getType());
+            $this->assertNotEquals('int', $codeGenParam->getType());
+        } else {
+            $this->assertEquals('int', $codeGenParam->getType());
+        }
     }
 
-    static public function dataFromReflection_Generate()
+    public static function dataFromReflection_Generate()
     {
         return array(
             array('name', '$param'),
@@ -147,7 +151,7 @@ class Zend_CodeGenerator_Php_ParameterTest extends PHPUnit_Framework_TestCase
             array('defaultValue', '$value = \'foo\''),
             array('defaultNull', '$value = null'),
             array('fromArray', 'array $array'),
-            array('hasNativeDocTypes', '$integer'),
+            array('hasNativeDocTypes', PHP_VERSION_ID >= 80000 ? 'int $integer' : '$integer'),
             array('defaultArray', '$array = array ()'),
             array('defaultArrayWithValues', '$array = array (  0 => 1,  1 => 2,  2 => 3,)'),
             array('defaultFalse', '$val = false'),


### PR DESCRIPTION
Methods like isArray and getClass have been completely substituted by
getType in PHP8. Calls are thus made conditionally now.

Extracted changes made by @Megatherium from https://github.com/zf1s/zf1/pull/32