### PR TITLE
[zend-validate] Ensure value is a string prior to validation

### DIFF
--- a/packages/zend-validate/library/Zend/Validate/Int.php
+++ b/packages/zend-validate/library/Zend/Validate/Int.php
@@ -134,7 +134,7 @@ class Zend_Validate_Int extends Zend_Validate_Abstract
 
         } else {
             try {
-                if (!Zend_Locale_Format::isInteger($value, array('locale' => $this->_locale))) {
+                if (!Zend_Locale_Format::isInteger(strval($value), array('locale' => $this->_locale))) {
                     $this->_error(self::NOT_INT);
                     return false;
                 }


### PR DESCRIPTION
Method expects a string value. If a float is
passed in PHP 7.4 will issue a notice for
trying to access array offset.

Carry https://github.com/Shardj/zf1-future/pull/151

cc @davejennings