### PR TITLE
zend-loader and autoloader overhaul - cont.

### DIFF
--- a/packages/zend-currency/library/Zend/Currency.php
+++ b/packages/zend-currency/library/Zend/Currency.php
@@ -800,10 +800,7 @@ class Zend_Currency
         if (is_string($service)) {
             // require_once 'Zend/Loader.php';
             if (!class_exists($service)) {
-                $file = str_replace('_', DIRECTORY_SEPARATOR, $service) . '.php';
-                if (Zend_Loader::isReadable($file)) {
-                    Zend_Loader::loadClass($service);
-                }
+                Zend_Loader::loadClass($service);
             }
 
             $service = new $service;

--- a/packages/zend-file-transfer/library/Zend/File/Transfer.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer.php
@@ -67,7 +67,9 @@ class Zend_File_Transfer
         if (class_exists('Zend_File_Transfer_Adapter_' . ucfirst($adapter))) {
             $adapter = 'Zend_File_Transfer_Adapter_' . ucfirst($adapter);
         } elseif (!class_exists($adapter)) {
-            Zend_Loader::loadClass($adapter);
+            if (!Zend_Loader::tryLoadClass('Zend_File_Transfer_Adapter_' . ucfirst($adapter), null, true)) {
+                Zend_Loader::loadClass($adapter);
+            }
         }
 
         $direction = (integer) $direction;

--- a/packages/zend-filter/library/Zend/Filter/Compress.php
+++ b/packages/zend-filter/library/Zend/Filter/Compress.php
@@ -100,10 +100,9 @@ class Zend_Filter_Compress implements Zend_Filter_Interface
             $adapter = 'Zend_Filter_Compress_' . ucfirst($adapter);
         } elseif (!class_exists($adapter)) {
             // require_once 'Zend/Loader.php';
-            if (Zend_Loader::isReadable('Zend/Filter/Compress/' . ucfirst($adapter) . '.php')) {
-                $adapter = 'Zend_Filter_Compress_' . ucfirst($adapter);
+            if (!Zend_Loader::tryLoadClass('Zend_Filter_Compress_' . ucfirst($adapter))) {
+                Zend_Loader::loadClass($adapter);
             }
-            Zend_Loader::loadClass($adapter);
         }
 
         $this->_adapter = new $adapter($options);

--- a/packages/zend-filter/library/Zend/Filter/Encrypt.php
+++ b/packages/zend-filter/library/Zend/Filter/Encrypt.php
@@ -92,7 +92,9 @@ class Zend_Filter_Encrypt implements Zend_Filter_Interface
         if (class_exists('Zend_Filter_Encrypt_' . ucfirst($adapter))) {
             $adapter = 'Zend_Filter_Encrypt_' . ucfirst($adapter);
         } elseif (!class_exists($adapter)) {
-            Zend_Loader::loadClass($adapter);
+            if (!Zend_Loader::tryLoadClass('Zend_Filter_Encrypt_' . ucfirst($adapter))) {
+                Zend_Loader::loadClass($adapter);
+            }
         }
 
         $this->_adapter = new $adapter($options);

--- a/packages/zend-gdata/library/Zend/Gdata/App.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App.php
@@ -828,7 +828,7 @@ class Zend_Gdata_App
 
         if (!$doc) {
             $err = error_get_last();
-            $phpErrormsg = $err['message'];
+            $phpErrormsg = isset($err['message'][0]) ? $err['message'] : null;
             // require_once 'Zend/Gdata/App/Exception.php';
             throw new Zend_Gdata_App_Exception(
                 "DOMDocument cannot parse XML: $phpErrormsg");

--- a/packages/zend-gdata/library/Zend/Gdata/App.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App.php
@@ -1053,12 +1053,7 @@ class Zend_Gdata_App
             $foundClassName = null;
             foreach ($this->_registeredPackages as $name) {
                  try {
-                     // Autoloading disabled on next line for compatibility
-                     // with magic factories. See ZF-6660.
-                     Zend_Loader_Autoloader::setDisabled();
-                     $found = class_exists($name . '_' . $class);
-                     Zend_Loader_Autoloader::setDisabled(false);
-                     if (!$found) {
+                     if (!class_exists($name . '_' . $class)) {
                         // require_once 'Zend/Loader.php';
                         @Zend_Loader::loadClass($name . '_' . $class);
                      }

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps.php
@@ -859,12 +859,7 @@ class Zend_Gdata_Gapps extends Zend_Gdata
             $foundClassName = null;
             foreach ($this->_registeredPackages as $name) {
                  try {
-                     // Autoloading disabled on next line for compatibility
-                     // with magic factories. See ZF-6660.
-                     Zend_Loader_Autoloader::setDisabled();
-                     $found = class_exists($name . '_' . $class);
-                     Zend_Loader_Autoloader::setDisabled(false);
-                     if (!$found) {
+                     if (!class_exists($name . '_' . $class)) {
                         // require_once 'Zend/Loader.php';
                         @Zend_Loader::loadClass($name . '_' . $class);
                      }

--- a/packages/zend-loader/library/Zend/Loader.php
+++ b/packages/zend-loader/library/Zend/Loader.php
@@ -208,19 +208,7 @@ class Zend_Loader
             return false;
         }
 
-        foreach (self::explodeIncludePath() as $path) {
-            if ($path == '.') {
-                if (is_readable($filename)) {
-                    return true;
-                }
-                continue;
-            }
-            $file = $path . '/' . $filename;
-            if (is_readable($file)) {
-                return true;
-            }
-        }
-        return false;
+        return stream_resolve_include_path($filename) !== false;
     }
 
     /**

--- a/packages/zend-loader/library/Zend/Loader/Autoloader.php
+++ b/packages/zend-loader/library/Zend/Loader/Autoloader.php
@@ -106,6 +106,9 @@ class Zend_Loader_Autoloader
      */
     public static function resetInstance()
     {
+        if (null !== self::$_instance) {
+            spl_autoload_unregister(array(__CLASS__, 'autoload'));
+        }
         self::$_instance = null;
     }
 

--- a/packages/zend-loader/library/Zend/Loader/Exception/ClassNotFoundException.php
+++ b/packages/zend-loader/library/Zend/Loader/Exception/ClassNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+// require_once dirname(__FILE__) . '/../Exception.php';
+
+/**
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Loader_Exception_ClassNotFoundException extends Zend_Loader_Exception
+{
+
+}

--- a/packages/zend-loader/library/Zend/Loader/Exception/FileNotFoundException.php
+++ b/packages/zend-loader/library/Zend/Loader/Exception/FileNotFoundException.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+// require_once dirname(__FILE__) . '/../Exception.php';
+
+/**
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage Exception
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Loader_Exception_FileNotFoundException extends Zend_Loader_Exception
+{
+
+}

--- a/packages/zend-translate/library/Zend/Translate.php
+++ b/packages/zend-translate/library/Zend/Translate.php
@@ -130,7 +130,9 @@ class Zend_Translate {
         if (class_exists('Zend_Translate_Adapter_' . ucfirst($options['adapter']))) {
             $options['adapter'] = 'Zend_Translate_Adapter_' . ucfirst($options['adapter']);
         } elseif (!class_exists($options['adapter'])) {
-            Zend_Loader::loadClass($options['adapter']);
+            if (!Zend_Loader::tryLoadClass('Zend_Translate_Adapter_' . ucfirst($options['adapter']))) {
+                Zend_Loader::loadClass($options['adapter']);
+            }
         }
 
         if (array_key_exists('cache', $options)) {

--- a/packages/zend-validate/library/Zend/Validate/Barcode.php
+++ b/packages/zend-validate/library/Zend/Validate/Barcode.php
@@ -134,7 +134,9 @@ class Zend_Validate_Barcode extends Zend_Validate_Abstract
         if (class_exists('Zend_Validate_Barcode_' . $adapter)) {
             $adapter = 'Zend_Validate_Barcode_' . $adapter;
         } elseif (!class_exists($adapter)) {
-            Zend_Loader::loadClass($adapter);
+            if (!Zend_Loader::tryLoadClass('Zend_Validate_Barcode_' . $adapter)) {
+                Zend_Loader::loadClass($adapter);
+            }
         }
 
         $this->_adapter = new $adapter($options);

--- a/tests/Zend/Barcode/FactoryTest.php
+++ b/tests/Zend/Barcode/FactoryTest.php
@@ -239,7 +239,7 @@ class Zend_Barcode_FactoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Loader_Exception_FileNotFoundException
      */
     public function testBarcodeObjectFactoryWithUnexistantBarcode()
     {
@@ -338,7 +338,7 @@ class Zend_Barcode_FactoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Loader_Exception_FileNotFoundException
      */
     public function testBarcodeRendererFactoryWithUnexistantRenderer()
     {

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -327,7 +327,7 @@ class Zend_Db_Adapter_StaticTest extends PHPUnit_Framework_TestCase
                 );
         } catch (Exception $e) {
             set_include_path($oldIncludePath);
-            $this->assertContains('failed to open stream', $e->getMessage(), '', true);
+            $this->assertContains('could not be found', $e->getMessage());
             return;
         }
 

--- a/tests/Zend/Db/Table/Relationships/TestCommon.php
+++ b/tests/Zend/Db/Table/Relationships/TestCommon.php
@@ -158,7 +158,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Db_Table_Row_Exception
+     * @expectedExceptionMessage could not be found
      */
     public function testTableRelationshipFindParentRowErrorOnBadString()
     {
@@ -265,7 +266,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Db_Table_Row_Exception
+     * @expectedExceptionMessage could not be found
      */
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsString()
     {
@@ -280,7 +282,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Db_Table_Row_Exception
+     * @expectedExceptionMessage could not be found
      */
     public function testTableRelationshipFindManyToManyRowsetErrorOnBadClassNameAsStringForIntersection()
     {
@@ -425,7 +428,8 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException Zend_Db_Table_Row_Exception
+     * @expectedExceptionMessage could not be found
      */
     public function testTableRelationshipFindDependentRowsetPhpError()
     {

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -331,12 +331,18 @@ class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_Foo'));
     }
 
+    public function testAutoloadShouldReturnFalseWhenClassIsNotDefinedInClassfile()
+    {
+        $this->addTestIncludePath();
+        $this->autoloader->registerNamespace('ZendLoaderAutoloader');
+        $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_ClassNonexistent'));
+    }
+
     public function testAutoloadShouldLoadClassWhenNamespaceIsRegisteredAndClassfileExists()
     {
         $this->addTestIncludePath();
         $this->autoloader->registerNamespace('ZendLoaderAutoloader');
-        $result = Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_Foo');
-        $this->assertFalse($result === false);
+        $this->assertTrue(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_Foo'));
         $this->assertTrue(class_exists('ZendLoaderAutoloader_Foo', false));
     }
 
@@ -347,6 +353,20 @@ class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
         $this->autoloader->registerNamespace('ZendLoaderAutoloader');
         set_error_handler(array($this, 'handleErrors'));
         $this->assertFalse(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_Bar'));
+        restore_error_handler();
+
+        // Zend_Loader does not issue "file not found warnings" anymore because files are now checked for being readable before include call
+        //$this->assertNotNull($this->error);
+        $this->assertNull($this->error);
+    }
+
+    public function testAutoloadShouldNotSuppressErrorsWhenFlagIsDisabled()
+    {
+        $this->addTestIncludePath();
+        $this->autoloader->suppressNotFoundWarnings(false);
+        $this->autoloader->registerNamespace('ZendLoaderAutoloader');
+        set_error_handler(array($this, 'handleErrors'));
+        $this->assertTrue(Zend_Loader_Autoloader::autoload('ZendLoaderAutoloader_SomethingWrong'));
         restore_error_handler();
         $this->assertNotNull($this->error);
     }

--- a/tests/Zend/Loader/_files/ZendLoaderAutoloader/ClassNonexistent.php
+++ b/tests/Zend/Loader/_files/ZendLoaderAutoloader/ClassNonexistent.php
@@ -1,0 +1,5 @@
+<?php
+
+/**
+ * A file not containing a class
+ */

--- a/tests/Zend/Loader/_files/ZendLoaderAutoloader/SomethingWrong.php
+++ b/tests/Zend/Loader/_files/ZendLoaderAutoloader/SomethingWrong.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * A class containing a parse error
+ */
+class ZendLoaderAutoloader_SomethingWrong
+{
+}
+
+trigger_error('Something is wrong here', E_USER_WARNING);

--- a/tests/Zend/Navigation/PageFactoryTest.php
+++ b/tests/Zend/Navigation/PageFactoryTest.php
@@ -155,8 +155,8 @@ class Zend_Navigation_PageFactoryTest extends PHPUnit_Framework_TestCase
             );
         } catch(Zend_Exception $e) {
             $this->assertEquals(
-                'File "My' . DIRECTORY_SEPARATOR . 'NonExistant' . DIRECTORY_SEPARATOR . 'Page.php" does not exist or class '
-                . '"My_NonExistant_Page" was not found in the file',
+                'File "My' . DIRECTORY_SEPARATOR . 'NonExistant' . DIRECTORY_SEPARATOR . 'Page.php" '
+                . 'could not be found within configured include_path.',
                 $e->getMessage()
             );
         }

--- a/tests/Zend/RegistryTest.php
+++ b/tests/Zend/RegistryTest.php
@@ -187,7 +187,7 @@ class Zend_RegistryTest extends PHPUnit_Framework_TestCase
             $registry = @Zend_Registry::setClassName('classdoesnotexist');
             $this->fail('Expected exception, because we cannot initialize the registry using a non-existent class.');
         } catch (Zend_Exception $e) {
-            $this->assertRegExp('/file .* does not exist or .*/i', $e->getMessage());
+            $this->assertRegExp('/file .* could not be found/i', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Service/StrikeIron/StrikeIronTest.php
+++ b/tests/Zend/Service/StrikeIron/StrikeIronTest.php
@@ -50,8 +50,7 @@ class Zend_Service_StrikeIron_StrikeIronTest extends PHPUnit_Framework_TestCase
             $this->strikeIron->getService(array('class' => 'BadServiceNameHere'));
             $this->fail();
         } catch (Zend_Service_StrikeIron_Exception $e) {
-            $this->assertRegExp('/could not be loaded/i', $e->getMessage());
-            $this->assertRegExp('/not found/i', $e->getMessage());
+            $this->assertRegExp('/could not be found/i', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Translate/Adapter/AllTests.php
+++ b/tests/Zend/Translate/Adapter/AllTests.php
@@ -33,6 +33,7 @@ require_once 'Zend/Translate/Adapter/TbxTest.php';
 require_once 'Zend/Translate/Adapter/TmxTest.php';
 require_once 'Zend/Translate/Adapter/XliffTest.php';
 require_once 'Zend/Translate/Adapter/XmlTmTest.php';
+require_once 'Zend/Translate/Adapter/CustomAdapterTest.php';
 
 /**
  * @category   Zend
@@ -62,6 +63,7 @@ class Zend_Translate_Adapter_AllTests
         $suite->addTestSuite('Zend_Translate_Adapter_TmxTest');
         $suite->addTestSuite('Zend_Translate_Adapter_XliffTest');
         $suite->addTestSuite('Zend_Translate_Adapter_XmlTmTest');
+        $suite->addTestSuite('Zend_Translate_Adapter_CustomAdapterTest');
 
         return $suite;
     }

--- a/tests/Zend/Translate/Adapter/CustomAdapterTest.php
+++ b/tests/Zend/Translate/Adapter/CustomAdapterTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Translate
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+if (!defined('PHPUnit_MAIN_METHOD')) {
+    define('PHPUnit_MAIN_METHOD', 'Zend_Translate_Adapter_CustomAdapterTest::main');
+}
+
+/**
+ * @category   Zend
+ * @package    Zend_Translate
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Translate
+ */
+class Zend_Translate_Adapter_CustomAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Runs the test methods of this class.
+     *
+     * @return void
+     */
+    public static function main()
+    {
+        $suite  = new PHPUnit_Framework_TestSuite("Zend_Translate_Adapter_CustomAdapterTest");
+        $result = PHPUnit_TextUI_TestRunner::run($suite);
+    }
+
+    public function setUp()
+    {
+        // Store original include_path
+        $this->includePath = get_include_path();
+    }
+
+    public function tearDown()
+    {
+        // Restore original include_path
+        set_include_path($this->includePath);
+
+        // Reset autoloader instance so it doesn't affect other tests
+        Zend_Loader_Autoloader::resetInstance();
+    }
+
+    public function testCreate()
+    {
+        $this->addTestIncludePath();
+
+        $translate = new Zend_Translate('My_CustomAdapter', array('test' => 'translated'), 'en');
+        $this->assertTrue(true);
+    }
+
+    public function testCreateWithZendAutoloaderEnabled()
+    {
+        $this->addTestIncludePath();
+
+        // register zend autoloader
+        Zend_Loader_Autoloader::getInstance();
+
+        $translate = new Zend_Translate('My_CustomAdapter', array('test' => 'translated'), 'en');
+        $this->assertTrue(true);
+    }
+
+    public function addTestIncludePath()
+    {
+        set_include_path(__DIR__ . '/_files/' . PATH_SEPARATOR . $this->includePath);
+    }
+
+}
+
+// Call Zend_Translate_Adapter_CustomAdapterTest::main() if this source file is executed directly.
+if (PHPUnit_MAIN_METHOD == "Zend_Translate_Adapter_CustomAdapterTest::main") {
+    Zend_Translate_Adapter_CustomAdapterTest::main();
+}

--- a/tests/Zend/Translate/Adapter/_files/My/CustomAdapter.php
+++ b/tests/Zend/Translate/Adapter/_files/My/CustomAdapter.php
@@ -1,0 +1,13 @@
+<?php
+
+class My_CustomAdapter extends Zend_Translate_Adapter {
+    protected function _loadTranslationData($data, $locale, array $options = array())
+    {
+        return array($locale => $data);
+    }
+
+    public function toString()
+    {
+        return "My_CustomAdapter";
+    }
+}

--- a/tests/Zend/Validate/BarcodeTest.php
+++ b/tests/Zend/Validate/BarcodeTest.php
@@ -53,7 +53,7 @@ class Zend_Validate_BarcodeTest extends PHPUnit_Framework_TestCase
             $barcode = new Zend_Validate_Barcode('Zend_Validate_BarcodeTest_NonExistentClassName');
             $this->fail("'Zend_Validate_BarcodeTest_NonExistentClassName' is not a valid barcode type'");
         } catch (Exception $e) {
-            $this->assertRegExp('#not found|No such file#', $e->getMessage());
+            $this->assertRegExp('#could not be found#', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
continued (apparently unfinished) https://github.com/zf1s/zf1/pull/1 / https://github.com/zf1s/zf1/commit/76477fbe00a198ef4376ea38c46df3960c574af8

- introduce `Zend_Loader::tryLoadClass()` to attempt loading a class but do not throw an exception when file is not found (but still throw when required class in the existing file is not defined)
- did not go for suppressing loading classes with `@` suppressor by default, since regular warnings/errors coming from a loaded file should be visible, otherwise it might be very confusing for devs
- introduce `Zend_Loader_Exception_FileNotFoundException` and `Zend_Loader_Exception_ClassNotFoundException`
  - instead of throwing `Zend_Exception` in `Zend_Loader::loadClass()` with a generic message `File \"$file\" does not exist or class \"$class\" was not found in the file`
  - `Zend_Loader_Exception_FileNotFoundException` will be thrown with message `File "$file" could not be found within configured include_path.` or
  - `Zend_Loader_Exception_ClassNotFoundException` with message `Class "$class" was not found in the file "$file".`, in their respective cases.
- since composer autoloader takes precedence and `Zend_Autoloader` / `Zend_Loader` is only an extra helper, when necessary (when still needed and configured on legacy projects) - `Zend_Loader` should not emit warnings when checking for files, by default. Added `isReadable` check inside `loadFile` before `include`/`include_once`. There might be a performance hit, but it should be okay when most of the autoloading is handled by composer autoloader anyway.
- use `stream_resolve_include_path()` in `isReadable()` - it should be more performant and the function is available since php 5.3.2
- `Zend_Loader::loadClass()` returns boolean now
- adjust combinations of `class_exists` + `Zend_Loader::loadClass()` in remaining affected places (i.a. Translate or File_Transfer or Filter adapters)
- unregister autoloader from spl_autoload when `Zend_Loader_Autoloader::resetInstance()` is called
- added more tests for `Zend_Loader` and `Zend_Autoloader`
- added tests for loading custom `Zend_Translate` adapter while having `Zend_Autoloader` enabled
- adjusted existing tests which expected "file not found" php warning to be triggered by `Zend_Loader`

should fix #46, replaces #96 and #20
Also possibly introduces a breaking change in how `Zend_Loader` works, so will probably release as v1.15