### PR TITLE
fix `Zend_View_Abstract::__get()` phpdoc

### DIFF
--- a/packages/zend-view/library/Zend/View/Abstract.php
+++ b/packages/zend-view/library/Zend/View/Abstract.php
@@ -262,7 +262,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
      * If {@link strictVars()} is on, raises a notice.
      *
      * @param  string $key
-     * @return null
+     * @return mixed
      */
     public function __get($key)
     {


### PR DESCRIPTION
as discussed in phpstan upstream issue https://github.com/phpstan/phpstan/issues/3927#issuecomment-705760442

to access variables from within a controller via `$this->view` without a phpstan error, this phpdoc needs to be fixed.