### PR TITLE
[zend-db] Fix PHPDoc @return statement for Zend_Db_Select::query()

### DIFF
--- a/packages/zend-db/library/Zend/Db/Select.php
+++ b/packages/zend-db/library/Zend/Db/Select.php
@@ -700,7 +700,7 @@ class Zend_Db_Select
      *
      * @param integer $fetchMode OPTIONAL
      * @param  mixed  $bind An array of data to bind to the placeholders.
-     * @return PDO_Statement|Zend_Db_Statement
+     * @return Zend_Db_Statement
      */
     public function query($fetchMode = null, $bind = array())
     {


### PR DESCRIPTION
Carry https://github.com/Shardj/zf1-future/pull/166

cc @rruchte