### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,48 @@
 ## Changelog:
 
-### 1.14.1 - 2022-xx-xx
+### 1.15.0 - 2022-10-04
+- zend-loader
+  - overhaul of zend-loader and autoloader done again ([#116])
+  - continues work done initially in [#1] / [76477fb]
+  - potential breaking changes:
+    > Introduced `Zend_Loader_Exception_FileNotFoundException` and `Zend_Loader_Exception_ClassNotFoundException`
+    > 
+    > Instead of throwing `Zend_Exception` in `Zend_Loader::loadClass()` with a generic message `File \"$file\" does not exist or class \"$class\" was not found in the file`
+    > - `Zend_Loader_Exception_FileNotFoundException` will be thrown with message `File "$file" could not be found within configured include_path`. or
+    > - `Zend_Loader_Exception_ClassNotFoundException` with message `Class "$class" was not found in the file "$file".`, in their respective cases.
+    
+    > Not suppressing loading classes with `@` suppressor by default anymore.
+    > 
+    > Regular warnings/errors coming from a loaded file should be visible, otherwise it might be very confusing for devs
+    >
+    > At the same time though, `Zend_Loader` will not emit warnings when checking for files if they exist, by default. Added `isReadable` check inside `loadFile` before `include`/`include_once`.
+    > 
+    > There might be a performance hit, but it should be okay when most of the autoloading is handled by composer autoloader.
+    > 
+    > This change should finally allow seamless integration of `Zend_Loader` with composer autoloader, without any warnings.
+  - fixed issues with loading custom Translate/File_Transfer/Filter adapters
+  - for more details see [#116]
 - zend-session
-  - added "session.cookie_samesite" option
+  - added "session.cookie_samesite" option ([#126])
+- zend-validate
+  - hostname: update TLDs (Version 2022100300) ([#104])
+  - hostname: allow underscores in subdomain parts ([#131])
+- general: docblock annotations
+  - fixed parameter annotation for `Zend_XmlRpc_Fault::setMessage()` ([#117])
+  - fixed parameter annotation for `Zend_Db_Table_Select::setIntegrityCheck()` ([#119])
+  - fixed wrong return-type in `Zend_Form_Element::removeValidator()` ([#121])
+  - fixed annotations for `Zend_Controller_Router_Route_Regex::__construct()` ([#123])
+  
+[#1]: https://github.com/zf1s/zf1/pull/1
+[#104]: https://github.com/zf1s/zf1/pull/104
+[#116]: https://github.com/zf1s/zf1/pull/116
+[#117]: https://github.com/zf1s/zf1/pull/117
+[#119]: https://github.com/zf1s/zf1/pull/119
+[#121]: https://github.com/zf1s/zf1/pull/121
+[#123]: https://github.com/zf1s/zf1/pull/123
+[#126]: https://github.com/zf1s/zf1/pull/126
+[#131]: https://github.com/zf1s/zf1/pull/131
+[76477fb]: https://github.com/zf1s/zf1/commit/76477fbe00a198ef4376ea38c46df3960c574af8
 
 ### 1.14.0 - 2021-10-01
 - general: php 8.0 compatibility ([#51])

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Original README: [click](README.orig.md)
 2. Bump interdependencies of packages to the next version
 
     ```bash
-    ../monorepo-builder/bin/monorepo-builder bump-interdependency "^1.14.1"
+    ../monorepo-builder/bin/monorepo-builder bump-interdependency "^1.15.1"
     ```
    
 3. Add git tag and push to this monorepo
@@ -133,7 +133,7 @@ Original README: [click](README.orig.md)
    
     Split operation:
     ```bash
-    ../monorepo-builder/bin/monorepo-builder split --max-processes=1 --tag=1.14.1
+    ../monorepo-builder/bin/monorepo-builder split --max-processes=1 --tag=1.15.1
     ```
 
 _Note: I had no success splitting this repo on win os, so unix-based system is recommended. (or WSL)

--- a/packages/zend-acl/composer.json
+++ b/packages/zend-acl/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-amf/composer.json
+++ b/packages/zend-amf/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-server": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-server": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-application/composer.json
+++ b/packages/zend-application/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-controller": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-controller": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-auth/composer.json
+++ b/packages/zend-auth/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-barcode/composer.json
+++ b/packages/zend-barcode/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-cache/composer.json
+++ b/packages/zend-cache/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-captcha/composer.json
+++ b/packages/zend-captcha/composer.json
@@ -7,11 +7,11 @@
     "require": {
         "php": ">=5.3.3",
         "ext-gd": "*",
-        "zf1s/zend-crypt": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-service-recaptcha": "^1.14.0",
-        "zf1s/zend-text": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-crypt": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-service-recaptcha": "^1.15.0",
+        "zf1s/zend-text": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-cloud/composer.json
+++ b/packages/zend-cloud/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-queue": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-queue": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-codegenerator/composer.json
+++ b/packages/zend-codegenerator/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-reflection": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-reflection": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-config/composer.json
+++ b/packages/zend-config/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-console-getopt/composer.json
+++ b/packages/zend-console-getopt/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -8,13 +8,13 @@
         "php": ">=5.3.3",
         "ext-reflection": "*",
         "ext-session": "*",
-        "zf1s/zend-config": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-view": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-config": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-view": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-crypt/composer.json
+++ b/packages/zend-crypt/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-currency/composer.json
+++ b/packages/zend-currency/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-date/composer.json
+++ b/packages/zend-date/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-db/composer.json
+++ b/packages/zend-db/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-dojo/composer.json
+++ b/packages/zend-dojo/composer.json
@@ -6,11 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-form": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0",
-        "zf1s/zend-view": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-form": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0",
+        "zf1s/zend-view": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-dom/composer.json
+++ b/packages/zend-dom/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-eventmanager/composer.json
+++ b/packages/zend-eventmanager/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-stdlib": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-stdlib": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-feed/composer.json
+++ b/packages/zend-feed/composer.json
@@ -9,12 +9,12 @@
         "ext-dom": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-version": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-version": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-file-transfer/composer.json
+++ b/packages/zend-file-transfer/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-filter/composer.json
+++ b/packages/zend-filter/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-crypt": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-crypt": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-form/composer.json
+++ b/packages/zend-form/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-filter": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-filter": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-gdata/composer.json
+++ b/packages/zend-gdata/composer.json
@@ -8,11 +8,11 @@
         "php": ">=5.3.3",
         "ext-ctype": "*",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-mime": "^1.14.0",
-        "zf1s/zend-version": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-mime": "^1.15.0",
+        "zf1s/zend-version": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-http/composer.json
+++ b/packages/zend-http/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-json/composer.json
+++ b/packages/zend-json/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-server": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-server": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-layout/composer.json
+++ b/packages/zend-layout/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-ldap/composer.json
+++ b/packages/zend-ldap/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ldap": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-loader/composer.json
+++ b/packages/zend-loader/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-locale/composer.json
+++ b/packages/zend-locale/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0",
-        "zf1s/zend-cache": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0",
+        "zf1s/zend-cache": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-log/composer.json
+++ b/packages/zend-log/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mail/composer.json
+++ b/packages/zend-mail/composer.json
@@ -6,11 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-mime": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-mime": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-markup/composer.json
+++ b/packages/zend-markup/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-filter": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-filter": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-measure/composer.json
+++ b/packages/zend-measure/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-memory/composer.json
+++ b/packages/zend-memory/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-cache": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-cache": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mime/composer.json
+++ b/packages/zend-mime/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mobile/composer.json
+++ b/packages/zend-mobile/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-navigation/composer.json
+++ b/packages/zend-navigation/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-controller": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-controller": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-oauth/composer.json
+++ b/packages/zend-oauth/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-crypt": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-crypt": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-openid/composer.json
+++ b/packages/zend-openid/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-session": "^1.14.0"
+        "zf1s/zend-controller": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-session": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-paginator/composer.json
+++ b/packages/zend-paginator/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-pdf/composer.json
+++ b/packages/zend-pdf/composer.json
@@ -10,9 +10,9 @@
         "ext-gd": "*",
         "ext-iconv": "*",
         "ext-zlib": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-log": "^1.14.0",
-        "zf1s/zend-memory": "^1.14.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-log": "^1.15.0",
+        "zf1s/zend-memory": "^1.15.0",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-progressbar/composer.json
+++ b/packages/zend-progressbar/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-config": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0"
+        "zf1s/zend-config": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-queue/composer.json
+++ b/packages/zend-queue/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-reflection/composer.json
+++ b/packages/zend-reflection/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-registry/composer.json
+++ b/packages/zend-registry/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-rest/composer.json
+++ b/packages/zend-rest/composer.json
@@ -10,11 +10,11 @@
         "ext-dom": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-server": "^1.14.0",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-server": "^1.15.0",
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-search-lucene/composer.json
+++ b/packages/zend-search-lucene/composer.json
@@ -9,9 +9,9 @@
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-search": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-search": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-search/composer.json
+++ b/packages/zend-search/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-serializer/composer.json
+++ b/packages/zend-serializer/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-server/composer.json
+++ b/packages/zend-server/composer.json
@@ -8,7 +8,7 @@
         "php": ">=5.3.3",
         "ext-spl": "*",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-akismet/composer.json
+++ b/packages/zend-service-akismet/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-version": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-version": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-amazon/composer.json
+++ b/packages/zend-service-amazon/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-rest": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-rest": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-audioscrobbler/composer.json
+++ b/packages/zend-service-audioscrobbler/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-iconv": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-delicious/composer.json
+++ b/packages/zend-service-delicious/composer.json
@@ -7,12 +7,12 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-date": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0",
-        "zf1s/zend-rest": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-date": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0",
+        "zf1s/zend-rest": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-ebay/composer.json
+++ b/packages/zend-service-ebay/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-rest": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-rest": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-flickr/composer.json
+++ b/packages/zend-service-flickr/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-livedocx/composer.json
+++ b/packages/zend-service-livedocx/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-date": "^1.14.0",
-        "zf1s/zend-soap": "^1.14.0"
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-date": "^1.15.0",
+        "zf1s/zend-soap": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-rackspace/composer.json
+++ b/packages/zend-service-rackspace/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-recaptcha/composer.json
+++ b/packages/zend-service-recaptcha/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-shorturl/composer.json
+++ b/packages/zend-service-shorturl/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0"
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-slideshare/composer.json
+++ b/packages/zend-service-slideshare/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-cache": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-cache": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-strikeiron/composer.json
+++ b/packages/zend-service-strikeiron/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-twitter/composer.json
+++ b/packages/zend-service-twitter/composer.json
@@ -6,12 +6,12 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-feed": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0",
-        "zf1s/zend-rest": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-feed": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0",
+        "zf1s/zend-rest": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-windowsazure/composer.json
+++ b/packages/zend-service-windowsazure/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-service": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-yahoo/composer.json
+++ b/packages/zend-service-yahoo/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-rest": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-rest": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service/composer.json
+++ b/packages/zend-service/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-session/composer.json
+++ b/packages/zend-session/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-session": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-soap/composer.json
+++ b/packages/zend-soap/composer.json
@@ -8,10 +8,10 @@
         "php": ">=5.3.3",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-server": "^1.14.0",
-        "zf1s/zend-uri": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-server": "^1.15.0",
+        "zf1s/zend-uri": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-tag/composer.json
+++ b/packages/zend-tag/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-test/composer.json
+++ b/packages/zend-test/composer.json
@@ -6,12 +6,12 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.14.0",
-        "zf1s/zend-dom": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-layout": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0",
-        "zf1s/zend-session": "^1.14.0"
+        "zf1s/zend-controller": "^1.15.0",
+        "zf1s/zend-dom": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-layout": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0",
+        "zf1s/zend-session": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-text/composer.json
+++ b/packages/zend-text/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-timesync/composer.json
+++ b/packages/zend-timesync/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-date": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-date": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-translate/composer.json
+++ b/packages/zend-translate/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-uri/composer.json
+++ b/packages/zend-uri/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0",
-        "zf1s/zend-validate": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0",
+        "zf1s/zend-validate": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-validate/composer.json
+++ b/packages/zend-validate/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-ctype": "*",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-view/composer.json
+++ b/packages/zend-view/composer.json
@@ -7,11 +7,11 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-controller": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0",
-        "zf1s/zend-locale": "^1.14.0",
-        "zf1s/zend-registry": "^1.14.0"
+        "zf1s/zend-controller": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0",
+        "zf1s/zend-locale": "^1.15.0",
+        "zf1s/zend-registry": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-wildfire/composer.json
+++ b/packages/zend-wildfire/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.14.0",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-json": "^1.14.0",
-        "zf1s/zend-loader": "^1.14.0"
+        "zf1s/zend-controller": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-json": "^1.15.0",
+        "zf1s/zend-loader": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-xml/composer.json
+++ b/packages/zend-xml/composer.json
@@ -9,7 +9,7 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
-        "zf1s/zend-exception": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-xmlrpc/composer.json
+++ b/packages/zend-xmlrpc/composer.json
@@ -10,10 +10,10 @@
         "ext-iconv": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.14.0",
-        "zf1s/zend-http": "^1.14.0",
-        "zf1s/zend-server": "^1.14.0",
-        "zf1s/zend-xml": "^1.14.0"
+        "zf1s/zend-exception": "^1.15.0",
+        "zf1s/zend-http": "^1.15.0",
+        "zf1s/zend-server": "^1.15.0",
+        "zf1s/zend-xml": "^1.15.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
### 1.15.0 - 2022-10-04
- zend-loader
  - overhaul of zend-loader and autoloader done again ([#116])
  - continues work done initially in [#1] / [76477fb]
  - potential breaking changes:
    > Introduced `Zend_Loader_Exception_FileNotFoundException` and `Zend_Loader_Exception_ClassNotFoundException`
    > 
    > Instead of throwing `Zend_Exception` in `Zend_Loader::loadClass()` with a generic message `File \"$file\" does not exist or class \"$class\" was not found in the file`
    > - `Zend_Loader_Exception_FileNotFoundException` will be thrown with message `File "$file" could not be found within configured include_path`. or
    > - `Zend_Loader_Exception_ClassNotFoundException` with message `Class "$class" was not found in the file "$file".`, in their respective cases.
    
    > Not suppressing loading classes with `@` suppressor by default anymore.
    > 
    > Regular warnings/errors coming from a loaded file should be visible, otherwise it might be very confusing for devs
    >
    > At the same time though, `Zend_Loader` will not emit warnings when checking for files if they exist, by default. Added `isReadable` check inside `loadFile` before `include`/`include_once`.
    > 
    > There might be a performance hit, but it should be okay when most of the autoloading is handled by composer autoloader.
    > 
    > This change should finally allow seamless integration of `Zend_Loader` with composer autoloader, without any warnings.
  - fixed issues with loading custom Translate/File_Transfer/Filter adapters
  - for more details see [#116]
- zend-session
  - added "session.cookie_samesite" option ([#126])
- zend-validate
  - hostname: update TLDs (Version 2022100300) ([#104])
  - hostname: allow underscores in subdomain parts ([#131])
- general: docblock annotations
  - fixed parameter annotation for `Zend_XmlRpc_Fault::setMessage()` ([#117])
  - fixed parameter annotation for `Zend_Db_Table_Select::setIntegrityCheck()` ([#119])
  - fixed wrong return-type in `Zend_Form_Element::removeValidator()` ([#121])
  - fixed annotations for `Zend_Controller_Router_Route_Regex::__construct()` ([#123])
  
[#1]: https://github.com/zf1s/zf1/pull/1
[#104]: https://github.com/zf1s/zf1/pull/104
[#116]: https://github.com/zf1s/zf1/pull/116
[#117]: https://github.com/zf1s/zf1/pull/117
[#119]: https://github.com/zf1s/zf1/pull/119
[#121]: https://github.com/zf1s/zf1/pull/121
[#123]: https://github.com/zf1s/zf1/pull/123
[#126]: https://github.com/zf1s/zf1/pull/126
[#131]: https://github.com/zf1s/zf1/pull/131
[76477fb]: https://github.com/zf1s/zf1/commit/76477fbe00a198ef4376ea38c46df3960c574af8