### PR TITLE
[zend-session] Fix error handler for PHP8 usage

### DIFF
--- a/packages/zend-session/library/Zend/Session/Exception.php
+++ b/packages/zend-session/library/Zend/Session/Exception.php
@@ -53,7 +53,7 @@ class Zend_Session_Exception extends Zend_Exception
      * @param  string $errstr
      * @return void
      */
-    static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext)
+    static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         self::$sessionStartError = $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
     }
@@ -66,7 +66,7 @@ class Zend_Session_Exception extends Zend_Exception
      * @param  string $errstr
      * @return void
      */
-    static public function handleSilentWriteClose($errno, $errstr, $errfile, $errline, $errcontext)
+    static public function handleSilentWriteClose($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         self::$sessionStartError .= PHP_EOL . $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
     }


### PR DESCRIPTION
```
E_ERROR: Uncaught ArgumentCountError: Too few arguments to function Zend_Session_Exception::handleSessionStartError(), 4 passed and exactly 5 expected in /home/tlauria/www/translate5-master/vendor/shardj/zf1-future/library/Zend/Session/Exception.php:56
```

Carry https://github.com/Shardj/zf1-future/pull/153

cc @thomaslauria