### PR TITLE
Enforce types for PHP 8.0

### DIFF
--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -588,7 +588,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * @param  string $key
      * @return void
      */
-    protected function _filterValue(&$value, &$key)
+    protected function _filterValue(&$value, $key)
     {
         foreach ($this->getFilters() as $filter) {
             $value = $filter->filter($value);

--- a/packages/zend-log/library/Zend/Log.php
+++ b/packages/zend-log/library/Zend/Log.php
@@ -619,7 +619,7 @@ class Zend_Log
      * @param array $errcontext
      * @return boolean
      */
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $errorLevel = error_reporting();
 

--- a/packages/zend-log/library/Zend/Log/Formatter/Simple.php
+++ b/packages/zend-log/library/Zend/Log/Formatter/Simple.php
@@ -100,7 +100,7 @@ class Zend_Log_Formatter_Simple extends Zend_Log_Formatter_Abstract
                 $value = gettype($value);
             }
 
-            $output = str_replace("%$name%", $value, $output);
+            $output = str_replace("%$name%", (string)$value, $output);
         }
 
         return $output;

--- a/packages/zend-rest/library/Zend/Rest/Server.php
+++ b/packages/zend-rest/library/Zend/Rest/Server.php
@@ -139,7 +139,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
      * @param string $key
      * @return string Lower cased string
      */
-    public static function lowerCase(&$value, &$key)
+    public static function lowerCase(&$value, $key)
     {
         return $value = strtolower($value);
     }


### PR DESCRIPTION
PHP 8.0 is a stickler for types necessitating some explicit casts.

Moved out of https://github.com/zf1s/zf1/pull/67, which was moved out from https://github.com/zf1s/zf1/pull/32