### PR TITLE
Fix str_split('') logic to keep same as PHP before 8.2 on PHP 8.2

### DIFF
--- a/packages/zend-console-getopt/library/Zend/Console/Getopt.php
+++ b/packages/zend-console-getopt/library/Zend/Console/Getopt.php
@@ -784,7 +784,8 @@ class Zend_Console_Getopt
     protected function _parseShortOptionCluster(&$argv)
     {
         $flagCluster = ltrim(array_shift($argv), '-');
-        foreach (str_split($flagCluster) as $flag) {
+        $listFlagChar = $flagCluster === '' ?  array('') : str_split($flagCluster);
+        foreach ($listFlagChar as $flag) {
             $this->_parseSingleOption($flag, $argv);
         }
     }


### PR DESCRIPTION
_Carries  https://github.com/Shardj/zf1-future/pull/277 which picked only relevant change from https://github.com/Shardj/zf1-future/pull/275 which was created by @hungtrinh_

Reference:
-  https://php.watch/versions/8.2/str_split-empty-string-empty-array

Fixes:
- https://github.com/Shardj/zf1-future/issues/276