### PR TITLE
[zend-application] fix autoloading of Useragent class

### DIFF
--- a/packages/zend-application/library/Zend/Application/Resource/Useragent.php
+++ b/packages/zend-application/library/Zend/Application/Resource/Useragent.php
@@ -26,7 +26,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Application_Resource_UserAgent extends Zend_Application_Resource_ResourceAbstract
+class Zend_Application_Resource_Useragent extends Zend_Application_Resource_ResourceAbstract
 {
     /**
      * @var Zend_Http_UserAgent


### PR DESCRIPTION
Class Zend_Application_Resource_UserAgent located in ./vendor/zf1s/zend-application/library/Zend/Application/Resource/Useragent.php does not comply with psr-0 autoloading standard.

Going with adjusting the class name to avoid issues with renaming files on case-insensitive systems (windows) and because php is case-insensitive when it comes to class names.

Similar to #24
Fixes #89