### PR TITLE
[zend-validate] allow underscores in subdomain parts in Hostname validator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,10 @@
 name: "Tests"
 
 on:
-  - pull_request
-  - push
+  pull_request: ~
+  push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/packages/zend-validate/library/Zend/Validate/Hostname.php
+++ b/packages/zend-validate/library/Zend/Validate/Hostname.php
@@ -2269,7 +2269,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                         // Check each domain part
                         $checked = false;
                         $isSubDomain = $domainPart != $lastDomainPart;
-                        $partRegexChars = $isSubDomain ? ['/^[a-z0-9_\x2d]{1,63}$/i'] + $regexChars : $regexChars;
+                        $partRegexChars = $isSubDomain ? array('/^[a-z0-9_\x2d]{1,63}$/i') + $regexChars : $regexChars;
                         foreach ($partRegexChars as $regexKey => $regexChar) {
                             $status = preg_match($regexChar, $domainPart);
                             if ($status > 0) {

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -127,6 +127,55 @@ class Zend_Validate_HostnameTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensure the underscore character tests work as expected
+     *
+     */
+    public function testUnderscores()
+    {
+        $valuesExpected = array(
+            array(Zend_Validate_Hostname::ALLOW_DNS, true, array(
+                '_subdomain.domain.com', 'subdomain_.domain.com', 'sub_domain.domain.com', 'sub__domain.domain.com'
+            )),
+            array(Zend_Validate_Hostname::ALLOW_DNS, false, array('_domain.com', 'domain_.com', 'do_main.com'))
+        );
+        foreach ($valuesExpected as $element) {
+            $validator = new Zend_Validate_Hostname($element[0]);
+            $validator->setValidateTld(false);
+            foreach ($element[2] as $input) {
+                $this->assertEquals(
+                    $element[1],
+                    $validator->isValid($input),
+                    implode("\n", $validator->getMessages()) . $input
+                );
+            }
+        }
+    }
+
+    /**
+     * Ensure the underscore character tests work as expected when not using tld check
+     *
+     */
+    public function testValidatorHandlesUnderscoresInDomainsWithoutTldCheckCorrectly()
+    {
+        $valuesExpected = array(
+            array(Zend_Validate_Hostname::ALLOW_DNS, true, array(
+                '_subdomain.domain.com', 'subdomain_.domain.com', 'sub_domain.domain.com', 'sub__domain.domain.com'
+            )),
+            array(Zend_Validate_Hostname::ALLOW_DNS, false, array('_domain.com', 'domain_.com', 'do_main.com'))
+        );
+        foreach ($valuesExpected as $element) {
+            $validator = new Zend_Validate_Hostname($element[0]);
+            foreach ($element[2] as $input) {
+                $this->assertEquals(
+                    $element[1],
+                    $validator->isValid($input),
+                    implode("\n", $validator->getMessages()) . $input
+                );
+            }
+        }
+    }
+
+    /**
      * Ensures that getMessages() returns expected default value
      *
      * @return void


### PR DESCRIPTION
ported from Laminas\Validator\Hostname
https://github.com/laminas/laminas-validator/commit/f4c26cf6552ef9b64f3843797e999555f1d35581
https://github.com/laminas/laminas-validator/commit/93c606a51c0f23b95342a2687b4356b7c70f242c

Carry https://github.com/Shardj/zf1-future/pull/149 over with additional tests
cc @onlime