### PR TITLE
publish the whole zf1s/zf1 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog:
 
-### 1.15.0 - 2022-10-04
+### 1.15.0 - 2022-10-05
 - zend-loader
   - overhaul of zend-loader and autoloader done again ([#116])
   - continues work done initially in [#1] / [76477fb]
@@ -32,6 +32,9 @@
   - fixed parameter annotation for `Zend_Db_Table_Select::setIntegrityCheck()` ([#119])
   - fixed wrong return-type in `Zend_Form_Element::removeValidator()` ([#121])
   - fixed annotations for `Zend_Controller_Router_Route_Regex::__construct()` ([#123])
+- general: publish the whole `zf1s/zf1` package on packagist ([#133])
+  - the whole framework package can be now installed at once with `composer require zf1s/zf1` to easy up the transition period,
+    but please keep in mind the recommended approach is to identify and install only the packages you need.
   
 [#1]: https://github.com/zf1s/zf1/pull/1
 [#104]: https://github.com/zf1s/zf1/pull/104
@@ -42,6 +45,7 @@
 [#123]: https://github.com/zf1s/zf1/pull/123
 [#126]: https://github.com/zf1s/zf1/pull/126
 [#131]: https://github.com/zf1s/zf1/pull/131
+[#133]: https://github.com/zf1s/zf1/pull/133
 [76477fb]: https://github.com/zf1s/zf1/commit/76477fbe00a198ef4376ea38c46df3960c574af8
 
 ### 1.14.0 - 2021-10-01

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/zf1s/zf1/actions/workflows/tests.yml/badge.svg)](https://github.com/zf1s/zf1/actions/workflows/tests.yml)
 
 This is a monorepo of a fork of Zend Framework 1, made after it's reached its EOL.
+
 All original framework's components have been split into individual packages, which can be installed separately with `composer`, e.g.
 ```
 composer require zf1s/zend-*
@@ -101,6 +102,19 @@ Currently everything should be compatible with **PHP 5.3-8.0**. _5.2 support is 
 
 They may also contain some fixes, either for long-standing bugs, which haven't made their way into zf1 official repo before EOL, or newly found ones
 and (backwards compatible) adjustments (optimisations for composer autoloader mostly). Maybe even one or two new features.
+
+Still, the main purpose is to allow working on legacy projects on more modern systems, while opening the possibility to **migrate away from zf1 gradually, one component at a time**.
+
+
+### Alternative Installation Method
+
+You may also install the whole framework at once, using composer:
+```
+composer require zf1s/zf1
+```
+to easy up the transition period, but please keep in mind the recommended approach is to
+identify and install only the packages you need.
+
 
 ### Changelog: [here](CHANGELOG.md)
 Original README: [click](README.orig.md)

--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
         }
     },
     "replace": {
+        "zendframework/zendframework1": ">=1.12.20",
         "zf1s/zend-acl": "self.version",
         "zf1s/zend-amf": "self.version",
         "zf1s/zend-application": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zf1s/zf1",
-    "description": "Monorepo for zf1s (Zend Framework 1) packages",
+    "description": "Zend Framework 1 complete package, PHP 5.3-8.0 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",


### PR DESCRIPTION
resolves https://github.com/zf1s/zf1/issues/57

despite what I wrote in https://github.com/zf1s/zf1/issues/57#issuecomment-1176125117, I've realized that it may make sense to publish the whole `zf1s/zf1` package after all, to easy up the transition period, in which devs should eventually identify and pick only those components they really use, to install (which may not ever happen, but it's ok) ;) 

Initially _(after reading through valid arguments posted by @fredericgboutin-yapla in https://github.com/zf1s/zf1/issues/128#issuecomment-1265381141 )_ I thought it would be enough if only `replace` definition `"zendframework/zendframework1": ">=1.12.20"` was added, while the whole framework could still be installed with git installation method, as described in https://github.com/zf1s/zf1/issues/57#issuecomment-1176125117,

and that
> we do not want to bring in another official "full" package to packagist, introducing more confusion - which one to install, how would that relate to individual packages etc.

but...
screw that, we do not have to be that opinionated.

I am going to install the whole package `zf1s/zf1` together with 1.15.0 release.
