### PR TITLE
Fix: Add monorepo-builder.yml and phpunit.xml.dist to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.git* export-ignore
 /monorepo-builder.yml export-ignore
 /tests export-ignore
 /phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+/monorepo-builder.yml export-ignore
 /tests export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
+/.editorconfig export-ignore
 /.git* export-ignore
 /monorepo-builder.yml export-ignore
-/tests export-ignore
 /phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
This prevents these files from being copied to `zf1s/zf1` install.