### PR TITLE
Remove default values from method signatures

### DIFF
--- a/packages/zend-pdf/library/Zend/Pdf/Element/Reference.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Element/Reference.php
@@ -88,7 +88,7 @@ class Zend_Pdf_Element_Reference extends Zend_Pdf_Element
      * @param Zend_Pdf_ElementFactory $factory
      * @throws Zend_Pdf_Exception
      */
-    public function __construct($objNum, $genNum = 0, Zend_Pdf_Element_Reference_Context $context, Zend_Pdf_ElementFactory $factory)
+    public function __construct($objNum, $genNum, Zend_Pdf_Element_Reference_Context $context, Zend_Pdf_ElementFactory $factory)
     {
         if ( !(is_integer($objNum) && $objNum > 0) ) {
             // require_once 'Zend/Pdf/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
@@ -519,7 +519,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	 * @param Zend_Service_WindowsAzure_Storage_QueueMessage $message Message to delete from queue. A message retrieved using "peekMessages" can NOT be deleted!
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function deleteMessage($queueName = '', Zend_Service_WindowsAzure_Storage_QueueMessage $message)
+	public function deleteMessage($queueName, Zend_Service_WindowsAzure_Storage_QueueMessage $message)
 	{
 		if ($queueName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';


### PR DESCRIPTION
As optional before required params are forbidden in PHP 8.0 these signatures
needed to be changed and the functionality of the method adapted
accordingly to still retain the original behavior.

Moved out of https://github.com/zf1s/zf1/pull/67, 
which was moved out from https://github.com/zf1s/zf1/pull/32

