### PR TITLE
Add compat symlinks for original zendframework layout

### DIFF
--- a/library/Zend/Acl
+++ b/library/Zend/Acl
@@ -1,0 +1,1 @@
+../../packages/zend-acl/library/Zend/Acl

--- a/library/Zend/Acl.php
+++ b/library/Zend/Acl.php
@@ -1,0 +1,1 @@
+../../packages/zend-acl/library/Zend/Acl.php

--- a/library/Zend/Amf
+++ b/library/Zend/Amf
@@ -1,0 +1,1 @@
+../../packages/zend-amf/library/Zend/Amf

--- a/library/Zend/Application
+++ b/library/Zend/Application
@@ -1,0 +1,1 @@
+../../packages/zend-application/library/Zend/Application

--- a/library/Zend/Application.php
+++ b/library/Zend/Application.php
@@ -1,0 +1,1 @@
+../../packages/zend-application/library/Zend/Application.php

--- a/library/Zend/Auth
+++ b/library/Zend/Auth
@@ -1,0 +1,1 @@
+../../packages/zend-auth/library/Zend/Auth

--- a/library/Zend/Auth.php
+++ b/library/Zend/Auth.php
@@ -1,0 +1,1 @@
+../../packages/zend-auth/library/Zend/Auth.php

--- a/library/Zend/Barcode
+++ b/library/Zend/Barcode
@@ -1,0 +1,1 @@
+../../packages/zend-barcode/library/Zend/Barcode

--- a/library/Zend/Barcode.php
+++ b/library/Zend/Barcode.php
@@ -1,0 +1,1 @@
+../../packages/zend-barcode/library/Zend/Barcode.php

--- a/library/Zend/Cache
+++ b/library/Zend/Cache
@@ -1,0 +1,1 @@
+../../packages/zend-cache/library/Zend/Cache

--- a/library/Zend/Cache.php
+++ b/library/Zend/Cache.php
@@ -1,0 +1,1 @@
+../../packages/zend-cache/library/Zend/Cache.php

--- a/library/Zend/Captcha
+++ b/library/Zend/Captcha
@@ -1,0 +1,1 @@
+../../packages/zend-captcha/library/Zend/Captcha

--- a/library/Zend/Cloud
+++ b/library/Zend/Cloud
@@ -1,0 +1,1 @@
+../../packages/zend-cloud/library/Zend/Cloud

--- a/library/Zend/CodeGenerator
+++ b/library/Zend/CodeGenerator
@@ -1,0 +1,1 @@
+../../packages/zend-codegenerator/library/Zend/CodeGenerator

--- a/library/Zend/Config
+++ b/library/Zend/Config
@@ -1,0 +1,1 @@
+../../packages/zend-config/library/Zend/Config

--- a/library/Zend/Config.php
+++ b/library/Zend/Config.php
@@ -1,0 +1,1 @@
+../../packages/zend-config/library/Zend/Config.php

--- a/library/Zend/Console
+++ b/library/Zend/Console
@@ -1,0 +1,1 @@
+../../packages/zend-console-getopt/library/Zend/Console

--- a/library/Zend/Controller
+++ b/library/Zend/Controller
@@ -1,0 +1,1 @@
+../../packages/zend-controller/library/Zend/Controller

--- a/library/Zend/Crypt
+++ b/library/Zend/Crypt
@@ -1,0 +1,1 @@
+../../packages/zend-crypt/library/Zend/Crypt

--- a/library/Zend/Crypt.php
+++ b/library/Zend/Crypt.php
@@ -1,0 +1,1 @@
+../../packages/zend-crypt/library/Zend/Crypt.php

--- a/library/Zend/Currency
+++ b/library/Zend/Currency
@@ -1,0 +1,1 @@
+../../packages/zend-currency/library/Zend/Currency

--- a/library/Zend/Currency.php
+++ b/library/Zend/Currency.php
@@ -1,0 +1,1 @@
+../../packages/zend-currency/library/Zend/Currency.php

