### PR TITLE
[zend-exception] allow Throwable in $previous

### DIFF
--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -254,7 +254,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             return $this->_stmt->fetch($style, $cursor, $offset);
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
-            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
@@ -295,7 +295,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             }
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
-            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
@@ -439,7 +439,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             return $this->_stmt->setFetchMode($mode);
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
-            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode());
+            throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);

--- a/packages/zend-exception/library/Zend/Exception.php
+++ b/packages/zend-exception/library/Zend/Exception.php
@@ -32,10 +32,10 @@ class Zend_Exception extends Exception
      *
      * @param  string $msg
      * @param  int $code
-     * @param  Exception $previous
+     * @param  Exception|Throwable $previous
      * @return void
      */
-    public function __construct($msg = '', $code = 0, Exception $previous = null)
+    public function __construct($msg = '', $code = 0, $previous = null)
     {
         parent::__construct($msg, (int) $code, $previous);
     }


### PR DESCRIPTION
Relax the type declaration to allow passing any type (as typing `Throwable` would not work in php 5.x) and just let the base `Exception` class check and throw on invalid type.

Note: The constructor overload must stay because zf1 relies on code being casted to int there in many places (e.g. exceptions coming from PDO, which may have `long` or `string` codes...)
