### PR TITLE
[zend-queue] prevent TypeError on md5 of non-string message

### DIFF
--- a/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
@@ -302,6 +302,8 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
             $queue = $this->_queue;
         }
 
+        $message = (string)$message;
+
         $frame = $this->_client->createFrame();
         $frame->setCommand('SEND');
         $frame->setHeader('destination', $queue->getName());
@@ -312,7 +314,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
             $frame->setHeader('persistent', $this->_options['driverOptions']['persistent']);
         }
 
-        $frame->setBody((string) $message);
+        $frame->setBody($message);
         $this->_client->send($frame);
 
         $data = array(

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
@@ -176,6 +176,10 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
             throw new Zend_Queue_Exception('Queue does not exist:' . $queue->getName());
         }
 
+        if (!is_string($message)) {
+            throw new Zend_Queue_Exception('$message must be a string');
+        }
+
         // create the message
         $data = array(
             'message_id' => md5(uniqid(rand(), true)),

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
@@ -342,7 +342,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
         $msg->queue_id = $this->getQueueId($queue->getName());
         $msg->created  = time();
         $msg->body     = $message;
-        $msg->md5      = md5($message);
+        $msg->md5      = md5((string)$message);
         // $msg->timeout = ??? @TODO
 
         try {


### PR DESCRIPTION
Previous php versions emits a warning error when md5 is passed a non-string argument.
PHP 8.0 throws a `TypeError` and test failed with `PHP Fatal error:  Uncaught TypeError: md5(): Argument #1 ($string) must be of type string, array given` (actually crashed the whole test run on php8 without any error message, had to run `vendor/bin/phpunit tests/Zend/Queue/AllTests.php` to isolate it.

Other adapters where md5 on a non-string value is attempted will also crash. (`Zend_Queue_Adapter_Activemq` and `Zend_Queue_Adapter_Db`) There is no easy way to fix this, keeping BC at the same time. Using a md5 hash there is wrong anyway - other adapters accept non-string values for a message, so even if the values are casted to string before md5 there be md5 clashes often (same hash in result) for objects or arrays "casted" fo string due to how php works internally (they should be probably serialized before calculating md5 hash, or using different hashing mechanism)

I decided to only add the throw on non-string value in Array adapter, what a test expects, and add string castints in Activemq and Db adapters so that md5 does not crash there. (and `strlen` in Activemq adapter)