--- a/library/Zend/Date
+++ b/library/Zend/Date
@@ -1,0 +1,1 @@
+../../packages/zend-date/library/Zend/Date

--- a/library/Zend/Date.php
+++ b/library/Zend/Date.php
@@ -1,0 +1,1 @@
+../../packages/zend-date/library/Zend/Date.php

--- a/library/Zend/Db.php
+++ b/library/Zend/Db.php
@@ -1,0 +1,1 @@
+../../packages/zend-db/library/Zend/Db.php

--- a/library/Zend/Debug.php
+++ b/library/Zend/Debug.php
@@ -1,0 +1,1 @@
+../../packages/zend-debug/library/Zend/Debug.php

--- a/library/Zend/Dojo
+++ b/library/Zend/Dojo
@@ -1,0 +1,1 @@
+../../packages/zend-dojo/library/Zend/Dojo

--- a/library/Zend/Dojo.php
+++ b/library/Zend/Dojo.php
@@ -1,0 +1,1 @@
+../../packages/zend-dojo/library/Zend/Dojo.php

--- a/library/Zend/Dom
+++ b/library/Zend/Dom
@@ -1,0 +1,1 @@
+../../packages/zend-dom/library/Zend/Dom

--- a/library/Zend/Exception.php
+++ b/library/Zend/Exception.php
@@ -1,0 +1,1 @@
+../../packages/zend-exception/library/Zend/Exception.php

--- a/library/Zend/Feed
+++ b/library/Zend/Feed
@@ -1,0 +1,1 @@
+../../packages/zend-feed/library/Zend/Feed

--- a/library/Zend/Feed.php
+++ b/library/Zend/Feed.php
@@ -1,0 +1,1 @@
+../../packages/zend-feed/library/Zend/Feed.php

--- a/library/Zend/File
+++ b/library/Zend/File
@@ -1,0 +1,1 @@
+../../packages/zend-file-transfer/library/Zend/File

--- a/library/Zend/Filter
+++ b/library/Zend/Filter
@@ -1,0 +1,1 @@
+../../packages/zend-filter/library/Zend/Filter

--- a/library/Zend/Filter.php
+++ b/library/Zend/Filter.php
@@ -1,0 +1,1 @@
+../../packages/zend-filter/library/Zend/Filter.php

--- a/library/Zend/Form
+++ b/library/Zend/Form
@@ -1,0 +1,1 @@
+../../packages/zend-form/library/Zend/Form

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -1,0 +1,1 @@
+../../packages/zend-form/library/Zend/Form.php

--- a/library/Zend/Gdata
+++ b/library/Zend/Gdata
@@ -1,0 +1,1 @@
+../../packages/zend-gdata/library/Zend/Gdata

--- a/library/Zend/Gdata.php
+++ b/library/Zend/Gdata.php
@@ -1,0 +1,1 @@
+../../packages/zend-gdata/library/Zend/Gdata.php

--- a/library/Zend/Http
+++ b/library/Zend/Http
@@ -1,0 +1,1 @@
+../../packages/zend-http/library/Zend/Http

--- a/library/Zend/Json
+++ b/library/Zend/Json
@@ -1,0 +1,1 @@
+../../packages/zend-json/library/Zend/Json

--- a/library/Zend/Json.php
+++ b/library/Zend/Json.php
@@ -1,0 +1,1 @@
+../../packages/zend-json/library/Zend/Json.php

--- a/library/Zend/Layout
+++ b/library/Zend/Layout
@@ -1,0 +1,1 @@
+../../packages/zend-layout/library/Zend/Layout

--- a/library/Zend/Layout.php
+++ b/library/Zend/Layout.php
@@ -1,0 +1,1 @@
+../../packages/zend-layout/library/Zend/Layout.php

--- a/library/Zend/Ldap
+++ b/library/Zend/Ldap
@@ -1,0 +1,1 @@
+../../packages/zend-ldap/library/Zend/Ldap

