### PR TITLE
Fix Zend_Db issues with php8

### DIFF
--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -252,6 +252,9 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
         }
         try {
             return $this->_stmt->fetch($style, $cursor, $offset);
+        } catch (ValueError $e) {
+            // PHP 8.0+ throws ValueError on invalid arguments
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
@@ -290,6 +293,9 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             } else {
                 return $this->_stmt->fetchAll($style);
             }
+        } catch (ValueError $e) {
+            // PHP 8.0+ throws ValueError on invalid arguments
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
@@ -431,6 +437,9 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
         $this->_fetchMode = $mode;
         try {
             return $this->_stmt->setFetchMode($mode);
+        } catch (ValueError $e) {
+            // PHP 8.0+ throws ValueError on invalid arguments
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -342,7 +342,7 @@ class Zend_Db_Adapter_StaticTest extends PHPUnit_Framework_TestCase
                 );
         } catch (Exception $e) {
             set_include_path($oldIncludePath);
-            $this->assertContains('failed to open stream', $e->getMessage());
+            $this->assertContains('failed to open stream', $e->getMessage(), '', true);
             return;
         }
 

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -59,16 +59,11 @@ class Zend_Db_Adapter_StaticTest extends PHPUnit_Framework_TestCase
 
     public function testDbConstructorExceptionInvalidOptions()
     {
-        list($major, $minor, $revision) = explode('.', PHP_VERSION);
-        if ($minor >= 2) {
-            try {
-                $db = new Zend_Db_Adapter_Static('scalar');
-                $this->fail('Expected exception not thrown');
-            } catch (Exception $e) {
-                $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
-            }
-        } else {
-            $this->markTestIncomplete('Failure to meet type hint results in fatal error in PHP < 5.2.0');
+        try {
+            $db = new Zend_Db_Adapter_Static('scalar');
+            $this->fail('Expected exception not thrown');
+        } catch (Exception $e) {
+            $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
         }
     }
 
@@ -152,31 +147,21 @@ class Zend_Db_Adapter_StaticTest extends PHPUnit_Framework_TestCase
 
     public function testDbFactoryExceptionInvalidOptions()
     {
-        list($major, $minor, $revision) = explode('.', PHP_VERSION);
-        if ($minor >= 2) {
-            try {
-                $db = Zend_Db::factory('Static', 'scalar');
-                $this->fail('Expected exception not thrown');
-            } catch (Exception $e) {
-                $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
-            }
-        } else {
-            $this->markTestIncomplete('Failure to meet type hint results in fatal error in PHP < 5.2.0');
+        try {
+            $db = Zend_Db::factory('Static', 'scalar');
+            $this->fail('Expected exception not thrown');
+        } catch (Exception $e) {
+            $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
         }
     }
 
     public function testDbFactoryExceptionNoConfig()
     {
-        list($major, $minor, $revision) = explode('.', PHP_VERSION);
-        if ($minor >= 2) {
-            try {
-                $db = Zend_Db::factory('Static');
-                $this->fail('Expected exception not thrown');
-            } catch (Exception $e) {
-                $this->assertContains('Configuration must have a key for \'dbname\' that names the database instance', $e->getMessage());
-            }
-        } else {
-            $this->markTestIncomplete('Failure to meet type hint results in fatal error in PHP < 5.2.0');
+        try {
+            $db = Zend_Db::factory('Static');
+            $this->fail('Expected exception not thrown');
+        } catch (Exception $e) {
+            $this->assertContains('Configuration must have a key for \'dbname\' that names the database instance', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Db/Statement/TestCommon.php
+++ b/tests/Zend/Db/Statement/TestCommon.php
@@ -328,7 +328,12 @@ abstract class Zend_Db_Statement_TestCommon extends Zend_Db_TestSetup
         } catch (Zend_Exception $e) {
             $this->assertTrue($e instanceof Zend_Db_Statement_Exception,
                 'Expecting object of type Zend_Db_Statement_Exception, got '.get_class($e));
-            $this->assertRegExp('#invalid fetch mode#i', $e->getMessage());
+            if (PHP_VERSION_ID >= 80000 && substr($this->getDriver(), 0, 4) === 'Pdo_') {
+                // PDO on PHP 8.0+ throws different error message on invalid arguments
+                $this->assertContains('must be a bitmask of PDO::FETCH_* constants', $e->getMessage());
+            } else {
+                $this->assertRegExp('#invalid fetch mode#i', $e->getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
1) _(replaces #85)_ PHP 8.0+ throws `ValueError` on invalid arguments. Catch `ValueError` on wrong "fetch" value passed to pdo methods, transform it to expected `Zend_Db_Statement_Exception` and test for different error message php. Fixes following fatal errors:
  - `PDOStatement::setFetchMode(): Argument #1 ($mode) must be a bitmask of PDO::FETCH_* constants`
  - `PDOStatement::fetchAll(): Argument #1 ($mode) must be a bitmask of PDO::FETCH_* constants`
  - `PDOStatement::fetch(): Argument #1 ($mode) must be a bitmask of PDO::FETCH_* constants`
  
2) allow case insensitive comparison in a zend db static test
  - Prevents following test failure: `Failed asserting that 'include_once(Test/MyCompany2/Dbadapter.php): Failed to open stream: No such file or directory' contains "failed to open stream".`

3) remove wrong conditions for targeting PHP < 5.2.0 in zend-db tests. Only `minor <= 2` was checked, resulting few tests to be skipped on php 8.0 (and 7.0 & 7.1). Removed the false-path completely as php <5.3 is not supported

refs:
- https://github.com/zf1s/zf1/issues/51
