### PR TITLE
[zend-loader] Avoiding error logs when using class_exists

### DIFF
--- a/packages/zend-loader/library/Zend/Loader.php
+++ b/packages/zend-loader/library/Zend/Loader.php
@@ -131,9 +131,13 @@ class Zend_Loader
          * Try finding for the plain filename in the include_path.
          */
         if ($once) {
-            include_once $filename;
+            if (stream_resolve_include_path($filename)) {
+                @include_once $filename;
+            }
         } else {
-            include $filename;
+            if (stream_resolve_include_path($filename)) {
+                @include $filename;
+            }
         }
 
         /**


### PR DESCRIPTION
Since PHP 8.0 @ doesn't mute the errors, which makes for a lot of clutter on the error log when you are using class_exists() and it doesn't.
Adding this verification solves the problem.

Carry https://github.com/Shardj/zf1-future/pull/168

cc @Dringho