--- a/library/Zend/Ldap.php
+++ b/library/Zend/Ldap.php
@@ -1,0 +1,1 @@
+../../packages/zend-ldap/library/Zend/Ldap.php

--- a/library/Zend/Loader
+++ b/library/Zend/Loader
@@ -1,0 +1,1 @@
+../../packages/zend-loader/library/Zend/Loader

--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -1,0 +1,1 @@
+../../packages/zend-loader/library/Zend/Loader.php

--- a/library/Zend/Locale
+++ b/library/Zend/Locale
@@ -1,0 +1,1 @@
+../../packages/zend-locale/library/Zend/Locale

--- a/library/Zend/Locale.php
+++ b/library/Zend/Locale.php
@@ -1,0 +1,1 @@
+../../packages/zend-locale/library/Zend/Locale.php

--- a/library/Zend/Log
+++ b/library/Zend/Log
@@ -1,0 +1,1 @@
+../../packages/zend-log/library/Zend/Log

--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -1,0 +1,1 @@
+../../packages/zend-log/library/Zend/Log.php

--- a/library/Zend/Mail
+++ b/library/Zend/Mail
@@ -1,0 +1,1 @@
+../../packages/zend-mail/library/Zend/Mail

--- a/library/Zend/Mail.php
+++ b/library/Zend/Mail.php
@@ -1,0 +1,1 @@
+../../packages/zend-mail/library/Zend/Mail.php

--- a/library/Zend/Markup
+++ b/library/Zend/Markup
@@ -1,0 +1,1 @@
+../../packages/zend-markup/library/Zend/Markup

--- a/library/Zend/Markup.php
+++ b/library/Zend/Markup.php
@@ -1,0 +1,1 @@
+../../packages/zend-markup/library/Zend/Markup.php

--- a/library/Zend/Measure
+++ b/library/Zend/Measure
@@ -1,0 +1,1 @@
+../../packages/zend-measure/library/Zend/Measure

--- a/library/Zend/Memory
+++ b/library/Zend/Memory
@@ -1,0 +1,1 @@
+../../packages/zend-memory/library/Zend/Memory

--- a/library/Zend/Memory.php
+++ b/library/Zend/Memory.php
@@ -1,0 +1,1 @@
+../../packages/zend-memory/library/Zend/Memory.php

--- a/library/Zend/Mime
+++ b/library/Zend/Mime
@@ -1,0 +1,1 @@
+../../packages/zend-mime/library/Zend/Mime

--- a/library/Zend/Mime.php
+++ b/library/Zend/Mime.php
@@ -1,0 +1,1 @@
+../../packages/zend-mime/library/Zend/Mime.php

--- a/library/Zend/Mobile
+++ b/library/Zend/Mobile
@@ -1,0 +1,1 @@
+../../packages/zend-mobile/library/Zend/Mobile

--- a/library/Zend/Navigation
+++ b/library/Zend/Navigation
@@ -1,0 +1,1 @@
+../../packages/zend-navigation/library/Zend/Navigation

--- a/library/Zend/Navigation.php
+++ b/library/Zend/Navigation.php
@@ -1,0 +1,1 @@
+../../packages/zend-navigation/library/Zend/Navigation.php

--- a/library/Zend/Oauth
+++ b/library/Zend/Oauth
@@ -1,0 +1,1 @@
+../../packages/zend-oauth/library/Zend/Oauth

--- a/library/Zend/Oauth.php
+++ b/library/Zend/Oauth.php
@@ -1,0 +1,1 @@
+../../packages/zend-oauth/library/Zend/Oauth.php

--- a/library/Zend/OpenId
+++ b/library/Zend/OpenId
@@ -1,0 +1,1 @@
+../../packages/zend-openid/library/Zend/OpenId

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -1,0 +1,1 @@
+../../packages/zend-openid/library/Zend/OpenId.php

--- a/library/Zend/Paginator
+++ b/library/Zend/Paginator
@@ -1,0 +1,1 @@
+../../packages/zend-paginator/library/Zend/Paginator

