### PR TITLE
DB2 constants are missing when setting up db factory

### DIFF
--- a/packages/zend-db/library/Zend/Db/Adapter/Db2.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Db2.php
@@ -79,7 +79,7 @@ class Zend_Db_Adapter_Db2 extends Zend_Db_Adapter_Abstract
      *
      * @var int execution flag (DB2_AUTOCOMMIT_ON or DB2_AUTOCOMMIT_OFF)
      */
-    protected $_execute_mode = DB2_AUTOCOMMIT_ON;
+    protected $_execute_mode;
 
     /**
      * Default class name for a DB statement.
@@ -110,6 +110,17 @@ class Zend_Db_Adapter_Db2 extends Zend_Db_Adapter_Abstract
         'DECIMAL'            => Zend_Db::FLOAT_TYPE,
         'NUMERIC'            => Zend_Db::FLOAT_TYPE
     );
+
+    public function __construct($config)
+    {
+        // Only assign the value if constant is present
+        // The required extension check is performed in _connect()
+        if (defined('DB2_AUTOCOMMIT_ON')) {
+            $this->_execute_mode = DB2_AUTOCOMMIT_ON;
+        }
+
+        parent::__construct($config);
+    }
 
     /**
      * Creates a connection resource.

--- a/tests/Zend/Db/TestSetup.php
+++ b/tests/Zend/Db/TestSetup.php
@@ -80,14 +80,18 @@ abstract class Zend_Db_TestSetup extends PHPUnit_Framework_TestCase
      */
     protected function _setUpAdapter()
     {
-        $this->_db = Zend_Db::factory($this->getDriver(), $this->_util->getParams());
         try {
+            $this->_db = Zend_Db::factory($this->getDriver(), $this->_util->getParams());
             $conn = $this->_db->getConnection();
         } catch (Zend_Exception $e) {
             $this->_db = null;
             $this->assertTrue($e instanceof Zend_Db_Adapter_Exception,
                 'Expecting Zend_Db_Adapter_Exception, got ' . get_class($e));
             $this->markTestSkipped($e->getMessage());
+        } catch (Throwable $e) {
+            if (stristr($e->getMessage(), 'undefined constant')) {
+                $this->markTestSkipped();
+            }
         }
     }
 


### PR DESCRIPTION
In a lot of cases with PHP8 Type and ValueErrors are thrown instead of
warnings emitted. The error handling in tests needed to be modified
accordingly.

Changes for this discussion:
- https://github.com/zf1s/zf1/pull/32#discussion_r534989302

