### PR TITLE
Add missing @throws annotations

### DIFF
--- a/packages/zend-amf/library/Zend/Amf/Server.php
+++ b/packages/zend-amf/library/Zend/Amf/Server.php
@@ -212,6 +212,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
     /**
      * @param namespace of all incoming sessions defaults to Zend_Amf
      * @return Zend_Amf_Server
+     * @throws Zend_Session_Exception
      */
     public function setSession($namespace = 'Zend_Amf')
     {
@@ -235,7 +236,9 @@ class Zend_Amf_Server implements Zend_Server_Interface
      *
      * @param string|object $object Object or class being accessed
      * @param string $function Function or method being accessed
-     * @return unknown_type
+     * @return bool
+     * @throws Zend_Acl_Exception
+     * @throws Zend_Amf_Server_Exception
      */
     protected function _checkAcl($object, $function)
     {
@@ -296,9 +299,11 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * the result
      *
      * @param  string $method Is the method to execute
-     * @param  mixed $param values for the method
+     * @param  mixed $params values for the method
      * @return mixed $response the result of executing the method
+     * @throws Zend_Acl_Exception
      * @throws Zend_Amf_Server_Exception
+     * @throws Zend_Server_Reflection_Exception
      */
     protected function _dispatch($method, $params = null, $source = null)
     {
@@ -384,6 +389,8 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * @see    Zend_Amf_Value_Messaging_CommandMessage
      * @param  Zend_Amf_Value_Messaging_CommandMessage $message
      * @return Zend_Amf_Value_Messaging_AcknowledgeMessage
+     * @throws Zend_Amf_Server_Exception
+     * @throws Zend_Session_Exception
      */
     protected function _loadCommandMessage(Zend_Amf_Value_Messaging_CommandMessage $message)
     {
@@ -460,6 +467,8 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * @param string $userid
      * @param string $password
      * @return boolean
+     * @throws Zend_Amf_Server_Exception
+     * @throws Zend_Session_Exception
      */
     protected function _handleAuth( $userid,  $password)
     {
@@ -490,8 +499,8 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * @todo   should implement and SPL observer pattern for custom AMF headers
      * @todo   DescribeService support
      * @param  Zend_Amf_Request $request
-     * @return Zend_Amf_Response
-     * @throws Zend_Amf_server_Exception|Exception
+     * @return void
+     * @throws Zend_Amf_Server_Exception
      */
     protected function _handle(Zend_Amf_Request $request)
     {
@@ -638,6 +647,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      *
      * @param  null|Zend_Amf_Request $request Optional
      * @return Zend_Amf_Response
+     * @throws Zend_Amf_Server_Exception
      */
     public function handle($request = null)
     {
@@ -675,6 +685,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      *
      * @param  string|Zend_Amf_Request $request
      * @return Zend_Amf_Server
+     * @throws Zend_Amf_Server_Exception
      */
     public function setRequest($request)
     {
@@ -696,6 +707,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * Return currently registered request object
      *
      * @return null|Zend_Amf_Request
+     * @throws Zend_Amf_Server_Exception
      */
     public function getRequest()
     {
@@ -712,6 +724,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      *
      * @param  string|Zend_Amf_Server_Response $response
      * @return Zend_Amf_Server
+     * @throws Zend_Amf_Server_Exception
      */
     public function setResponse($response)
     {
@@ -733,6 +746,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * get a reference to the Zend_Amf_response instance
      *
      * @return Zend_Amf_Server_Response
+     * @throws Zend_Amf_Server_Exception
      */
     public function getResponse()
     {
@@ -757,6 +771,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * @param  mixed $arg Optional arguments to pass to a method
      * @return Zend_Amf_Server
      * @throws Zend_Amf_Server_Exception on invalid input
+     * @throws Zend_Server_Reflection_Exception
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
@@ -798,6 +813,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * @param  string $namespace Optional namespace prefix
      * @return Zend_Amf_Server
      * @throws Zend_Amf_Server_Exception
+     * @throws Zend_Server_Reflection_Exception
      */
     public function addFunction($function, $namespace = '')
     {
@@ -830,6 +846,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * TODO: add support for prefixes?
      *
      * @param string $dir
+     * @throws Zend_Loader_PluginLoader_Exception
      */
     public function addDirectory($dir)
     {
@@ -853,6 +870,7 @@ class Zend_Amf_Server implements Zend_Server_Interface
      * Zend_Server_Reflection_Function_Abstract pairs
      *
      * @return void
+     * @throws Zend_Amf_Server_Exception
      */
     protected function _buildDispatchTable()
     {

--- a/packages/zend-application/library/Zend/Application/Resource/Translate.php
+++ b/packages/zend-application/library/Zend/Application/Resource/Translate.php
@@ -61,6 +61,9 @@ class Zend_Application_Resource_Translate extends Zend_Application_Resource_Reso
      * @return Zend_Translate
      * @throws Zend_Application_Resource_Exception if registry key was used
      *          already but is no instance of Zend_Translate
+     * @throws Zend_Exception
+     * @throws Zend_Log_Exception
+     * @throws Zend_Translate_Exception
      */
     public function getTranslate()
     {

--- a/packages/zend-cloud/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
+++ b/packages/zend-cloud/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
@@ -153,7 +153,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      *
      * @param  string $queueId
      * @param  array  $options
-     * @return array
+     * @return array|false
      * @throws Zend_Cloud_QueueService_Exception
      */
     public function fetchQueueMetadata($queueId, $options = null)

--- a/packages/zend-cloud/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
+++ b/packages/zend-cloud/library/Zend/Cloud/QueueService/Adapter/ZendQueue.php
@@ -55,6 +55,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      *
      * @param  array|Zend_Config $options
      * @return void
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function __construct ($options = array())
     {
@@ -96,6 +97,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  string $name
      * @param  array  $options
      * @return string Queue ID (typically URL)
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function createQueue($name, $options = null)
     {
@@ -113,6 +115,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  string $queueId
      * @param  array  $options
      * @return boolean true if successful, false otherwise
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function deleteQueue($queueId, $options = null)
     {
@@ -134,6 +137,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      *
      * @param  array $options
      * @return array Queue IDs
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function listQueues($options = null)
     {
@@ -150,6 +154,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  string $queueId
      * @param  array  $options
      * @return array
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function fetchQueueMetadata($queueId, $options = null)
     {
@@ -172,6 +177,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  array  $metadata
      * @param  array  $options
      * @return void
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function storeQueueMetadata($queueId, $metadata, $options = null)
     {
@@ -192,6 +198,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  string $message
      * @param  array  $options
      * @return string Message ID
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function sendMessage($queueId, $message, $options = null)
     {
@@ -213,6 +220,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  int    $max
      * @param  array  $options
      * @return array
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function receiveMessages($queueId, $max = 1, $options = null)
     {
@@ -256,6 +264,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  Zend_Cloud_QueueService_Message $message Message ID or message
      * @param  array  $options
      * @return void
+     * @throws Zend_Cloud_QueueService_Exception
      */
     public function deleteMessage($queueId, $message, $options = null)
     {
@@ -283,6 +292,7 @@ class Zend_Cloud_QueueService_Adapter_ZendQueue
      * @param  int $num How many messages
      * @param  array  $options
      * @return Zend_Cloud_QueueService_Message[]
+     * @throws Zend_Cloud_OperationNotAvailableException
      */
     public function peekMessages($queueId, $num = 1, $options = null)
     {

--- a/packages/zend-controller/library/Zend/Controller/Plugin/Broker.php
+++ b/packages/zend-controller/library/Zend/Controller/Plugin/Broker.php
@@ -47,6 +47,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      * @param  Zend_Controller_Plugin_Abstract $plugin
      * @param  int $stackIndex
      * @return Zend_Controller_Plugin_Broker
+     * @throws Zend_Controller_Exception
      */
     public function registerPlugin(Zend_Controller_Plugin_Abstract $plugin, $stackIndex = null)
     {
@@ -90,6 +91,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param string|Zend_Controller_Plugin_Abstract $plugin Plugin object or class name
      * @return Zend_Controller_Plugin_Broker
+     * @throws Zend_Controller_Exception
      */
     public function unregisterPlugin($plugin)
     {
@@ -229,6 +231,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function routeStartup(Zend_Controller_Request_Abstract $request)
     {
@@ -252,6 +255,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param  Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function routeShutdown(Zend_Controller_Request_Abstract $request)
     {
@@ -279,6 +283,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param  Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function dispatchLoopStartup(Zend_Controller_Request_Abstract $request)
     {
@@ -301,6 +306,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param  Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function preDispatch(Zend_Controller_Request_Abstract $request)
     {
@@ -325,6 +331,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param  Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function postDispatch(Zend_Controller_Request_Abstract $request)
     {
@@ -347,6 +354,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
      *
      * @param  Zend_Controller_Request_Abstract $request
      * @return void
+     * @throws Zend_Controller_Exception
      */
     public function dispatchLoopShutdown()
     {

--- a/packages/zend-db/library/Zend/Db/Adapter/Pdo/Ibm.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Pdo/Ibm.php
@@ -145,6 +145,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * Creates a PDO DSN for the adapter from $this->_config settings.
      *
      * @return string
+     * @throws Zend_Db_Adapter_Exception
      */
     protected function _dsn()
     {
@@ -189,6 +190,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * @param string $sql The SQL statement with placeholders.
      * @param array $bind An array of data to bind to the placeholders.
      * @return PDOStatement
+     * @throws Zend_Db_Adapter_Exception
      */
     public function prepare($sql)
     {
@@ -203,6 +205,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * Returns a list of the tables in the database.
      *
      * @return array
+     * @throws Zend_Db_Adapter_Exception
      */
     public function listTables()
     {
@@ -238,6 +241,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * @param string $tableName
      * @param string $schemaName OPTIONAL
      * @return array
+     * @throws Zend_Db_Adapter_Exception
      */
     public function describeTable($tableName, $schemaName = null)
     {
@@ -253,6 +257,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * @param mixed $table The table to insert data into.
      * @param array $bind Column-value pairs.
      * @return int The number of affected rows.
+     * @throws Zend_Db_Adapter_Exception
      */
     public function insert($table, array $bind)
     {
@@ -276,6 +281,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * @param integer $count
      * @param integer $offset OPTIONAL
      * @return string
+     * @throws Zend_Db_Adapter_Exception
      */
     public function limit($sql, $count, $offset = 0)
     {
@@ -290,6 +296,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * @param string $tableName OPTIONAL
      * @param string $primaryKey OPTIONAL
      * @return integer
+     * @throws Zend_Db_Adapter_Exception
      */
     public function lastInsertId($tableName = null, $primaryKey = null)
     {
@@ -314,6 +321,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      *
      * @param string $sequenceName
      * @return integer
+     * @throws Zend_Db_Adapter_Exception
      */
     public function lastSequenceId($sequenceName)
     {
@@ -327,6 +335,7 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      *
      * @param string $sequenceName
      * @return integer
+     * @throws Zend_Db_Adapter_Exception
      */
     public function nextSequenceId($sequenceName)
     {
@@ -338,6 +347,8 @@ class Zend_Db_Adapter_Pdo_Ibm extends Zend_Db_Adapter_Pdo_Abstract
      * Retrieve server version in PHP style
      * Pdo_Idm doesn't support getAttribute(PDO::ATTR_SERVER_VERSION)
      * @return string
+     * @throws Zend_Db_Adapter_Exception
+     * @throws Zend_Db_Statement_Exception
      */
     public function getServerVersion()
     {

--- a/packages/zend-dojo/library/Zend/Dojo/Data.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Data.php
@@ -525,6 +525,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  array|object $item
      * @param  string|int|null $id
      * @return array
+     * @throws Zend_Dojo_Exception
      */
     protected function _normalizeItem($item, $id)
     {

--- a/packages/zend-dojo/library/Zend/Dojo/View/Helper/CustomDijit.php
+++ b/packages/zend-dojo/library/Zend/Dojo/View/Helper/CustomDijit.php
@@ -51,6 +51,7 @@ class Zend_Dojo_View_Helper_CustomDijit extends Zend_Dojo_View_Helper_DijitConta
      * @param  array $params
      * @param  array $attribs
      * @return string|Zend_Dojo_View_Helper_CustomDijit
+     * @throws Zend_Dojo_View_Exception
      */
     public function customDijit($id = null, $value = null, array $params = array(), array $attribs = array())
     {
@@ -90,6 +91,7 @@ class Zend_Dojo_View_Helper_CustomDijit extends Zend_Dojo_View_Helper_DijitConta
      * @param  array $params
      * @param  array $attribs
      * @return void
+     * @throws Zend_Dojo_View_Exception
      */
     public function captureStart($id, array $params = array(), array $attribs = array())
     {

--- a/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
+++ b/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Entry/Atom.php
@@ -90,6 +90,7 @@ class Zend_Feed_Writer_Renderer_Entry_Atom
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
@@ -139,6 +140,7 @@ class Zend_Feed_Writer_Renderer_Entry_Atom
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
@@ -265,6 +267,7 @@ class Zend_Feed_Writer_Renderer_Entry_Atom
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {
@@ -339,6 +342,7 @@ class Zend_Feed_Writer_Renderer_Entry_Atom
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setContent(DOMDocument $dom, DOMElement $root)
     {

--- a/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
+++ b/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Entry/Rss.php
@@ -84,6 +84,7 @@ class Zend_Feed_Writer_Renderer_Entry_Rss
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
@@ -113,6 +114,7 @@ class Zend_Feed_Writer_Renderer_Entry_Rss
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
@@ -211,6 +213,7 @@ class Zend_Feed_Writer_Renderer_Entry_Rss
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setEnclosure(DOMDocument $dom, DOMElement $root)
     {

--- a/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Feed/Atom/AtomAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Feed/Atom/AtomAbstract.php
@@ -75,6 +75,7 @@ class Zend_Feed_Writer_Renderer_Feed_Atom_AtomAbstract
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
@@ -123,6 +124,7 @@ class Zend_Feed_Writer_Renderer_Feed_Atom_AtomAbstract
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
@@ -199,6 +201,7 @@ class Zend_Feed_Writer_Renderer_Feed_Atom_AtomAbstract
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setFeedLinks(DOMDocument $dom, DOMElement $root)
     {
@@ -274,6 +277,7 @@ class Zend_Feed_Writer_Renderer_Feed_Atom_AtomAbstract
      * @param  DOMDocument $dom
      * @param  DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {

--- a/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
+++ b/packages/zend-feed/library/Zend/Feed/Writer/Renderer/Feed/Rss.php
@@ -142,6 +142,7 @@ class Zend_Feed_Writer_Renderer_Feed_Rss
      * @param DOMDocument $dom
      * @param DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
@@ -170,6 +171,7 @@ class Zend_Feed_Writer_Renderer_Feed_Rss
      * @param DOMDocument $dom
      * @param DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
@@ -246,6 +248,7 @@ class Zend_Feed_Writer_Renderer_Feed_Rss
      * @param DOMDocument $dom
      * @param DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
@@ -321,6 +324,7 @@ class Zend_Feed_Writer_Renderer_Feed_Rss
      * @param DOMDocument $dom
      * @param DOMElement $root
      * @return void
+     * @throws Zend_Feed_Exception
      */
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {

--- a/packages/zend-json/library/Zend/Json/Decoder.php
+++ b/packages/zend-json/library/Zend/Json/Decoder.php
@@ -163,6 +163,7 @@ class Zend_Json_Decoder
      *
      * @throws Zend_Json_Exception
      * @return mixed
+     * @throws Zend_Json_Exception
      */
     protected function _decodeValue()
     {
@@ -313,6 +314,7 @@ class Zend_Json_Decoder
      *
      * @throws Zend_Json_Exception
      * @return int Token constant value specified in class definition
+     * @throws Zend_Json_Exception
      */
     protected function _getNextToken()
     {

--- a/packages/zend-json/library/Zend/Json/Server.php
+++ b/packages/zend-json/library/Zend/Json/Server.php
@@ -85,6 +85,9 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * @param  string|array $function Valid PHP callback
      * @param  string $namespace  Ignored
      * @return Zend_Json_Server
+     * @throws Zend_Json_Server_Exception
+     * @throws Zend_Server_Exception
+     * @throws Zend_Server_Reflection_Exception
      */
     public function addFunction($function, $namespace = '')
     {
@@ -138,6 +141,8 @@ class Zend_Json_Server extends Zend_Server_Abstract
      * @param  string $namespace Ignored
      * @param  mixed $argv Ignored
      * @return Zend_Json_Server
+     * @throws Zend_Server_Exception
+     * @throws Zend_Server_Reflection_Exception
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
@@ -208,6 +213,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      *
      * @param  array|Zend_Server_Definition $definition
      * @return void
+     * @throws Zend_Json_Server_Exception
      */
     public function loadFunctions($definition)
     {
@@ -343,6 +349,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
      *
      * @param  Zend_Server_Reflection_Function $method
      * @return void
+     * @throws Zend_Json_Server_Exception
      */
     protected function _addMethodServiceMap(Zend_Server_Method_Definition $method)
     {
@@ -497,7 +504,9 @@ class Zend_Json_Server extends Zend_Server_Abstract
     /**
      * Internal method for handling request
      *
-     * @return void
+     * @return false
+     * @throws ReflectionException
+     * @throws Zend_Server_Exception
      */
     protected function _handle()
     {

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene.php
@@ -202,6 +202,8 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      *
      * @param mixed $directory
      * @return Zend_Search_Lucene_Interface
+     * @throws Zend_Search_Exception
+     * @throws Zend_Search_Lucene_Exception
      */
     public static function create($directory)
     {
@@ -216,6 +218,8 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      *
      * @param mixed $directory
      * @return Zend_Search_Lucene_Interface
+     * @throws Zend_Search_Exception
+     * @throws Zend_Search_Lucene_Exception
      */
     public static function open($directory)
     {
@@ -504,6 +508,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      *
      * @param Zend_Search_Lucene_Storage_Directory_Filesystem|string $directory
      * @throws Zend_Search_Lucene_Exception
+     * @throws Zend_Search_Exception
      */
     public function __construct($directory = null, $create = false)
     {
@@ -916,6 +921,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      * @param Zend_Search_Lucene_Search_QueryParser|string $query
      * @return array Zend_Search_Lucene_Search_QueryHit
      * @throws Zend_Search_Lucene_Exception
+     * @throws Zend_Search_Exception
      */
     public function find($query)
     {

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Search/QueryParser.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Search/QueryParser.php
@@ -348,6 +348,8 @@ class Zend_Search_Lucene_Search_QueryParser extends Zend_Search_Lucene_FSM
      * @param string $strQuery
      * @param string $encoding
      * @return Zend_Search_Lucene_Search_Query
+     * @throws Zend_Search_Exception
+     * @throws Zend_Search_Lucene_Exception
      * @throws Zend_Search_Lucene_Search_QueryParserException
      */
     public static function parse($strQuery, $encoding = null)
@@ -546,6 +548,7 @@ class Zend_Search_Lucene_Search_QueryParser extends Zend_Search_Lucene_FSM
      * Process last range query term (opened interval)
      *
      * @throws Zend_Search_Lucene_Search_QueryParserException
+     * @throws Zend_Search_Lucene_Exception
      */
     public function openedRQLastTerm()
     {
@@ -595,6 +598,7 @@ class Zend_Search_Lucene_Search_QueryParser extends Zend_Search_Lucene_FSM
      * Process last range query term (closed interval)
      *
      * @throws Zend_Search_Lucene_Search_QueryParserException
+     * @throws Zend_Search_Lucene_Exception
      */
     public function closedRQLastTerm()
     {

--- a/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
+++ b/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
@@ -225,6 +225,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param int $lifetime
      * @param boolean $overrideLifetime (optional)
      * @return Zend_Session_SaveHandler_DbTable
+     * @throws Zend_Session_SaveHandler_Exception
      */
     public function setLifetime($lifetime, $overrideLifetime = null)
     {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Db/Operation/Truncate.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Db/Operation/Truncate.php
@@ -42,6 +42,7 @@ class Zend_Test_PHPUnit_Db_Operation_Truncate implements PHPUnit_Extensions_Data
      * @param PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection
      * @param PHPUnit_Extensions_Database_DataSet_IDataSet $dataSet
      * @return void
+     * @throws Zend_Test_PHPUnit_Db_Exception
      */
     public function execute(PHPUnit_Extensions_Database_DB_IDatabaseConnection $connection, PHPUnit_Extensions_Database_DataSet_IDataSet $dataSet)
     {
@@ -66,6 +67,7 @@ class Zend_Test_PHPUnit_Db_Operation_Truncate implements PHPUnit_Extensions_Data
      * @param Zend_Db_Adapter_Abstract $db
      * @param string $tableName
      * @return void
+     * @throws Zend_Db_Adapter_Exception
      */
     protected function _truncate(Zend_Db_Adapter_Abstract $db, $tableName)
     {

--- a/packages/zend-text/library/Zend/Text/MultiByte.php
+++ b/packages/zend-text/library/Zend/Text/MultiByte.php
@@ -38,6 +38,7 @@ class Zend_Text_MultiByte
      * @param  boolean $cut
      * @param  string  $charset
      * @return string
+     * @throws Zend_Text_Exception
      */
     public static function wordWrap($string, $width = 75, $break = "\n", $cut = false, $charset = 'utf-8')
     {

--- a/packages/zend-tool/library/Zend/Tool/Project/Provider/Abstract.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Provider/Abstract.php
@@ -122,6 +122,8 @@ abstract class Zend_Tool_Project_Provider_Abstract
      * @param string $projectDirectory        The project directory to use to search
      * @param bool   $searchParentDirectories Whether or not to search upper level direcotries
      * @return Zend_Tool_Project_Profile
+     * @throws Zend_Tool_Project_Provider_Exception
+     * @throws Zend_Tool_Project_Exception
      */
     protected function _loadProfile($loadProfileFlag = self::NO_PROFILE_THROW_EXCEPTION, $projectDirectory = null, $searchParentDirectories = true)
     {
@@ -182,6 +184,8 @@ abstract class Zend_Tool_Project_Provider_Abstract
      * Load the project profile from the current working directory, if not throw exception
      *
      * @return Zend_Tool_Project_Profile
+     * @throws Zend_Tool_Project_Exception
+     * @throws Zend_Tool_Project_Provider_Exception
      */
     protected function _loadProfileRequired()
     {
@@ -196,7 +200,10 @@ abstract class Zend_Tool_Project_Provider_Abstract
     /**
      * Return the currently loaded profile
      *
+     * @param bool $loadProfileFlag
      * @return Zend_Tool_Project_Profile
+     * @throws Zend_Tool_Project_Exception
+     * @throws Zend_Tool_Project_Provider_Exception
      */
     protected function _getProfile($loadProfileFlag = self::NO_PROFILE_THROW_EXCEPTION)
     {

--- a/packages/zend-tool/library/Zend/Tool/Project/Provider/Form.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Provider/Form.php
@@ -76,6 +76,7 @@ class Zend_Tool_Project_Provider_Form extends Zend_Tool_Project_Provider_Abstrac
      * @param Zend_Tool_Project_Profile $profile
      * @param string $moduleName
      * @return Zend_Tool_Project_Profile_Resource
+     * @throws Zend_Tool_Project_Profile_Exception
      */
     protected static function _getFormsDirectoryResource(Zend_Tool_Project_Profile $profile, $moduleName = null)
     {
@@ -119,6 +120,8 @@ class Zend_Tool_Project_Provider_Form extends Zend_Tool_Project_Provider_Abstrac
      *
      * @param string $name
      * @param string $module
+     * @throws Zend_Tool_Project_Exception
+     * @throws Zend_Tool_Project_Provider_Exception
      */
     public function create($name, $module = null)
     {

--- a/packages/zend-validate/library/Zend/Validate/File/MimeType.php
+++ b/packages/zend-validate/library/Zend/Validate/File/MimeType.php
@@ -157,6 +157,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      * Returns the actual set magicfile
      *
      * @return string
+     * @throws Zend_Validate_Exception
      */
     public function getMagicFile()
     {
@@ -275,6 +276,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      *
      * @param  string|array $mimetype The mimetypes to validate
      * @return Zend_Validate_File_Extension Provides a fluent interface
+     * @throws Zend_Validate_Exception
      */
     public function setMimeType($mimetype)
     {
@@ -396,6 +398,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      * Try to detect mime type of given file.
      * @param string $file File which mime type should be detected
      * @return string File mime type or null if not detected
+     * @throws Zend_Validate_Exception
      */
     protected function _detectMimeType($file)
     {


### PR DESCRIPTION
Carry  only `@throws` annotations from https://github.com/zf1s/zf1/pull/138

Which itself was to carry https://github.com/Shardj/zf1-future/pull/104:
- Excluded whitespace and formatting changes.
- Included extra fixes:
   - https://github.com/Shardj/zf1-future/pull/104/files#r992515043
   - https://github.com/Shardj/zf1-future/pull/104/files#r992486395
   
cc @kstenschke