--- a/library/Zend/Paginator.php
+++ b/library/Zend/Paginator.php
@@ -1,0 +1,1 @@
+../../packages/zend-paginator/library/Zend/Paginator.php

--- a/library/Zend/Pdf
+++ b/library/Zend/Pdf
@@ -1,0 +1,1 @@
+../../packages/zend-pdf/library/Zend/Pdf

--- a/library/Zend/Pdf.php
+++ b/library/Zend/Pdf.php
@@ -1,0 +1,1 @@
+../../packages/zend-pdf/library/Zend/Pdf.php

--- a/library/Zend/ProgressBar
+++ b/library/Zend/ProgressBar
@@ -1,0 +1,1 @@
+../../packages/zend-progressbar/library/Zend/ProgressBar

--- a/library/Zend/ProgressBar.php
+++ b/library/Zend/ProgressBar.php
@@ -1,0 +1,1 @@
+../../packages/zend-progressbar/library/Zend/ProgressBar.php

--- a/library/Zend/Queue
+++ b/library/Zend/Queue
@@ -1,0 +1,1 @@
+../../packages/zend-queue/library/Zend/Queue

--- a/library/Zend/Queue.php
+++ b/library/Zend/Queue.php
@@ -1,0 +1,1 @@
+../../packages/zend-queue/library/Zend/Queue.php

--- a/library/Zend/Reflection
+++ b/library/Zend/Reflection
@@ -1,0 +1,1 @@
+../../packages/zend-reflection/library/Zend/Reflection

--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -1,0 +1,1 @@
+../../packages/zend-registry/library/Zend/Registry.php

--- a/library/Zend/Rest
+++ b/library/Zend/Rest
@@ -1,0 +1,1 @@
+../../packages/zend-rest/library/Zend/Rest

--- a/library/Zend/Search
+++ b/library/Zend/Search
@@ -1,0 +1,1 @@
+../../packages/zend-search-lucene/library/Zend/Search

--- a/library/Zend/Serializer
+++ b/library/Zend/Serializer
@@ -1,0 +1,1 @@
+../../packages/zend-serializer/library/Zend/Serializer

--- a/library/Zend/Serializer.php
+++ b/library/Zend/Serializer.php
@@ -1,0 +1,1 @@
+../../packages/zend-serializer/library/Zend/Serializer.php

--- a/library/Zend/Server
+++ b/library/Zend/Server
@@ -1,0 +1,1 @@
+../../packages/zend-server/library/Zend/Server

--- a/library/Zend/Service/Abstract.php
+++ b/library/Zend/Service/Abstract.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service/library/Zend/Service/Abstract.php

--- a/library/Zend/Service/Akismet.php
+++ b/library/Zend/Service/Akismet.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-akismet/library/Zend/Service/Akismet.php

--- a/library/Zend/Service/Amazon
+++ b/library/Zend/Service/Amazon
@@ -1,0 +1,1 @@
+../../../packages/zend-service-amazon/library/Zend/Service/Amazon

--- a/library/Zend/Service/Amazon.php
+++ b/library/Zend/Service/Amazon.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-amazon/library/Zend/Service/Amazon.php

--- a/library/Zend/Service/Audioscrobbler.php
+++ b/library/Zend/Service/Audioscrobbler.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-audioscrobbler/library/Zend/Service/Audioscrobbler.php

--- a/library/Zend/Service/Console
+++ b/library/Zend/Service/Console
@@ -1,0 +1,1 @@
+../../../packages/zend-service-console/library/Zend/Service/Console

--- a/library/Zend/Service/Delicious
+++ b/library/Zend/Service/Delicious
@@ -1,0 +1,1 @@
+../../../packages/zend-service-delicious/library/Zend/Service/Delicious

--- a/library/Zend/Service/Delicious.php
+++ b/library/Zend/Service/Delicious.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-delicious/library/Zend/Service/Delicious.php

--- a/library/Zend/Service/Ebay
+++ b/library/Zend/Service/Ebay
@@ -1,0 +1,1 @@
+../../../packages/zend-service-ebay/library/Zend/Service/Ebay

