### PR TITLE
[zend-amf] phpdoc: fix Zend_Amf_Server_Response class name, should be Zend_Amf_Response

### DIFF
--- a/packages/zend-amf/library/Zend/Amf/Server.php
+++ b/packages/zend-amf/library/Zend/Amf/Server.php
@@ -708,9 +708,9 @@ class Zend_Amf_Server implements Zend_Server_Interface
     }
 
     /**
-     * Public access method to private Zend_Amf_Server_Response reference
+     * Public access method to private Zend_Amf_Response reference
      *
-     * @param  string|Zend_Amf_Server_Response $response
+     * @param  string|Zend_Amf_Response $response
      * @return Zend_Amf_Server
      */
     public function setResponse($response)


### PR DESCRIPTION
I was analyzing changes from https://github.com/Shardj/zf1-future/pull/104 and noticed invalid class name.