### PR TITLE
Fixed invalid doc-block for \Zend_XmlRpc_Fault::setMessage()

### DIFF
--- a/packages/zend-xmlrpc/library/Zend/XmlRpc/Fault.php
+++ b/packages/zend-xmlrpc/library/Zend/XmlRpc/Fault.php
@@ -140,7 +140,7 @@ class Zend_XmlRpc_Fault
     /**
      * Retrieve fault message
      *
-     * @param string
+     * @param string $message
      * @return Zend_XmlRpc_Fault
      */
     public function setMessage($message)


### PR DESCRIPTION
Psalm static analysis would complain about \Zend_XmlRpc_Fault::setMessage() having an invalid doc-block.