--- a/library/Zend/Service/Exception.php
+++ b/library/Zend/Service/Exception.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service/library/Zend/Service/Exception.php

--- a/library/Zend/Service/Flickr
+++ b/library/Zend/Service/Flickr
@@ -1,0 +1,1 @@
+../../../packages/zend-service-flickr/library/Zend/Service/Flickr

--- a/library/Zend/Service/Flickr.php
+++ b/library/Zend/Service/Flickr.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-flickr/library/Zend/Service/Flickr.php

--- a/library/Zend/Service/LiveDocx
+++ b/library/Zend/Service/LiveDocx
@@ -1,0 +1,1 @@
+../../../packages/zend-service-livedocx/library/Zend/Service/LiveDocx

--- a/library/Zend/Service/LiveDocx.php
+++ b/library/Zend/Service/LiveDocx.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-livedocx/library/Zend/Service/LiveDocx.php

--- a/library/Zend/Service/Rackspace
+++ b/library/Zend/Service/Rackspace
@@ -1,0 +1,1 @@
+../../../packages/zend-service-rackspace/library/Zend/Service/Rackspace

--- a/library/Zend/Service/ReCaptcha
+++ b/library/Zend/Service/ReCaptcha
@@ -1,0 +1,1 @@
+../../../packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha

--- a/library/Zend/Service/ReCaptcha.php
+++ b/library/Zend/Service/ReCaptcha.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha.php

--- a/library/Zend/Service/ShortUrl
+++ b/library/Zend/Service/ShortUrl
@@ -1,0 +1,1 @@
+../../../packages/zend-service-shorturl/library/Zend/Service/ShortUrl

--- a/library/Zend/Service/SlideShare
+++ b/library/Zend/Service/SlideShare
@@ -1,0 +1,1 @@
+../../../packages/zend-service-slideshare/library/Zend/Service/SlideShare

--- a/library/Zend/Service/SlideShare.php
+++ b/library/Zend/Service/SlideShare.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-slideshare/library/Zend/Service/SlideShare.php

--- a/library/Zend/Service/SqlAzure
+++ b/library/Zend/Service/SqlAzure
@@ -1,0 +1,1 @@
+../../../packages/zend-service-windowsazure/library/Zend/Service/SqlAzure

--- a/library/Zend/Service/StrikeIron
+++ b/library/Zend/Service/StrikeIron
@@ -1,0 +1,1 @@
+../../../packages/zend-service-strikeiron/library/Zend/Service/StrikeIron

--- a/library/Zend/Service/StrikeIron.php
+++ b/library/Zend/Service/StrikeIron.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-strikeiron/library/Zend/Service/StrikeIron.php

--- a/library/Zend/Service/Twitter
+++ b/library/Zend/Service/Twitter
@@ -1,0 +1,1 @@
+../../../packages/zend-service-twitter/library/Zend/Service/Twitter

--- a/library/Zend/Service/Twitter.php
+++ b/library/Zend/Service/Twitter.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-twitter/library/Zend/Service/Twitter.php

--- a/library/Zend/Service/WindowsAzure
+++ b/library/Zend/Service/WindowsAzure
@@ -1,0 +1,1 @@
+../../../packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure

--- a/library/Zend/Service/Yahoo
+++ b/library/Zend/Service/Yahoo
@@ -1,0 +1,1 @@
+../../../packages/zend-service-yahoo/library/Zend/Service/Yahoo

--- a/library/Zend/Service/Yahoo.php
+++ b/library/Zend/Service/Yahoo.php
@@ -1,0 +1,1 @@
+../../../packages/zend-service-yahoo/library/Zend/Service/Yahoo.php

--- a/library/Zend/Session
+++ b/library/Zend/Session
@@ -1,0 +1,1 @@
+../../packages/zend-session/library/Zend/Session

--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -1,0 +1,1 @@
+../../packages/zend-session/library/Zend/Session.php

