### PR TITLE
Add AllowDynamicProperties Attribute to classes

### DIFF
--- a/packages/zend-application/library/Zend/Application/Bootstrap/Bootstrap.php
+++ b/packages/zend-application/library/Zend/Application/Bootstrap/Bootstrap.php
@@ -37,6 +37,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Application_Bootstrap_Bootstrap
     extends Zend_Application_Bootstrap_BootstrapAbstract
 {

--- a/packages/zend-http/library/Zend/Http/Client.php
+++ b/packages/zend-http/library/Zend/Http/Client.php
@@ -69,6 +69,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Http_Client
 {
     /**

--- a/packages/zend-http/library/Zend/Http/Header/SetCookie.php
+++ b/packages/zend-http/library/Zend/Http/Header/SetCookie.php
@@ -49,6 +49,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Http_Header_SetCookie
 {
 

--- a/packages/zend-json/library/Zend/Json/Decoder.php
+++ b/packages/zend-json/library/Zend/Json/Decoder.php
@@ -32,6 +32,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Json_Decoder
 {
     /**

--- a/packages/zend-loader/library/Zend/Loader/Autoloader/Resource.php
+++ b/packages/zend-loader/library/Zend/Loader/Autoloader/Resource.php
@@ -32,6 +32,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interface
 {
     /**

--- a/packages/zend-pdf/library/Zend/Pdf.php
+++ b/packages/zend-pdf/library/Zend/Pdf.php
@@ -81,6 +81,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf
 {
   /**** Class Constants ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Parser.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Parser.php
@@ -35,6 +35,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Parser
 {
     /**

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/CidFont.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/CidFont.php
@@ -54,6 +54,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 abstract class Zend_Pdf_Resource_Font_CidFont extends Zend_Pdf_Resource_Font
 {
     /**

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Courier extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierBoldOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Helvetica extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -45,6 +45,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBoldOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Symbol extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Instance Variables ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesBoldItalic extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesItalic extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesRoman extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -46,6 +46,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_ZapfDingbats extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Instance Variables ****/

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Type0.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Font/Type0.php
@@ -60,6 +60,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Type0 extends Zend_Pdf_Resource_Font
 {
     /**

--- a/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
@@ -30,6 +30,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Stdlib_CallbackHandler
 {
     /**

--- a/tests/Zend/AllTests/StreamWrapper/PhpInput.php
+++ b/tests/Zend/AllTests/StreamWrapper/PhpInput.php
@@ -49,6 +49,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_AllTests_StreamWrapper_PhpInput
 {
     protected static $_data;

--- a/tests/Zend/Application/Bootstrap/BootstrapTest.php
+++ b/tests/Zend/Application/Bootstrap/BootstrapTest.php
@@ -37,6 +37,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Application
  */
+#[AllowDynamicProperties]
 class Zend_Application_Bootstrap_BootstrapTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Cache/ClassFrontendTest.php
+++ b/tests/Zend/Cache/ClassFrontendTest.php
@@ -78,6 +78,7 @@ class test
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_ClassFrontendTest extends PHPUnit_Framework_TestCase
 {
     private $_instance1;

--- a/tests/Zend/Cache/CoreTest.php
+++ b/tests/Zend/Cache/CoreTest.php
@@ -38,6 +38,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_CoreTest extends PHPUnit_Framework_TestCase
 {
     private $_instance;

--- a/tests/Zend/Cache/FileFrontendTest.php
+++ b/tests/Zend/Cache/FileFrontendTest.php
@@ -35,6 +35,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_FileFrontendTest extends PHPUnit_Framework_TestCase {
 
     private $_instance1;

--- a/tests/Zend/Cache/FunctionFrontendTest.php
+++ b/tests/Zend/Cache/FunctionFrontendTest.php
@@ -55,6 +55,7 @@ class fooclass {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_FunctionFrontendTest extends PHPUnit_Framework_TestCase {
 
     private $_instance;

--- a/tests/Zend/Cache/ManagerTest.php
+++ b/tests/Zend/Cache/ManagerTest.php
@@ -29,6 +29,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Cache_ManagerTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Cache/OutputFrontendTest.php
+++ b/tests/Zend/Cache/OutputFrontendTest.php
@@ -35,6 +35,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_OutputFrontendTest extends PHPUnit_Framework_TestCase {
 
     private $_instance;

--- a/tests/Zend/Cache/PageFrontendTest.php
+++ b/tests/Zend/Cache/PageFrontendTest.php
@@ -35,6 +35,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_PageFrontendTest extends PHPUnit_Framework_TestCase {
 
     private $_instance;

--- a/tests/Zend/Captcha/DumbTest.php
+++ b/tests/Zend/Captcha/DumbTest.php
@@ -36,6 +36,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_DumbTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -122,6 +123,7 @@ class Zend_Captcha_DumbTest extends PHPUnit_Framework_TestCase
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Captcha_DumbTest_SessionContainer
 {
     protected static $_word;

--- a/tests/Zend/Captcha/FigletTest.php
+++ b/tests/Zend/Captcha/FigletTest.php
@@ -37,6 +37,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_FigletTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -315,6 +316,7 @@ class Zend_Captcha_FigletTest extends PHPUnit_Framework_TestCase
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Captcha_FigletTest_SessionContainer
 {
     protected static $_word;

--- a/tests/Zend/Captcha/ReCaptchaTest.php
+++ b/tests/Zend/Captcha/ReCaptchaTest.php
@@ -36,6 +36,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_ReCaptchaTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Config/IniTest.php
+++ b/tests/Zend/Config/IniTest.php
@@ -33,6 +33,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_IniTest extends PHPUnit_Framework_TestCase
 {
     protected $_iniFileConfig;

--- a/tests/Zend/Config/JsonTest.php
+++ b/tests/Zend/Config/JsonTest.php
@@ -32,6 +32,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Config_JsonTest extends PHPUnit_Framework_TestCase
 {
     protected $_iniFileConfig;

--- a/tests/Zend/Config/XmlTest.php
+++ b/tests/Zend/Config/XmlTest.php
@@ -33,6 +33,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_XmlTest extends PHPUnit_Framework_TestCase
 {
     protected $_xmlFileConfig;

--- a/tests/Zend/Config/YamlTest.php
+++ b/tests/Zend/Config/YamlTest.php
@@ -33,6 +33,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_YamlTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
+++ b/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
@@ -50,6 +50,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AjaxContextTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -244,6 +245,7 @@ class ZendTest_Controller_Request_SimpleMock_AjaxTest
          }
 }
 
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AjaxContextTestController extends Zend_Controller_Action
 {
     public $ajaxable = array(

--- a/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
+++ b/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
@@ -49,6 +49,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AutoCompleteTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/CacheTest.php
+++ b/tests/Zend/Controller/Action/Helper/CacheTest.php
@@ -16,6 +16,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
 /**
  * Test class for Zend_Controller_Action_Helper_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_CacheTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
+++ b/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
@@ -51,6 +51,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_ContextSwitchTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -921,6 +922,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends PHPUnit_Framework_
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_ContextSwitchTestController extends Zend_Controller_Action
 {
     public $contextSwitch;

--- a/tests/Zend/Controller/Action/Helper/JsonTest.php
+++ b/tests/Zend/Controller/Action/Helper/JsonTest.php
@@ -46,6 +46,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_JsonTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/RedirectorTest.php
+++ b/tests/Zend/Controller/Action/Helper/RedirectorTest.php
@@ -44,6 +44,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_RedirectorTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/UrlTest.php
+++ b/tests/Zend/Controller/Action/Helper/UrlTest.php
@@ -42,6 +42,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_UrlTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/ActionTest.php
+++ b/tests/Zend/Controller/ActionTest.php
@@ -41,6 +41,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller
  * @group      Zend_Controller_Action
  */
+#[AllowDynamicProperties]
 class Zend_Controller_ActionTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Request/HttpTest.php
+++ b/tests/Zend/Controller/Request/HttpTest.php
@@ -36,6 +36,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller
  * @group      Zend_Controller_Request
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Request_HttpTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Request/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Request/HttpTestCaseTest.php
@@ -39,6 +39,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller
  * @group      Zend_Controller_Request
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Request_HttpTestCaseTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Controller/Response/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Response/HttpTestCaseTest.php
@@ -39,6 +39,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Controller
  * @group      Zend_Controller_Response
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Response_HttpTestCaseTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Crypt/Rsa/RsaTest.php
+++ b/tests/Zend/Crypt/Rsa/RsaTest.php
@@ -31,6 +31,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Crypt
  */
+#[AllowDynamicProperties]
 class Zend_Crypt_RsaTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/CurrencyTest.php
+++ b/tests/Zend/CurrencyTest.php
@@ -35,6 +35,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Currency
  */
+#[AllowDynamicProperties]
 class Zend_CurrencyTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -33,6 +33,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
+#[AllowDynamicProperties]
 class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -53,6 +53,7 @@ if (!defined('TESTS_ZEND_I18N_EXTENDED_COVERAGE')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
+#[AllowDynamicProperties]
 class Zend_DateTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -38,6 +38,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Dom
  */
+#[AllowDynamicProperties]
 class Zend_Dom_QueryTest extends PHPUnit_Framework_TestCase
 {
     public $html;

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -39,6 +39,7 @@ require_once 'Zend/EventManager/TestAsset/MockAggregate.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_EventManagerTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/FilterChainTest.php
+++ b/tests/Zend/EventManager/FilterChainTest.php
@@ -35,6 +35,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_FilterChainTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/GlobalEventManagerTest.php
+++ b/tests/Zend/EventManager/GlobalEventManagerTest.php
@@ -34,6 +34,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_GlobalEventManagerTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -34,6 +34,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_StaticEventManagerTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/StaticIntegrationTest.php
+++ b/tests/Zend/EventManager/StaticIntegrationTest.php
@@ -36,6 +36,7 @@ require_once 'Zend/EventManager/TestAsset/StaticEventsMock.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_StaticIntegrationTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Filter/InflectorTest.php
+++ b/tests/Zend/Filter/InflectorTest.php
@@ -47,6 +47,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_Filter_InflectorTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Filter/PregReplaceTest.php
+++ b/tests/Zend/Filter/PregReplaceTest.php
@@ -42,6 +42,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_Filter_PregReplaceTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/FilterTest.php
+++ b/tests/Zend/FilterTest.php
@@ -34,6 +34,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_FilterTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Form/DisplayGroupTest.php
+++ b/tests/Zend/Form/DisplayGroupTest.php
@@ -46,6 +46,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Form
  */
+#[AllowDynamicProperties]
 class Zend_Form_DisplayGroupTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Http/Client/ClientTest.php
+++ b/tests/Zend/Http/Client/ClientTest.php
@@ -31,6 +31,7 @@
  * @group      Zend_Http
  * @group      Zend_Http_Client
  */
+#[AllowDynamicProperties]
 class Zend_Http_Client_ClientTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -43,6 +43,7 @@
  * @group      Zend_Http_Header
  * @group      ZF-4520
  */
+#[AllowDynamicProperties]
 class Zend_Http_Header_SetCookieTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Http/UserAgentTest.php
+++ b/tests/Zend/Http/UserAgentTest.php
@@ -39,6 +39,7 @@ require_once dirname(__FILE__) . '/TestAsset/PopulatedStorage.php';
  * @group      Zend_Http
  * @group      Zend_Http_UserAgent
  */
+#[AllowDynamicProperties]
 class Zend_Http_UserAgentTest extends PHPUnit_Framework_TestCase
 {
 

--- a/tests/Zend/Json/Server/CacheTest.php
+++ b/tests/Zend/Json/Server/CacheTest.php
@@ -39,6 +39,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_CacheTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/Server/ErrorTest.php
+++ b/tests/Zend/Json/Server/ErrorTest.php
@@ -39,6 +39,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_ErrorTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/Server/RequestTest.php
+++ b/tests/Zend/Json/Server/RequestTest.php
@@ -37,6 +37,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_RequestTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -40,6 +40,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_ResponseTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/Server/Smd/ServiceTest.php
+++ b/tests/Zend/Json/Server/Smd/ServiceTest.php
@@ -40,6 +40,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_Smd_ServiceTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/Server/SmdTest.php
+++ b/tests/Zend/Json/Server/SmdTest.php
@@ -40,6 +40,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_SmdTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -42,6 +42,7 @@ if (!defined("PHPUnit_MAIN_METHOD")) {
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_ServerTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Loader/Autoloader/ResourceTest.php
+++ b/tests/Zend/Loader/Autoloader/ResourceTest.php
@@ -50,6 +50,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_Autoloader_ResourceTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -38,6 +38,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderFactoryTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderMultiVersionTest.php
+++ b/tests/Zend/Loader/AutoloaderMultiVersionTest.php
@@ -37,6 +37,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderMultiVersionTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -42,6 +42,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -34,6 +34,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_ClassMapAutoloaderTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/PluginLoaderTest.php
+++ b/tests/Zend/Loader/PluginLoaderTest.php
@@ -37,6 +37,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_PluginLoaderTest extends PHPUnit_Framework_TestCase
 {
     protected $_includeCache;

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -35,6 +35,7 @@ require_once 'Zend/Loader/TestAsset/StandardAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_StandardAutoloaderTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -43,6 +43,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_LoaderTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/Zend/Log/Filter/ChainingTest.php
+++ b/tests/Zend/Log/Filter/ChainingTest.php
@@ -38,6 +38,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Filter_ChainingTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Log/Filter/SuppressTest.php
+++ b/tests/Zend/Log/Filter/SuppressTest.php
@@ -38,6 +38,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Filter_SuppressTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -44,6 +44,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_LogTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Log/Writer/DbTest.php
+++ b/tests/Zend/Log/Writer/DbTest.php
@@ -35,6 +35,7 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Writer_DbTest extends PHPUnit_Framework_TestCase
 {
     public static function main()

--- a/tests/Zend/Mail/FileTransportTest.php
+++ b/tests/Zend/Mail/FileTransportTest.php
@@ -38,6 +38,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Mail
  */
+#[AllowDynamicProperties]
 class Zend_Mail_FileTransportTest extends PHPUnit_Framework_TestCase
 {
     protected $_params;


### PR DESCRIPTION
_Carry https://github.com/Shardj/zf1-future/pull/278, which was extracted from https://github.com/Shardj/zf1-future/pull/275 which was created by @hungtrinh_:

> To save time, i used [Classes with #[AllowDynamicProperties] attribute](https://php.watch/versions/8.2/dynamic-properties-deprecated#AllowDynamicProperties) to resolve issue Deprecated: Creation of dynamic property {x} is deprecated on PHP 8.2

This is to fix the issue:
> `Deprecated: Creation of dynamic property {x} is deprecated`