### PR TITLE
Fix vsprintf TypeError for php 8.0

### DIFF
--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Regex.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Regex.php
@@ -246,7 +246,7 @@ class Zend_Controller_Router_Route_Regex extends Zend_Controller_Router_Route_Ab
 
         ksort($mergedData);
 
-        $return = @vsprintf($this->_reverse, $mergedData);
+        $return = !empty($mergedData) ? @vsprintf($this->_reverse, $mergedData) : false;
 
         if ($return === false) {
             // require_once 'Zend/Controller/Router/Exception.php';


### PR DESCRIPTION
In php 8.0, passing invalid arguments to vsprintf, results TypeError.
Restore previous behavior of returning false.

Moved out of https://github.com/zf1s/zf1/pull/67, which was moved out from https://github.com/zf1s/zf1/pull/32