--- a/library/Zend/Soap
+++ b/library/Zend/Soap
@@ -1,0 +1,1 @@
+../../packages/zend-soap/library/Zend/Soap

--- a/library/Zend/Stdlib
+++ b/library/Zend/Stdlib
@@ -1,0 +1,1 @@
+../../packages/zend-stdlib/library/Zend/Stdlib

--- a/library/Zend/Tag
+++ b/library/Zend/Tag
@@ -1,0 +1,1 @@
+../../packages/zend-tag/library/Zend/Tag

--- a/library/Zend/Test
+++ b/library/Zend/Test
@@ -1,0 +1,1 @@
+../../packages/zend-test/library/Zend/Test

--- a/library/Zend/Text
+++ b/library/Zend/Text
@@ -1,0 +1,1 @@
+../../packages/zend-text/library/Zend/Text

--- a/library/Zend/TimeSync
+++ b/library/Zend/TimeSync
@@ -1,0 +1,1 @@
+../../packages/zend-timesync/library/Zend/TimeSync

--- a/library/Zend/TimeSync.php
+++ b/library/Zend/TimeSync.php
@@ -1,0 +1,1 @@
+../../packages/zend-timesync/library/Zend/TimeSync.php

--- a/library/Zend/Translate
+++ b/library/Zend/Translate
@@ -1,0 +1,1 @@
+../../packages/zend-translate/library/Zend/Translate

--- a/library/Zend/Translate.php
+++ b/library/Zend/Translate.php
@@ -1,0 +1,1 @@
+../../packages/zend-translate/library/Zend/Translate.php

--- a/library/Zend/Uri
+++ b/library/Zend/Uri
@@ -1,0 +1,1 @@
+../../packages/zend-uri/library/Zend/Uri

--- a/library/Zend/Uri.php
+++ b/library/Zend/Uri.php
@@ -1,0 +1,1 @@
+../../packages/zend-uri/library/Zend/Uri.php

--- a/library/Zend/Validate
+++ b/library/Zend/Validate
@@ -1,0 +1,1 @@
+../../packages/zend-validate/library/Zend/Validate

--- a/library/Zend/Validate.php
+++ b/library/Zend/Validate.php
@@ -1,0 +1,1 @@
+../../packages/zend-validate/library/Zend/Validate.php

--- a/library/Zend/Version.php
+++ b/library/Zend/Version.php
@@ -1,0 +1,1 @@
+../../packages/zend-version/library/Zend/Version.php

--- a/library/Zend/View
+++ b/library/Zend/View
@@ -1,0 +1,1 @@
+../../packages/zend-view/library/Zend/View

--- a/library/Zend/View.php
+++ b/library/Zend/View.php
@@ -1,0 +1,1 @@
+../../packages/zend-view/library/Zend/View.php

--- a/library/Zend/Wildfire
+++ b/library/Zend/Wildfire
@@ -1,0 +1,1 @@
+../../packages/zend-wildfire/library/Zend/Wildfire

--- a/library/Zend/Xml
+++ b/library/Zend/Xml
@@ -1,0 +1,1 @@
+../../packages/zend-xml/library/Zend/Xml

--- a/library/Zend/XmlRpc
+++ b/library/Zend/XmlRpc
@@ -1,0 +1,1 @@
+../../packages/zend-xmlrpc/library/Zend/XmlRpc


### PR DESCRIPTION
This allows easier patching and syncing with [zf1 future](https://github.com/Shardj/zf1-future):

In `zf1-future` repo:
1. Extract patch from the other repo: `git format-patch  -1 COMMIT`

In `zf1s` repo:
1. switch to this branch `git checkout symlink-compat`
2. create new branch: `git checkout -b zf1-future/asdf`
3. and apply the patch file `git am 0001-something.patch`
4. rebase without the symlinks commit `git rebase -i origin/master`

an alternative would be to use `cherry-pick`:
1. `git remote add zf1-future https://github.com/Shardj/zf1-future`
2. `git fetch zf1-future`
3. `git cherry-pick COMMIT`