### PR TITLE
 [zend-loader] refactor broken resolvePharParentPath static method 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,7 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
-        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
-        include:
-          - php: "8.0"
-            experimental: true
+          - "8.0"
 
     env:
       MYSQL_USER: "zftest"


### PR DESCRIPTION
Refactor broken resolvePharParentPath static method _(which never worked properly anyway because of that `if ($value !== '...') return` condition)_ into an inline foreach loop which discards '..' values from path parts array, in a way that also previous part is discarded when '..' is found.

This also fixes `Zend_Loader_ClassMapAutoloader::resolvePharParentPath(): Argument #3 ($parts) must be passed by reference, value given` error on php8.

\+ disallow test failures on php 8.0 as this was the last failing case.