### PR TITLE
Use gnu parallel for validating composer.json

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,7 @@ jobs:
       # https://github.com/zf1s/zf1/pull/6#issuecomment-495397170
       - name: Validate composer.json for all packages
         run: |
-          for json in composer.json packages/*/composer.json; do COMPOSER=$json composer validate || touch failed; done
-          test ! -f failed
+          for json in composer.json packages/*/composer.json; do echo COMPOSER=$json; done | parallel env {} composer validate
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
On my local laptop, the runtime changes 45s to 11s.

On GitHub Actions the difference is 16s vs 10s.

And here's an example for a job where composer.json validation failed for two files:
- https://github.com/zf1s/zf1/runs/2114897482