### PR TITLE
paginator: fixed phpdoc typo

### DIFF
--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -854,7 +854,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      * Returns the page collection.
      *
      * @param  string $scrollingStyle Scrolling style
-     * @return array
+     * @return stdClass
      */
     public function getPages($scrollingStyle = null)
     {

--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -168,7 +168,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
     /**
      * Pages
      *
-     * @var array
+     * @var stdClass
      */
     protected $_pages = null;
 


### PR DESCRIPTION
`$this->_createPages($scrollingStyle);` returns a `stdClass` so `getPages` can never return a array as documented