### PR TITLE
Fix iterators usage

### DIFF
--- a/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
+++ b/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
@@ -57,10 +57,10 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit_Fram
         $this->stack->push(new Zend_Controller_Action_Helper_ViewRenderer());
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
         $this->assertEquals(2, count($this->stack));
-        $iterator = $this->stack->getIterator();
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($iterator)));
-        next($iterator);
-        $this->assertEquals('Zend_Controller_Action_Helper_ViewRenderer', get_class(current($iterator)));
+        $iterator = $this->stack->getIterator()->getIterator();
+        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($iterator->current()));
+        $iterator->next();
+        $this->assertEquals('Zend_Controller_Action_Helper_ViewRenderer', get_class($iterator->current()));
     }
 
     public function testStackPrioritiesWithDefaults()
@@ -107,7 +107,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends PHPUnit_Fram
         $this->stack->push(new Zend_Controller_Action_Helper_Redirector());
         unset($this->stack->ViewRenderer);
         $this->assertEquals(1, count($this->stack));
-        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class(current($this->stack->getIterator())));
+        $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->getIterator()->getIterator()->current()));
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->Redirector));
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->offsetGet('Redirector')));
         $this->assertEquals('Zend_Controller_Action_Helper_Redirector', get_class($this->stack->offsetGet(2)));


### PR DESCRIPTION
Made the handling of iterators in Zend_Controller_Action_HelperBroker_PriorityStackTest compatible with all versions.

From https://github.com/zf1s/zf1/pull/32#discussion_r534987951:
> @falkenhawk on 3 Dec 2020 Member
> does php8 throw on calling current() / next() on an iterator?
> 
> @Megatherium Megatherium on 3 Dec 2020 Author
> It returns false and thus get_class throws a TypeError
> 

Extracted out of https://github.com/zf1s/zf1/pull/77 which was @Megatherium changes from https://github.com/zf1s/zf1/pull/32