### PR TITLE
Zend_Log: catch TypeError/ValueError for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,20 +13,9 @@ jobs:
       matrix:
         experimental:
           - false
-        php:
-          - "5.3"
-          - "5.4"
-          - "5.5"
-          - "5.6"
-          - "7.0"
-          - "7.1"
-          - "7.2"
-          - "7.3"
-          - "7.4"
         # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
         include:
           - php: "8.0"
-            experimental: true
             runs-on: ubuntu-20.04
 
     env:

--- a/packages/zend-log/library/Zend/Log/Writer/Stream.php
+++ b/packages/zend-log/library/Zend/Log/Writer/Stream.php
@@ -77,6 +77,9 @@ class Zend_Log_Writer_Stream extends Zend_Log_Writer_Abstract
 
             try {
                 $this->_stream = @fopen($streamOrUrl, $mode, false);
+            } catch (ValueError $e) {
+                // require_once 'Zend/Log/Exception.php';
+                throw new Zend_Log_Exception($e->getMessage(), $e->getCode());
             } catch (TypeError $e) {
                 // require_once 'Zend/Log/Exception.php';
                 throw new Zend_Log_Exception($e->getMessage(), $e->getCode());

--- a/packages/zend-log/library/Zend/Log/Writer/Stream.php
+++ b/packages/zend-log/library/Zend/Log/Writer/Stream.php
@@ -75,7 +75,14 @@ class Zend_Log_Writer_Stream extends Zend_Log_Writer_Abstract
                 $streamOrUrl = $streamOrUrl['stream'];
             }
 
-            if (! $this->_stream = @fopen($streamOrUrl, $mode, false)) {
+            try {
+                $this->_stream = @fopen($streamOrUrl, $mode, false);
+            } catch (TypeError $e) {
+                // require_once 'Zend/Log/Exception.php';
+                throw new Zend_Log_Exception($e->getMessage(), $e->getCode());
+            }
+
+            if (!$this->_stream) {
                 // require_once 'Zend/Log/Exception.php';
                 $msg = "\"$streamOrUrl\" cannot be opened with mode \"$mode\"";
                 throw new Zend_Log_Exception($msg);

--- a/packages/zend-log/library/Zend/Log/Writer/Stream.php
+++ b/packages/zend-log/library/Zend/Log/Writer/Stream.php
@@ -140,7 +140,14 @@ class Zend_Log_Writer_Stream extends Zend_Log_Writer_Abstract
     {
         $line = $this->_formatter->format($event);
 
-        if (false === @fwrite($this->_stream, $line)) {
+        try {
+            $result = @fwrite($this->_stream, $line);
+        } catch (TypeError $e) {
+            // require_once 'Zend/Log/Exception.php';
+            throw new Zend_Log_Exception($e->getMessage(), $e->getCode());
+        }
+
+        if ($result === false) {
             // require_once 'Zend/Log/Exception.php';
             throw new Zend_Log_Exception("Unable to write to stream");
         }


### PR DESCRIPTION
Similar to https://github.com/zf1s/zf1/pull/85, catch `TypeError`/`ValueError` being thrown from PHP 8.0 from invalid arguments and convert to appropriate `Zend_Exception`.

refs:
- https://github.com/zf1s/zf1/issues/51