### PR TITLE
zf1s/zf1: require php extensions in dev only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "symfony/polyfill-php70": "^1.19"
+    },
+    "require-dev": {
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-gd": "*",
@@ -16,13 +19,10 @@
         "ext-spl": "*",
         "ext-xml": "*",
         "ext-zlib": "*",
-        "symfony/polyfill-php70": "^1.19"
-    },
-    "require-dev": {
         "php-parallel-lint/php-parallel-lint": "1.3.0",
         "phpunit/dbunit": "1.3.2",
-        "zf1s/phpunit": "3.7.41",
-        "staabm/annotate-pull-request-from-checkstyle": "1.5.0"
+        "staabm/annotate-pull-request-from-checkstyle": "1.5.0",
+        "zf1s/phpunit": "3.7.40"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
followup on https://github.com/zf1s/zf1/pull/133, https://github.com/zf1s/zf1/issues/128#issuecomment-1270091768

It is probably too restrictive to have them listed in `require` section in the root `composer.json` file.

Composer will complain that an extension is not installed, e.g. `ext-ldap` for `Zend_Ldap`, even if it's not needed i.e. a project is not using `Zend_Ldap` at all.

```sh
> composer require zf1s/zf1

  [InvalidArgumentException]                                                                                  
  Package zf1s/zf1 has requirements incompatible with your PHP version, PHP extensions and Composer version:  
    - zf1s/zf1 1.15.0 requires ext-ldap * but it is not present.    
```

Due to the nature of zf1, you may never need some of the extensions, as long as you do not use components which require them. But when you start using them, those components themselves should throw errors that required extensions are not installed.

Moved to `require-dev` to ensure they are installed when running tests on dev/CI.

I've considered adding them to `suggest` section but imo composer might spam too much with irrelevant information, when installing `zf1s/zf1` package.

ref: https://github.com/zf1s/zf1/issues/128#issuecomment-1270091768