### PR TITLE
Fix Zend_Form_ElementTest

### DIFF
--- a/tests/Zend/Form/ElementTest.php
+++ b/tests/Zend/Form/ElementTest.php
@@ -48,6 +48,11 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  */
 class Zend_Form_ElementTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Zend_Form_Element
+     */
+    private $element;
+
     public static function main()
     {
         $suite  = new PHPUnit_Framework_TestSuite('Zend_Form_ElementTest');
@@ -1760,12 +1765,12 @@ class Zend_Form_ElementTest extends PHPUnit_Framework_TestCase
 
         $options = $this->getOptions();
         $options['filters'] = array(
-            array('Digits', array('bar' => 'baz')),
+            array('Alnum', array('allowWhiteSpace' => true)),
             array('Alpha', array('foo')),
         );
         $this->element->setOptions($options);
-        $filter = $this->element->getFilter('Digits');
-        $this->assertTrue($filter instanceof Zend_Filter_Digits);
+        $filter = $this->element->getFilter('Alnum');
+        $this->assertTrue($filter instanceof Zend_Filter_Alnum);
         $filter = $this->element->getFilter('Alpha');
         $this->assertTrue($filter instanceof Zend_Filter_Alpha);
     }


### PR DESCRIPTION
@Megatherium on 3 Dec 2020:

> The behaviour hasn't really changed because the intent of the test is to
> use an array of arrays in setOptions. What has changed is that PHP 8.0
> supports calling functions with named parameters and will throw a Fatal
> if you try to access a parameter by name that does not exist.
> Digits::__construct has no param named bar ergo we get a Fatal.
> 

See discussion here:
- https://github.com/zf1s/zf1/pull/32#discussion_r534991212


Extracted out of https://github.com/zf1s/zf1/pull/77 which was @Megatherium changes from https://github.com/zf1s/zf1/pull/32