### PR TITLE
php 8.1 compat: ReturnTypeWillChange Attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-parallel-lint/php-parallel-lint": "1.3.0",
         "phpunit/dbunit": "1.3.2",
         "staabm/annotate-pull-request-from-checkstyle": "1.5.0",
-        "zf1s/phpunit": "3.7.40"
+        "zf1s/phpunit": "3.7.41"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "ext-xml": "*",
         "ext-zlib": "*",
         "php-parallel-lint/php-parallel-lint": "1.3.0",
-        "phpunit/dbunit": "1.3.2",
         "staabm/annotate-pull-request-from-checkstyle": "1.5.0",
-        "zf1s/phpunit": "3.7.41"
+        "zf1s/dbunit": "1.3.2",
+        "zf1s/phpunit": "3.7.42"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Document.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Document.php
@@ -161,6 +161,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return isset($this->_fields[$name]);
@@ -172,6 +173,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->getField($name);
@@ -184,6 +186,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  mixed $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         $this->setField($name, $value);
@@ -195,6 +198,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         if ($this->offsetExists($name)) {
@@ -231,6 +235,7 @@ class Zend_Cloud_DocumentService_Document
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_fields);
@@ -241,6 +246,7 @@ class Zend_Cloud_DocumentService_Document
      *
      * @return Iterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_fields);

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/DocumentSet.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/DocumentSet.php
@@ -51,6 +51,7 @@ class Zend_Cloud_DocumentService_DocumentSet implements Countable, IteratorAggre
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_documentCount;
@@ -61,6 +62,7 @@ class Zend_Cloud_DocumentService_DocumentSet implements Countable, IteratorAggre
      *
      * @return Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->_documents;

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/ImageList.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/ImageList.php
@@ -87,6 +87,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->images);
@@ -99,6 +100,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return Image
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->images[$this->iteratorKey];
@@ -111,6 +113,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -123,6 +126,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey++;
@@ -135,6 +139,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -147,6 +152,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -164,6 +170,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -178,6 +185,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @throws  Zend_Cloud_Infrastructure_Exception
      * @return  Image
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {
@@ -196,6 +204,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   string  $value
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Cloud/Infrastructure/Exception.php';
@@ -210,6 +219,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   int     $offset
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Cloud/Infrastructure/Exception.php';

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
@@ -88,6 +88,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->instances);
@@ -100,6 +101,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return Instance
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->instances[$this->iteratorKey];
@@ -112,6 +114,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -124,6 +127,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey++;
@@ -136,6 +140,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -148,6 +153,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -165,6 +171,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param  int $offset
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -179,6 +186,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @return Instance
      * @throws Zend_Cloud_Infrastructure_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!$this->offsetExists($offset)) {
@@ -197,6 +205,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param   string  $value
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Cloud/Infrastructure/Exception.php';
@@ -211,6 +220,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param   int     $offset
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Cloud/Infrastructure/Exception.php';

--- a/packages/zend-cloud/library/Zend/Cloud/QueueService/MessageSet.php
+++ b/packages/zend-cloud/library/Zend/Cloud/QueueService/MessageSet.php
@@ -51,6 +51,7 @@ class Zend_Cloud_QueueService_MessageSet implements Countable, IteratorAggregate
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_messageCount;
@@ -61,6 +62,7 @@ class Zend_Cloud_QueueService_MessageSet implements Countable, IteratorAggregate
      *
      * @return Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->_messages;

--- a/packages/zend-config/library/Zend/Config.php
+++ b/packages/zend-config/library/Zend/Config.php
@@ -261,6 +261,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;
@@ -271,6 +272,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->_skipNextIteration = false;
@@ -282,6 +284,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_data);
@@ -291,6 +294,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         if ($this->_skipNextIteration) {
@@ -305,6 +309,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_skipNextIteration = false;
@@ -317,6 +322,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_index < $this->_count;

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/FlashMessenger.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/FlashMessenger.php
@@ -269,6 +269,7 @@ class Zend_Controller_Action_Helper_FlashMessenger extends Zend_Controller_Actio
      *
      * @return ArrayObject
      */
+    #[ReturnTypeWillChange]
     public function getIterator($namespace = null)
     {
         if (!is_string($namespace) || $namespace == '') {
@@ -287,6 +288,7 @@ class Zend_Controller_Action_Helper_FlashMessenger extends Zend_Controller_Actio
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count($namespace = null)
     {
         if (!is_string($namespace) || $namespace == '') {

--- a/packages/zend-controller/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
@@ -88,6 +88,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayObject($this->_helpersByPriority);
@@ -99,6 +100,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * @param int|string $priorityOrHelperName
      * @return Zend_Controller_Action_HelperBroker_PriorityStack
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($priorityOrHelperName)
     {
         if (is_string($priorityOrHelperName)) {
@@ -114,6 +116,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * @param int|string $priorityOrHelperName
      * @return Zend_Controller_Action_HelperBroker_PriorityStack
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($priorityOrHelperName)
     {
         if (!$this->offsetExists($priorityOrHelperName)) {
@@ -135,6 +138,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * @param Zend_Controller_Action_Helper_Abstract $helper
      * @return Zend_Controller_Action_HelperBroker_PriorityStack
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($priority, $helper)
     {
         $priority = (int) $priority;
@@ -172,6 +176,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * @param int|string $priorityOrHelperName Priority integer or the helper name
      * @return Zend_Controller_Action_HelperBroker_PriorityStack
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($priorityOrHelperName)
     {
         if (!$this->offsetExists($priorityOrHelperName)) {
@@ -198,6 +203,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_helpersByPriority);

--- a/packages/zend-crypt/library/Zend/Crypt/Rsa/Key.php
+++ b/packages/zend-crypt/library/Zend/Crypt/Rsa/Key.php
@@ -83,6 +83,7 @@ class Zend_Crypt_Rsa_Key implements Countable
         return $this->toString();
     }
 
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_details['bits'];

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -266,6 +266,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      *
      * @return IteratorIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new IteratorIterator($this->_stmt);

--- a/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
@@ -263,6 +263,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->__isset($offset);
@@ -275,6 +276,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return string
      */
+    #[ReturnTypeWillChange]
      public function offsetGet($offset)
      {
          return $this->__get($offset);
@@ -287,6 +289,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       * @param string $offset
       * @param mixed $value
       */
+     #[ReturnTypeWillChange]
      public function offsetSet($offset, $value)
      {
          $this->__set($offset, $value);
@@ -298,6 +301,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       *
       * @param string $offset
       */
+     #[ReturnTypeWillChange]
      public function offsetUnset($offset)
      {
          return $this->__unset($offset);
@@ -642,6 +646,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
         return $result;
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator((array) $this->_data);

--- a/packages/zend-db/library/Zend/Db/Table/Rowset/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Rowset/Abstract.php
@@ -227,6 +227,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return Zend_Db_Table_Rowset_Abstract Fluent interface.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_pointer = 0;
@@ -240,6 +241,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return Zend_Db_Table_Row_Abstract|null current element from the collection
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if ($this->valid() === false) {
@@ -257,6 +259,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_pointer;
@@ -269,6 +272,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_pointer;
@@ -281,6 +285,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return bool False if there's nothing more to iterate over
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_pointer >= 0 && $this->_pointer < $this->_count;
@@ -293,6 +298,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;
@@ -306,6 +312,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      * @return Zend_Db_Table_Rowset_Abstract
      * @throws Zend_Db_Table_Rowset_Exception
      */
+    #[ReturnTypeWillChange]
     public function seek($position)
     {
         $position = (int) $position;
@@ -324,6 +331,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      * @param string $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_data[(int) $offset]);
@@ -336,6 +344,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      * @param string $offset
      * @return Zend_Db_Table_Row_Abstract
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $offset = (int) $offset;
@@ -355,6 +364,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      * @param string $offset
      * @param mixed $value
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
@@ -365,6 +375,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      *
      * @param string $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }

--- a/packages/zend-dojo/library/Zend/Dojo/Data.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Data.php
@@ -420,6 +420,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string|int $offset
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return (null !== $this->getItem($offset));
@@ -431,6 +432,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string|int $offset
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getItem($offset);
@@ -443,6 +445,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  array|object|null $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->setItem($value, $offset);
@@ -454,6 +457,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string $offset
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->removeItem($offset);
@@ -464,6 +468,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_items);
@@ -474,6 +479,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return string|int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_items);
@@ -484,6 +490,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_items);
@@ -494,6 +501,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->_items);
@@ -504,6 +512,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (bool) $this->current();
@@ -514,6 +523,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_items);

--- a/packages/zend-dom/library/Zend/Dom/Query/Result.php
+++ b/packages/zend-dom/library/Zend/Dom/Query/Result.php
@@ -120,6 +120,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMNode|null
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_position = 0;
@@ -131,6 +132,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if (in_array($this->_position, range(0, $this->_nodeList->length - 1)) && $this->_nodeList->length > 0) {
@@ -144,6 +146,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMElement
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_nodeList->item($this->_position);
@@ -154,6 +157,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_position;
@@ -164,6 +168,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMNode|null
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_position;
@@ -175,6 +180,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_nodeList->length;

--- a/packages/zend-eventmanager/library/Zend/EventManager/Filter/FilterIterator.php
+++ b/packages/zend-eventmanager/library/Zend/EventManager/Filter/FilterIterator.php
@@ -96,6 +96,7 @@ class Zend_EventManager_Filter_FilterIterator extends Zend_Stdlib_SplPriorityQue
      * @param  Zend_EventManager_Filter_FilterIterator $chain
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function next($context = null, array $params = array(), $chain = null)
     {
         if (empty($context) || $chain->isEmpty()) {

--- a/packages/zend-feed/library/Zend/Feed/Abstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Abstract.php
@@ -173,6 +173,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return integer Entry count.
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_entries);
@@ -184,6 +185,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_entryIndex = 0;
@@ -195,6 +197,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The current row, or null if no rows.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new $this->_entryClassName(
@@ -208,6 +211,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The current row number (starts at 0), or NULL if no rows
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_entryIndex;
@@ -219,6 +223,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The next row, or null if no more rows.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_entryIndex;
@@ -230,6 +235,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return boolean Whether the iteration is valid
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->_entryIndex && $this->_entryIndex < $this->count();

--- a/packages/zend-feed/library/Zend/Feed/Element.php
+++ b/packages/zend-feed/library/Zend/Feed/Element.php
@@ -369,6 +369,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         if (strpos($offset, ':') !== false) {
@@ -386,6 +387,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (strpos($offset, ':') !== false) {
@@ -404,6 +406,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $value
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->ensureAppended();
@@ -424,6 +427,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (strpos($offset, ':') !== false) {

--- a/packages/zend-feed/library/Zend/Feed/Reader/Feed/Atom/Source.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/Feed/Atom/Source.php
@@ -67,31 +67,37 @@ class Zend_Feed_Reader_Feed_Atom_Source extends Zend_Feed_Reader_Feed_Atom
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function count() {}
 
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function current() {}
 
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function key() {}
 
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next() {}
 
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind() {}
 
     /**
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function valid() {}
 
     /**

--- a/packages/zend-feed/library/Zend/Feed/Reader/FeedAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/FeedAbstract.php
@@ -136,6 +136,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_entries);
@@ -146,6 +147,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return Zend_Feed_Reader_EntryInterface
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (substr($this->getType(), 0, 3) == 'rss') {
@@ -228,6 +230,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return unknown
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_entriesKey;
@@ -237,6 +240,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      * Move the feed pointer forward
      *
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_entriesKey;
@@ -246,6 +250,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      * Reset the pointer in the feed object
      *
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_entriesKey = 0;
@@ -256,6 +261,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->_entriesKey && $this->_entriesKey < $this->count();

--- a/packages/zend-feed/library/Zend/Feed/Reader/FeedSet.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/FeedSet.php
@@ -132,6 +132,7 @@ class Zend_Feed_Reader_FeedSet extends ArrayObject
      * @return mixed
      * @uses Zend_Feed_Reader
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($offset == 'feed' && !$this->offsetExists('feed')) {

--- a/packages/zend-feed/library/Zend/Feed/Writer/Feed.php
+++ b/packages/zend-feed/library/Zend/Feed/Writer/Feed.php
@@ -200,6 +200,7 @@ implements Iterator, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_entries);
@@ -210,6 +211,7 @@ implements Iterator, Countable
      *
      * @return Zend_Feed_Reader_Entry_Interface
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_entries[$this->key()];
@@ -220,6 +222,7 @@ implements Iterator, Countable
      *
      * @return unknown
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_entriesKey;
@@ -230,6 +233,7 @@ implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_entriesKey;
@@ -240,6 +244,7 @@ implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_entriesKey = 0;
@@ -250,6 +255,7 @@ implements Iterator, Countable
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->_entriesKey && $this->_entriesKey < $this->count();

--- a/packages/zend-file/library/Zend/File/ClassFileLocator.php
+++ b/packages/zend-file/library/Zend/File/ClassFileLocator.php
@@ -71,6 +71,7 @@ class Zend_File_ClassFileLocator extends FilterIterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         $file = $this->getInnerIterator()->current();

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -3272,6 +3272,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @throws Zend_Form_Exception
      * @return Zend_Form_Element|Zend_Form_DisplayGroup|Zend_Form
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->_sort();
@@ -3295,6 +3296,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $this->_sort();
@@ -3306,6 +3308,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_sort();
@@ -3317,6 +3320,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_sort();
@@ -3328,6 +3332,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $this->_sort();
@@ -3339,6 +3344,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_order);

--- a/packages/zend-form/library/Zend/Form/DisplayGroup.php
+++ b/packages/zend-form/library/Zend/Form/DisplayGroup.php
@@ -1046,6 +1046,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return Zend_Form_Element
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->_sort();
@@ -1059,6 +1060,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $this->_sort();
@@ -1070,6 +1072,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_sort();
@@ -1081,6 +1084,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_sort();
@@ -1092,6 +1096,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $this->_sort();
@@ -1103,6 +1108,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_elements);

--- a/packages/zend-gdata/library/Zend/Gdata/App/Feed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App/Feed.php
@@ -129,6 +129,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return integer Entry count.
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_entry);
@@ -139,6 +140,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_entryIndex = 0;
@@ -149,6 +151,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The current row, or null if no rows.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_entry[$this->_entryIndex];
@@ -159,6 +162,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The current row number (starts at 0), or NULL if no rows
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_entryIndex;
@@ -169,6 +173,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The next row, or null if no more rows.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_entryIndex;
@@ -179,6 +184,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return boolean Whether the iteration is valid
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->_entryIndex && $this->_entryIndex < $this->count();
@@ -228,6 +234,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param Zend_Gdata_App_Entry $value The value to set
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->_entry[$key] = $value;
@@ -239,6 +246,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to get
      * @param Zend_Gdata_App_Entry $value The value to set
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($key)
     {
         if (array_key_exists($key, $this->_entry)) {
@@ -252,6 +260,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to set
      * @param Zend_Gdata_App_Entry $value The value to set
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         if (array_key_exists($key, $this->_entry)) {
@@ -265,6 +274,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to check for existence
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return (array_key_exists($key, $this->_entry));

--- a/packages/zend-http/library/Zend/Http/CookieJar.php
+++ b/packages/zend-http/library/Zend/Http/CookieJar.php
@@ -390,6 +390,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_rawCookies);
@@ -400,6 +401,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return ArrayIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_rawCookies);

--- a/packages/zend-ldap/library/Zend/Ldap.php
+++ b/packages/zend-ldap/library/Zend/Ldap.php
@@ -1056,6 +1056,7 @@ class Zend_Ldap
      * @return integer
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function count($filter, $basedn = null, $scope = self::SEARCH_SCOPE_SUB)
     {
         try {

--- a/packages/zend-ldap/library/Zend/Ldap/Collection.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Collection.php
@@ -120,6 +120,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_iterator->count();
@@ -132,6 +133,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      * @return array|null
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if ($this->count() > 0) {
@@ -185,6 +187,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return int|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         if ($this->count() > 0) {
@@ -203,6 +206,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_iterator->next();
@@ -215,6 +219,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_iterator->rewind();
@@ -228,6 +233,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if (isset($this->_cache[$this->_current])) {

--- a/packages/zend-ldap/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -177,6 +177,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_itemCount;
@@ -189,6 +190,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      * @return array|null
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (!is_resource($this->_current)) {
@@ -234,6 +236,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return string|null
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         if (!is_resource($this->_current)) {
@@ -258,6 +261,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         if (is_resource($this->_current) && $this->_itemCount > 0) {
@@ -284,6 +288,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         if (is_resource($this->_resultId)) {
@@ -304,6 +309,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (is_resource($this->_current));

--- a/packages/zend-ldap/library/Zend/Ldap/Dn.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Dn.php
@@ -417,6 +417,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @param  int $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $offset = (int)$offset;
@@ -434,6 +435,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @param  int $offset
      * @return array
      */
+    #[ReturnTypeWillChange]
      public function offsetGet($offset)
      {
          return $this->get($offset, 1, null);
@@ -446,6 +448,7 @@ class Zend_Ldap_Dn implements ArrayAccess
       * @param int   $offset
       * @param array $value
       */
+     #[ReturnTypeWillChange]
      public function offsetSet($offset, $value)
      {
          $this->set($offset, $value);
@@ -457,6 +460,7 @@ class Zend_Ldap_Dn implements ArrayAccess
       *
       * @param int $offset
       */
+     #[ReturnTypeWillChange]
      public function offsetUnset($offset)
      {
          $this->remove($offset, 1);

--- a/packages/zend-ldap/library/Zend/Ldap/Node.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node.php
@@ -874,6 +874,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return null
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         $this->setAttribute($name, $value);
@@ -891,6 +892,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return null
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         $this->deleteAttribute($name);
@@ -1006,6 +1008,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return boolean
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         if (!is_array($this->_children)) {
@@ -1027,6 +1030,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node_ChildrenIterator
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         if (!is_array($this->_children)) {
@@ -1069,6 +1073,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this;
@@ -1080,6 +1085,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->getRdnString();
@@ -1089,6 +1095,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * Move forward to next attribute.
      * Implements Iterator
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_iteratorRewind = false;
@@ -1098,6 +1105,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * Rewind the Iterator to the first attribute.
      * Implements Iterator
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_iteratorRewind = true;
@@ -1110,6 +1118,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_iteratorRewind;

--- a/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
@@ -421,6 +421,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @return null
      * @throws BadMethodCallException
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         throw new BadMethodCallException();
@@ -436,6 +437,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @return array
      * @throws Zend_Ldap_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->getAttribute($name, null);
@@ -453,6 +455,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @return null
      * @throws BadMethodCallException
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         throw new BadMethodCallException();
@@ -467,6 +470,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @param  string $name
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return $this->existsAttribute($name, false);
@@ -478,6 +482,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_currentData);

--- a/packages/zend-ldap/library/Zend/Ldap/Node/ChildrenIterator.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/ChildrenIterator.php
@@ -60,6 +60,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);
@@ -71,6 +72,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return Zend_Ldap_Node
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_data);
@@ -82,6 +84,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_data);
@@ -91,6 +94,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * Move forward to next child.
      * Implements Iterator
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->_data);
@@ -100,6 +104,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * Rewind the Iterator to the first child.
      * Implements Iterator
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_data);
@@ -112,6 +117,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (current($this->_data)!==false);
@@ -137,6 +143,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return Zend_Ldap_Node_ChildrenIterator
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         if ($this->current() instanceof Zend_Ldap_Node) {
@@ -153,6 +160,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $rdn
      * @return Zend_Ldap_node
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($rdn)
     {
         if ($this->offsetExists($rdn)) {
@@ -169,6 +177,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $rdn
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($rdn)
     {
         return (array_key_exists($rdn, $this->_data));
@@ -181,6 +190,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $name
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($name) { }
 
     /**
@@ -191,6 +201,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  mixed $value
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($name, $value) { }
 
     /**

--- a/packages/zend-ldap/library/Zend/Ldap/Node/Collection.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/Collection.php
@@ -60,6 +60,7 @@ class Zend_Ldap_Node_Collection extends Zend_Ldap_Collection
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_iterator->key();

--- a/packages/zend-ldap/library/Zend/Ldap/Node/Schema/Item.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/Schema/Item.php
@@ -108,6 +108,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @return null
      * @throws BadMethodCallException
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         throw new BadMethodCallException();
@@ -119,6 +120,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @param  string $name
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->__get($name);
@@ -134,6 +136,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @return null
      * @throws BadMethodCallException
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         throw new BadMethodCallException();
@@ -145,6 +148,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @param  string $name
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return $this->__isset($name);
@@ -156,6 +160,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);

--- a/packages/zend-mail/library/Zend/Mail/Part.php
+++ b/packages/zend-mail/library/Zend/Mail/Part.php
@@ -509,6 +509,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return bool current element has children/is multipart
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         $current = $this->current();
@@ -520,6 +521,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return Zend_Mail_Part same as self::current()
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->current();
@@ -530,6 +532,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return bool check if there's a current element
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if ($this->_countParts === null) {
@@ -543,6 +546,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_iterationPos;
@@ -553,6 +557,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return string key/number of current part
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_iterationPos;
@@ -563,6 +568,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return Zend_Mail_Part current part
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->getPart($this->_iterationPos);
@@ -573,6 +579,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
      *
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->countParts();
@@ -582,6 +589,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface, Cou
     /**
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->countParts();

--- a/packages/zend-mail/library/Zend/Mail/Storage/Abstract.php
+++ b/packages/zend-mail/library/Zend/Mail/Storage/Abstract.php
@@ -215,6 +215,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
      *
      * @return   int
      */
+     #[ReturnTypeWillChange]
      public function count()
      {
         return $this->countMessages();
@@ -227,6 +228,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int     $id
       * @return   boolean
       */
+     #[ReturnTypeWillChange]
      public function offsetExists($id)
      {
         try {
@@ -245,6 +247,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int $id
       * @return   Zend_Mail_Message message object
       */
+    #[ReturnTypeWillChange]
      public function offsetGet($id)
      {
         return $this->getMessage($id);
@@ -259,6 +262,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @throws   Zend_Mail_Storage_Exception
       * @return   void
       */
+     #[ReturnTypeWillChange]
      public function offsetSet($id, $value)
      {
         /**
@@ -275,6 +279,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int   $id
       * @return   boolean success
       */
+     #[ReturnTypeWillChange]
      public function offsetUnset($id)
      {
         return $this->removeMessage($id);
@@ -290,6 +295,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   void
       */
+     #[ReturnTypeWillChange]
      public function rewind()
      {
         $this->_iterationMax = $this->countMessages();
@@ -302,6 +308,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   Zend_Mail_Message current message
       */
+     #[ReturnTypeWillChange]
      public function current()
      {
         return $this->getMessage($this->_iterationPos);
@@ -313,6 +320,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   int id of current position
       */
+     #[ReturnTypeWillChange]
      public function key()
      {
         return $this->_iterationPos;
@@ -324,6 +332,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   void
       */
+     #[ReturnTypeWillChange]
      public function next()
      {
         ++$this->_iterationPos;
@@ -335,6 +344,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   boolean
       */
+     #[ReturnTypeWillChange]
      public function valid()
      {
         if ($this->_iterationMax === null) {
@@ -351,6 +361,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @return void
       * @throws OutOfBoundsException
       */
+    #[ReturnTypeWillChange]
      public function seek($pos)
      {
         if ($this->_iterationMax === null) {

--- a/packages/zend-mail/library/Zend/Mail/Storage/Folder.php
+++ b/packages/zend-mail/library/Zend/Mail/Storage/Folder.php
@@ -75,6 +75,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return bool current element has children
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         $current = $this->current();
@@ -86,6 +87,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return Zend_Mail_Storage_Folder same as self::current()
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->current();
@@ -96,6 +98,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return bool check if there's a current element
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return key($this->_folders) !== null;
@@ -106,6 +109,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->_folders);
@@ -116,6 +120,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return string key/local name of current element
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_folders);
@@ -126,6 +131,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return Zend_Mail_Storage_Folder current folder
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_folders);
@@ -136,6 +142,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_folders);

--- a/packages/zend-markup/library/Zend/Markup/TokenList.php
+++ b/packages/zend-markup/library/Zend/Markup/TokenList.php
@@ -45,6 +45,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_Token
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_tokens);
@@ -55,6 +56,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_TokenList
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return current($this->_tokens)->getChildren();
@@ -77,6 +79,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return current($this->_tokens)->hasChildren();
@@ -87,6 +90,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_tokens);
@@ -97,6 +101,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_Token
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_tokens);
@@ -107,6 +112,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_tokens);
@@ -117,6 +123,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;

--- a/packages/zend-memory/library/Zend/Memory/Value.php
+++ b/packages/zend-memory/library/Zend/Memory/Value.php
@@ -86,6 +86,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $offset >= 0  &&  $offset < strlen($this->_value);
@@ -98,6 +99,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_value[$offset];
@@ -110,6 +112,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @param string $char
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $char)
     {
         $this->_value[$offset] = $char;
@@ -126,6 +129,7 @@ class Zend_Memory_Value implements ArrayAccess {
      *
      * @param integer $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_value[$offset]);

--- a/packages/zend-navigation/library/Zend/Navigation/Container.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Container.php
@@ -509,6 +509,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      * @return Zend_Navigation_Page       current page or null
      * @throws Zend_Navigation_Exception  if the index is invalid
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $this->_sort();
@@ -532,6 +533,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return string  hash code of current page
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $this->_sort();
@@ -545,6 +547,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_sort();
@@ -558,6 +561,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_sort();
@@ -571,6 +575,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $this->_sort();
@@ -584,6 +589,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return $this->hasPages();
@@ -596,6 +602,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return Zend_Navigation_Page|null
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         $hash = key($this->_index);
@@ -616,6 +623,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return int  number of pages in the container
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_index);

--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -514,6 +514,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if (!$this->_pageCount) {
@@ -818,6 +819,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      *
      * @return Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getCurrentItems();

--- a/packages/zend-paginator/library/Zend/Paginator/Adapter/Array.php
+++ b/packages/zend-paginator/library/Zend/Paginator/Adapter/Array.php
@@ -74,6 +74,7 @@ class Zend_Paginator_Adapter_Array implements Zend_Paginator_Adapter_Interface
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;

--- a/packages/zend-paginator/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/packages/zend-paginator/library/Zend/Paginator/Adapter/DbSelect.php
@@ -175,6 +175,7 @@ class Zend_Paginator_Adapter_DbSelect implements Zend_Paginator_Adapter_Interfac
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->_rowCount === null) {

--- a/packages/zend-paginator/library/Zend/Paginator/Adapter/Iterator.php
+++ b/packages/zend-paginator/library/Zend/Paginator/Adapter/Iterator.php
@@ -95,6 +95,7 @@ class Zend_Paginator_Adapter_Iterator implements Zend_Paginator_Adapter_Interfac
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;

--- a/packages/zend-paginator/library/Zend/Paginator/Adapter/Null.php
+++ b/packages/zend-paginator/library/Zend/Paginator/Adapter/Null.php
@@ -73,6 +73,7 @@ class Zend_Paginator_Adapter_Null implements Zend_Paginator_Adapter_Interface
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;

--- a/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
+++ b/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
@@ -86,6 +86,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      * @param int $offset
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $currentOffset = $this->key();
@@ -102,6 +103,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      * @param int $offset
      * @param mixed $value
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
@@ -111,6 +113,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      *
      * @param int $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         if ($offset > 0 && $offset < $this->_count) {
@@ -136,6 +139,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      *
      * @param int $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }

--- a/packages/zend-pdf/library/Zend/Pdf/Action.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Action.php
@@ -326,6 +326,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return Zend_Pdf_Action
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->next);
@@ -336,6 +337,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->next);
@@ -344,6 +346,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
     /**
      * Go to next child
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->next);
@@ -352,6 +355,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
     /**
      * Rewind children
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->next);
@@ -362,6 +366,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current($this->next) !== false;
@@ -372,6 +377,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return Zend_Pdf_Action|null
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return current($this->next);
@@ -382,6 +388,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return bool  whether container has any pages
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return count($this->next) > 0;
@@ -397,6 +404,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->childOutlines);

--- a/packages/zend-pdf/library/Zend/Pdf/NameTree.php
+++ b/packages/zend-pdf/library/Zend/Pdf/NameTree.php
@@ -85,47 +85,54 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
         }
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_items);
     }
 
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_items);
     }
 
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_items);
     }
 
 
+    #[ReturnTypeWillChange]
     public function valid() {
         return current($this->_items)!==false;
     }
 
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_items);
     }
 
 
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->_items);
     }
 
-
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_items[$offset];
     }
 
 
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
@@ -136,6 +143,7 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
     }
 
 
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_items[$offset]);
@@ -147,6 +155,7 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
         $this->_items = array();
     }
 
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_items);

--- a/packages/zend-pdf/library/Zend/Pdf/Outline.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline.php
@@ -295,6 +295,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return Zend_Pdf_Outline
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->childOutlines);
@@ -305,6 +306,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->childOutlines);
@@ -313,6 +315,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
     /**
      * Go to next child
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->childOutlines);
@@ -321,6 +324,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
     /**
      * Rewind children
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->childOutlines);
@@ -331,6 +335,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current($this->childOutlines) !== false;
@@ -341,6 +346,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return Zend_Pdf_Outline|null
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return current($this->childOutlines);
@@ -351,6 +357,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return count($this->childOutlines) > 0;
@@ -366,6 +373,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->childOutlines);

--- a/packages/zend-pdf/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
+++ b/packages/zend-pdf/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
@@ -33,13 +33,21 @@ class Zend_Pdf_RecursivelyIteratableObjectsContainer implements RecursiveIterato
 
     public function __construct(array $objects) { $this->_objects = $objects; }
 
+    #[ReturnTypeWillChange]
     public function current()      { return current($this->_objects);            }
+    #[ReturnTypeWillChange]
     public function key()          { return key($this->_objects);                }
+    #[ReturnTypeWillChange]
     public function next()         { return next($this->_objects);               }
+    #[ReturnTypeWillChange]
     public function rewind()       { return reset($this->_objects);              }
+    #[ReturnTypeWillChange]
     public function valid()        { return current($this->_objects) !== false;  }
+    #[ReturnTypeWillChange]
     public function getChildren()  { return current($this->_objects);            }
+    #[ReturnTypeWillChange]
     public function hasChildren()  { return count($this->_objects) > 0;          }
 
+    #[ReturnTypeWillChange]
     public function count() { return count($this->_objects); }
 }

--- a/packages/zend-progressbar/library/Zend/ProgressBar.php
+++ b/packages/zend-progressbar/library/Zend/ProgressBar.php
@@ -188,6 +188,7 @@ class Zend_ProgressBar
      * @param  string $text
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next($diff = 1, $text = null)
     {
         $this->update(max($this->_min, min($this->_max, $this->_current + $diff)), $text);

--- a/packages/zend-queue/library/Zend/Queue.php
+++ b/packages/zend-queue/library/Zend/Queue.php
@@ -421,6 +421,7 @@ class Zend_Queue implements Countable
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->getAdapter()->isSupported('count')) {

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
@@ -344,6 +344,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * @return integer
      * @throws Zend_Queue_Exception (not supported)
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';

--- a/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
@@ -107,6 +107,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue|null $queue
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue = null);
 
     /********************************************************************

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
@@ -136,6 +136,7 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @return integer
      * @throws Zend_Queue_Exception
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue=null)
     {
         if ($queue === null) {

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
@@ -288,6 +288,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @return integer
      * @throws Zend_Queue_Exception
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue = null)
     {
         if ($queue === null) {

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
@@ -231,6 +231,7 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * @return integer
      * @throws Zend_Queue_Exception (not supported)
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
@@ -102,6 +102,7 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @throws Zend_Queue_Exception - not supported.
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';

--- a/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -151,6 +151,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @param  Zend_Queue|null $queue
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count(Zend_Queue $queue = null)
     {
         if ($queue !== null) {

--- a/packages/zend-queue/library/Zend/Queue/Message/Iterator.php
+++ b/packages/zend-queue/library/Zend/Queue/Message/Iterator.php
@@ -212,6 +212,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_pointer = 0;
@@ -224,6 +225,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return Zend_Queue_Message current element from the collection
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return (($this->valid() === false)
@@ -238,6 +240,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_pointer;
@@ -250,6 +253,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->_pointer;
@@ -262,6 +266,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return bool False if there's nothing more to iterate over
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_pointer < count($this);
@@ -278,6 +283,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);

--- a/packages/zend-reflection/library/Zend/Reflection/Class.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Class.php
@@ -85,6 +85,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -118,6 +119,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getInterfaces($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflections  = parent::getInterfaces();
@@ -142,6 +144,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Reflection class to utilize
      * @return Zend_Reflection_Method
      */
+    #[ReturnTypeWillChange]
     public function getMethod($name, $reflectionClass = 'Zend_Reflection_Method')
     {
         $phpReflection  = parent::getMethod($name);
@@ -163,6 +166,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Reflection class to use for methods
      * @return array Array of Zend_Reflection_Method objects
      */
+    #[ReturnTypeWillChange]
     public function getMethods($filter = -1, $reflectionClass = 'Zend_Reflection_Method')
     {
         $phpReflections  = parent::getMethods($filter);
@@ -186,6 +190,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of Reflection class to use
      * @return Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getParentClass($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflection = parent::getParentClass();
@@ -209,6 +214,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return Zend_Reflection_Property
      */
+    #[ReturnTypeWillChange]
     public function getProperty($name, $reflectionClass = 'Zend_Reflection_Property')
     {
         $phpReflection  = parent::getProperty($name);
@@ -228,6 +234,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Property
      */
+    #[ReturnTypeWillChange]
     public function getProperties($filter = -1, $reflectionClass = 'Zend_Reflection_Property')
     {
         $phpReflections = parent::getProperties($filter);

--- a/packages/zend-reflection/library/Zend/Reflection/Extension.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Extension.php
@@ -43,6 +43,7 @@ class Zend_Reflection_Extension extends ReflectionExtension
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Function objects
      */
+    #[ReturnTypeWillChange]
     public function getFunctions($reflectionClass = 'Zend_Reflection_Function')
     {
         $phpReflections  = parent::getFunctions();
@@ -66,6 +67,7 @@ class Zend_Reflection_Extension extends ReflectionExtension
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Class objects
      */
+    #[ReturnTypeWillChange]
     public function getClasses($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflections  = parent::getClasses();

--- a/packages/zend-reflection/library/Zend/Reflection/Function.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Function.php
@@ -58,6 +58,7 @@ class Zend_Reflection_Function extends ReflectionFunction
      * @param  bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -93,6 +94,7 @@ class Zend_Reflection_Function extends ReflectionFunction
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Parameter
      */
+    #[ReturnTypeWillChange]
     public function getParameters($reflectionClass = 'Zend_Reflection_Parameter')
     {
         $phpReflections  = parent::getParameters();

--- a/packages/zend-reflection/library/Zend/Reflection/Method.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Method.php
@@ -69,6 +69,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  bool $includeDocComment
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -86,6 +87,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  string $reflectionClass Name of reflection class to use
      * @return Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflection  = parent::getDeclaringClass();
@@ -104,6 +106,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  string $reflectionClass Name of reflection class to use
      * @return array of Zend_Reflection_Parameter objects
      */
+    #[ReturnTypeWillChange]
     public function getParameters($reflectionClass = 'Zend_Reflection_Parameter')
     {
         $phpReflections  = parent::getParameters();

--- a/packages/zend-reflection/library/Zend/Reflection/Parameter.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Parameter.php
@@ -38,6 +38,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflection  = parent::getDeclaringClass();
@@ -56,6 +57,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getClass($reflectionClass = 'Zend_Reflection_Class')
     {
         if (PHP_VERSION_ID < 80000) {
@@ -88,6 +90,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Function|Zend_Reflection_Method
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringFunction($reflectionClass = null)
     {
         $phpReflection = parent::getDeclaringFunction();
@@ -117,6 +120,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function getType()
     {
         try {

--- a/packages/zend-reflection/library/Zend/Reflection/Property.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Property.php
@@ -33,6 +33,7 @@ class Zend_Reflection_Property extends ReflectionProperty
      *
      * @return Zend_Reflection_Class
      */
+    #[ReturnTypeWillChange]
     public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflection  = parent::getDeclaringClass();
@@ -51,6 +52,7 @@ class Zend_Reflection_Property extends ReflectionProperty
      * @param  string $reflectionClass
      * @return Zend_Reflection_Docblock|false False if no docblock defined
      */
+    #[ReturnTypeWillChange]
     public function getDocComment($reflectionClass = 'Zend_Reflection_Docblock')
     {
         $docblock = parent::getDocComment();

--- a/packages/zend-rest/library/Zend/Rest/Client/Result.php
+++ b/packages/zend-rest/library/Zend/Rest/Client/Result.php
@@ -169,6 +169,7 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
      *
      * @return SimpleXMLIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->_sxml;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene.php
@@ -670,6 +670,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_docCount;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/SegmentInfo.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/SegmentInfo.php
@@ -684,6 +684,7 @@ class Zend_Search_Lucene_Index_SegmentInfo implements Zend_Search_Lucene_Index_T
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_docCount;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/SegmentWriter.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/SegmentWriter.php
@@ -257,6 +257,7 @@ abstract class Zend_Search_Lucene_Index_SegmentWriter
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_docCount;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/Term.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Index/Term.php
@@ -67,6 +67,7 @@ class Zend_Search_Lucene_Index_Term
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->field . chr(0) . $this->text;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Interface.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Interface.php
@@ -93,6 +93,7 @@ interface Zend_Search_Lucene_Interface extends Zend_Search_Lucene_Index_TermsStr
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count();
 
     /**

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/MultiSearcher.php
@@ -145,6 +145,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $count = 0;

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Proxy.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Proxy.php
@@ -129,6 +129,7 @@ class Zend_Search_Lucene_Proxy implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_index->count();

--- a/packages/zend-server/library/Zend/Server/Definition.php
+++ b/packages/zend-server/library/Zend/Server/Definition.php
@@ -210,6 +210,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_methods);
@@ -220,6 +221,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_methods);
@@ -230,6 +232,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return int|string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_methods);
@@ -240,6 +243,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_methods);
@@ -250,6 +254,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->_methods);
@@ -260,6 +265,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (bool) $this->current();

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/ResultSet.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/ResultSet.php
@@ -106,6 +106,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return Zend_Service_Amazon_Item
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Amazon_Item($this->_results->item($this->_currentIndex));
@@ -116,6 +117,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_currentIndex;
@@ -126,6 +128,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_currentIndex += 1;
@@ -136,6 +139,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_currentIndex = 0;
@@ -148,6 +152,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      * @throws OutOfBoundsException
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function seek($index)
     {
         $indexInt = (int) $index;
@@ -163,6 +168,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->_results && $this->_currentIndex < $this->_results->length;

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/Sqs.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/Sqs.php
@@ -262,6 +262,7 @@ class Zend_Service_Amazon_Sqs extends Zend_Service_Amazon_Abstract
      * @return integer
      * @throws Zend_Service_Amazon_Sqs_Exception
      */
+    #[ReturnTypeWillChange]
     public function count($queue_url)
     {
         return (int)$this->getAttribute($queue_url, 'ApproximateNumberOfMessages');

--- a/packages/zend-service-delicious/library/Zend/Service/Delicious/PostList.php
+++ b/packages/zend-service-delicious/library/Zend/Service/Delicious/PostList.php
@@ -161,6 +161,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_posts);
@@ -173,6 +174,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return Zend_Service_Delicious_SimplePost
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_posts[$this->_iteratorKey];
@@ -185,6 +187,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_iteratorKey;
@@ -197,6 +200,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_iteratorKey += 1;
@@ -209,6 +213,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_iteratorKey = 0;
@@ -221,6 +226,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -240,6 +246,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -254,6 +261,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @throws  OutOfBoundsException
      * @return  Zend_Service_Delicious_SimplePost
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -272,6 +280,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   string  $value
      * @throws  Zend_Service_Delicious_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         /**
@@ -289,6 +298,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   int     $offset
      * @throws  Zend_Service_Delicious_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         /**

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
@@ -40,6 +40,7 @@ class Zend_Service_Ebay_Finding_Aspect_Histogram_Value_Set extends Zend_Service_
      *
      * @return Zend_Service_Ebay_Finding_Aspect_Histogram_Value
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         // check node

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Aspect/Set.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Aspect/Set.php
@@ -40,6 +40,7 @@ class Zend_Service_Ebay_Finding_Aspect_Set extends Zend_Service_Ebay_Finding_Set
      *
      * @return Zend_Service_Ebay_Finding_Aspect
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         // check node

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
@@ -40,6 +40,7 @@ class Zend_Service_Ebay_Finding_Category_Histogram_Set extends Zend_Service_Ebay
      *
      * @return Zend_Service_Ebay_Finding_Category_Histogram
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         // check node

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Error/Data/Set.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Error/Data/Set.php
@@ -40,6 +40,7 @@ class Zend_Service_Ebay_Finding_Error_Data_Set extends Zend_Service_Ebay_Finding
      *
      * @return Zend_Service_Ebay_Finding_Error_Data
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         // check node

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Search/Item/Set.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Search/Item/Set.php
@@ -40,6 +40,7 @@ class Zend_Service_Ebay_Finding_Search_Item_Set extends Zend_Service_Ebay_Findin
      *
      * @return Zend_Service_Ebay_Finding_Search_Item
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         // check node

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Set/Abstract.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding/Set/Abstract.php
@@ -67,6 +67,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      * @throws OutOfBoundsException When $key is not seekable
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function seek($key)
     {
         if ($key < 0 || $key >= $this->count()) {
@@ -81,6 +82,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -91,6 +93,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_key++;
@@ -101,6 +104,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_key = 0;
@@ -111,6 +115,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_key >= 0 && $this->_key < $this->count();
@@ -121,6 +126,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->_nodes ? $this->_nodes->length : 0;

--- a/packages/zend-service-flickr/library/Zend/Service/Flickr/ResultSet.php
+++ b/packages/zend-service-flickr/library/Zend/Service/Flickr/ResultSet.php
@@ -123,6 +123,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return Zend_Service_Flickr_Result
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Flickr_Result($this->_results->item($this->_currentIndex), $this->_flickr);
@@ -133,6 +134,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_currentIndex;
@@ -143,6 +145,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_currentIndex += 1;
@@ -153,6 +156,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_currentIndex = 0;
@@ -165,6 +169,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      * @throws OutOfBoundsException
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function seek($index)
     {
         $indexInt = (int) $index;
@@ -180,6 +185,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return null !== $this->_results && $this->_currentIndex < $this->_results->length;

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Files/ContainerList.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Files/ContainerList.php
@@ -95,6 +95,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->objects);
@@ -106,6 +107,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return Zend_Service_Rackspace_Files_Container
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->objects[$this->iteratorKey];
@@ -117,6 +119,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -128,6 +131,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey += 1;
@@ -139,6 +143,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -150,6 +155,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -167,6 +173,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -180,6 +187,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @throws  Zend_Service_Rackspace_Files_Exception
      * @return  Zend_Service_Rackspace_Files_Container
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -199,6 +207,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Service/Rackspace/Files/Exception.php';
@@ -213,6 +222,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Service/Rackspace/Files/Exception.php';

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Files/ObjectList.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Files/ObjectList.php
@@ -111,6 +111,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->objects);
@@ -122,6 +123,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return Zend_Service_Rackspace_Files_Object
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->objects[$this->iteratorKey];
@@ -133,6 +135,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -144,6 +147,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey += 1;
@@ -155,6 +159,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -166,6 +171,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -183,6 +189,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -196,6 +203,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @throws  Zend_Service_Rackspace_Files_Exception
      * @return  Zend_Service_Rackspace_Files_Object
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -215,6 +223,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Service/Rackspace/Files/Exception.php';
@@ -229,6 +238,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Service/Rackspace/Files/Exception.php';

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/ImageList.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/ImageList.php
@@ -108,6 +108,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->images);
@@ -119,6 +120,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return Zend_Service_Rackspace_Servers_Image
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->images[$this->iteratorKey];
@@ -130,6 +132,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -141,6 +144,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey += 1;
@@ -152,6 +156,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -163,6 +168,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -180,6 +186,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -193,6 +200,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_Image
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -212,6 +220,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';
@@ -226,6 +235,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/ServerList.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/ServerList.php
@@ -109,6 +109,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->servers);
@@ -120,6 +121,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return Zend_Service_Rackspace_Servers_Server
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->servers[$this->iteratorKey];
@@ -131,6 +133,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -142,6 +145,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey += 1;
@@ -153,6 +157,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -164,6 +169,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -181,6 +187,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   int     $offset
      * @return  bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -194,6 +201,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_Server
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -213,6 +221,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';
@@ -227,6 +236,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
@@ -108,6 +108,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->shared);
@@ -119,6 +120,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return Zend_Service_Rackspace_Servers_SharedIpGroup
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->shared[$this->iteratorKey];
@@ -130,6 +132,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKey;
@@ -141,6 +144,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorKey += 1;
@@ -152,6 +156,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorKey = 0;
@@ -163,6 +168,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         $numItems = $this->count();
@@ -180,6 +186,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param   int     $offset
      * @return  boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return ($offset < $this->count());
@@ -193,6 +200,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_SharedIpGroup
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -212,6 +220,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';
@@ -226,6 +235,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param  int $offset
      * @throws Zend_Service_Rackspace_Servers_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // require_once 'Zend/Service/Rackspace/Servers/Exception.php';

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/ImageResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/ImageResultSet.php
@@ -56,6 +56,7 @@ class Zend_Service_Yahoo_ImageResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_ImageResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_ImageResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/InlinkDataResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/InlinkDataResultSet.php
@@ -55,6 +55,7 @@ class Zend_Service_Yahoo_InlinkDataResultSet extends Zend_Service_Yahoo_ResultSe
      *
      * @return Zend_Service_Yahoo_InlinkDataResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_InlinkDataResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/LocalResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/LocalResultSet.php
@@ -77,6 +77,7 @@ class Zend_Service_Yahoo_LocalResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_LocalResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_LocalResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/NewsResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/NewsResultSet.php
@@ -56,6 +56,7 @@ class Zend_Service_Yahoo_NewsResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_NewsResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_NewsResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/PageDataResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/PageDataResultSet.php
@@ -55,6 +55,7 @@ class Zend_Service_Yahoo_PageDataResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_WebResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_PageDataResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/ResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/ResultSet.php
@@ -121,6 +121,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      * @throws Zend_Service_Exception
      * @return Zend_Service_Yahoo_Result
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         /**
@@ -137,6 +138,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_currentIndex;
@@ -148,6 +150,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_currentIndex += 1;
@@ -159,6 +162,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_currentIndex = 0;
@@ -172,6 +176,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      * @return void
      * @throws OutOfBoundsException
      */
+    #[ReturnTypeWillChange]
     public function seek($index)
     {
         $indexInt = (int) $index;
@@ -188,6 +193,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_currentIndex < $this->_results->length;

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/VideoResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/VideoResultSet.php
@@ -56,6 +56,7 @@ class Zend_Service_Yahoo_VideoResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_VideoResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_VideoResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-service-yahoo/library/Zend/Service/Yahoo/WebResultSet.php
+++ b/packages/zend-service-yahoo/library/Zend/Service/Yahoo/WebResultSet.php
@@ -56,6 +56,7 @@ class Zend_Service_Yahoo_WebResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_WebResult
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return new Zend_Service_Yahoo_WebResult($this->_results->item($this->_currentIndex));

--- a/packages/zend-session/library/Zend/Session/Namespace.php
+++ b/packages/zend-session/library/Zend/Session/Namespace.php
@@ -207,6 +207,7 @@ class Zend_Session_Namespace extends Zend_Session_Abstract implements IteratorAg
      *
      * @return ArrayObject - iteratable container of the namespace contents
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayObject(parent::_namespaceGetAll($this->_namespace));

--- a/packages/zend-stdlib/library/Zend/Stdlib/PriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/PriorityQueue.php
@@ -134,6 +134,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      * 
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
@@ -171,6 +172,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      * 
      * @return SplPriorityQueue
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $queue = $this->getQueue();

--- a/packages/zend-tag/library/Zend/Tag/ItemList.php
+++ b/packages/zend-tag/library/Zend/Tag/ItemList.php
@@ -45,6 +45,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return integer
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_items);
@@ -118,6 +119,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When the seek position is invalid
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function seek($index)
     {
         $this->rewind();
@@ -138,6 +140,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_items);
@@ -148,6 +151,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_items);
@@ -158,6 +162,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_items);
@@ -168,6 +173,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return ($this->current() !== false);
@@ -178,6 +184,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_items);
@@ -189,6 +196,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset) {
         return array_key_exists($offset, $this->_items);
     }
@@ -199,6 +207,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return Zend_Tag_Taggable
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset) {
         return $this->_items[$offset];
     }
@@ -211,6 +220,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When item does not implement Zend_Tag_Taggable
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $item) {
         // We need to make that check here, as the method signature must be
         // compatible with ArrayAccess::offsetSet()
@@ -232,6 +242,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset) {
         unset($this->_items[$offset]);
     }

--- a/packages/zend-timesync/library/Zend/TimeSync.php
+++ b/packages/zend-timesync/library/Zend/TimeSync.php
@@ -93,6 +93,7 @@ class Zend_TimeSync implements IteratorAggregate
      *
      * @return ArrayObject
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayObject($this->_timeservers);

--- a/packages/zend-tool/library/Zend/Tool/Framework/Action/Repository.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Action/Repository.php
@@ -120,6 +120,7 @@ class Zend_Tool_Framework_Action_Repository
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_actions);
@@ -130,6 +131,7 @@ class Zend_Tool_Framework_Action_Repository
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_actions);

--- a/packages/zend-tool/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
@@ -51,6 +51,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return unknown
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         $currentNode = $this->current();
@@ -74,6 +75,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         if (empty($this->ref)) {

--- a/packages/zend-tool/library/Zend/Tool/Framework/Manifest/Repository.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Manifest/Repository.php
@@ -295,6 +295,7 @@ class Zend_Tool_Framework_Manifest_Repository
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_metadatas);
@@ -305,6 +306,7 @@ class Zend_Tool_Framework_Manifest_Repository
      *
      * @return ArrayIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_metadatas);

--- a/packages/zend-tool/library/Zend/Tool/Framework/Provider/Repository.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Provider/Repository.php
@@ -238,6 +238,7 @@ class Zend_Tool_Framework_Provider_Repository
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_providers);
@@ -248,6 +249,7 @@ class Zend_Tool_Framework_Provider_Repository
      *
      * @return ArrayIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->getProviders());

--- a/packages/zend-tool/library/Zend/Tool/Project/Context/Repository.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Context/Repository.php
@@ -176,6 +176,7 @@ class Zend_Tool_Project_Context_Repository implements Countable
         return $this->_contexts[$index]['isOverwritable'];
     }
 
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_contexts);

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile.php
@@ -80,6 +80,7 @@ class Zend_Tool_Project_Profile extends Zend_Tool_Project_Profile_Resource_Conta
      *
      * @return RecursiveIteratorIterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         // require_once 'Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php';

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
@@ -165,6 +165,7 @@ class Zend_Tool_Project_Profile_Iterator_ContextFilter extends RecursiveFilterIt
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         $currentItem = $this->current();
@@ -198,6 +199,7 @@ class Zend_Tool_Project_Profile_Iterator_ContextFilter extends RecursiveFilterIt
      *
      * @return unknown
      */
+    #[ReturnTypeWillChange]
     function getChildren()
     {
 

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
@@ -36,6 +36,7 @@ class Zend_Tool_Project_Profile_Iterator_EnabledResourceFilter extends Recursive
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         return $this->current()->isEnabled();

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -331,6 +331,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return Zend_Tool_Project_Profile_Resource
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->_subResources);
@@ -341,6 +342,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->_subResources);
@@ -351,6 +353,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->_subResources);
@@ -361,6 +364,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->_subResources);
@@ -371,6 +375,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (bool) $this->current();
@@ -381,6 +386,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function hasChildren()
     {
         return count($this->_subResources) > 0;
@@ -391,6 +397,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function getChildren()
     {
         return $this->current();
@@ -401,6 +408,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->_subResources);

--- a/packages/zend-uri/library/Zend/Uri/Http.php
+++ b/packages/zend-uri/library/Zend/Uri/Http.php
@@ -269,6 +269,7 @@ class Zend_Uri_Http extends Zend_Uri
      *
      * @return boolean
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         // Return true if and only if all parts of the URI have passed validation

--- a/packages/zend-view/library/Zend/View/Helper/Cycle.php
+++ b/packages/zend-view/library/Zend/View/Helper/Cycle.php
@@ -154,6 +154,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return Zend_View_Helper_Cycle
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $count = count($this->_data[$this->_name]);
@@ -184,6 +185,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         if ($this->_pointers[$this->_name] < 0)
@@ -197,6 +199,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return Zend_View_Helper_Cycle
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->_pointers[$this->_name] = -1;
@@ -208,6 +211,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->_data[$this->_name][$this->key()]);
@@ -218,6 +222,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_data[$this->_name][$this->key()];

--- a/packages/zend-view/library/Zend/View/Helper/HeadLink.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadLink.php
@@ -233,6 +233,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
      * @param  array $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $value)
     {
         if (!$this->_isValid($value)) {

--- a/packages/zend-view/library/Zend/View/Helper/HeadMeta.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadMeta.php
@@ -258,6 +258,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
      * @return void
      * @throws Zend_View_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $value)
     {
         if (!$this->_isValid($value)) {
@@ -277,6 +278,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
      * @return void
      * @throws Zend_View_Exception
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($index)
     {
         if (!in_array($index, $this->getContainer()->getKeys())) {

--- a/packages/zend-view/library/Zend/View/Helper/HeadScript.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadScript.php
@@ -370,6 +370,7 @@ class Zend_View_Helper_HeadScript extends Zend_View_Helper_Placeholder_Container
      * @param  mixed $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $value)
     {
         if (!$this->_isValid($value)) {

--- a/packages/zend-view/library/Zend/View/Helper/HeadStyle.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadStyle.php
@@ -220,6 +220,7 @@ class Zend_View_Helper_HeadStyle extends Zend_View_Helper_Placeholder_Container_
      * @param  mixed $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($index, $value)
     {
         if (!$this->_isValid($value)) {

--- a/packages/zend-view/library/Zend/View/Helper/Placeholder/Container/Standalone.php
+++ b/packages/zend-view/library/Zend/View/Helper/Placeholder/Container/Standalone.php
@@ -261,6 +261,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $container = $this->getContainer();
@@ -273,6 +274,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->getContainer()->offsetExists($offset);
@@ -284,6 +286,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getContainer()->offsetGet($offset);
@@ -296,6 +299,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  mixed $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         return $this->getContainer()->offsetSet($offset, $value);
@@ -307,6 +311,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->getContainer()->offsetUnset($offset);
@@ -317,6 +322,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      *
      * @return Iterator
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getContainer()->getIterator();

--- a/tests/Zend/Dojo/DataTest.php
+++ b/tests/Zend/Dojo/DataTest.php
@@ -554,26 +554,31 @@ class Zend_Dojo_DataTest_DataCollection implements Iterator
         }
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (bool) $this->current();

--- a/tests/Zend/JsonTest.php
+++ b/tests/Zend/JsonTest.php
@@ -1041,6 +1041,7 @@ class ZF12347_IteratorAggregate implements IteratorAggregate
         'baz' => 5
     );
 
+    #[ReturnTypeWillChange]
     public function getIterator() {
         return new ArrayIterator($this->array);
     }

--- a/tests/Zend/Loader/TestAsset/TestPluginMap.php
+++ b/tests/Zend/Loader/TestAsset/TestPluginMap.php
@@ -46,6 +46,7 @@ class ZendTest_Loader_TestAsset_TestPluginMap implements IteratorAggregate
      * 
      * @return Traversable
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->map);

--- a/tests/Zend/Paginator/_files/Zf4207.php
+++ b/tests/Zend/Paginator/_files/Zf4207.php
@@ -31,6 +31,7 @@
  */
 class Zf4207 extends ArrayObject implements Zend_Paginator_Adapter_Interface
 {
+    #[ReturnTypeWillChange]
     public function count()
     {
         return 10;

--- a/tests/Zend/Queue/Custom/Messages.php
+++ b/tests/Zend/Queue/Custom/Messages.php
@@ -120,6 +120,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayAccess::offsetSet
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value) {
         if (! $value instanceof Custom_Message) {
             $msg = '$value must be a child or an instance of Custom_Messag';
@@ -144,6 +145,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayAccess::offsetUnset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset) {
         if (! $this->_connected) {
             $msg = 'Cannot delete message after serialization';
@@ -161,6 +163,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayAccess::offsetExists
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset) {
         return isSet($this->_data[$offset]);
     }

--- a/tests/Zend/Reflection/ClassTest.php
+++ b/tests/Zend/Reflection/ClassTest.php
@@ -118,6 +118,7 @@ class Zend_Reflection_ClassTest extends PHPUnit_Framework_TestCase
         return \$this->_prop2;
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return array();

--- a/tests/Zend/Reflection/ClassTest.php
+++ b/tests/Zend/Reflection/ClassTest.php
@@ -134,8 +134,8 @@ EOS;
     {
         $reflectionClass = new Zend_Reflection_Class('Zend_Reflection_TestSampleClass5');
 
-        $this->assertEquals(87, $reflectionClass->getStartLine());
-        $this->assertEquals(76, $reflectionClass->getStartLine(true));
+        $this->assertEquals(88, $reflectionClass->getStartLine());
+        $this->assertEquals(77, $reflectionClass->getStartLine(true));
     }
 
 

--- a/tests/Zend/Reflection/DocblockTest.php
+++ b/tests/Zend/Reflection/DocblockTest.php
@@ -90,8 +90,8 @@ EOS;
 
         $classDocblock = $classReflection->getDocblock();
 
-        $this->assertEquals($classDocblock->getStartLine(), 76);
-        $this->assertEquals($classDocblock->getEndLine(), 86);
+        $this->assertEquals($classDocblock->getStartLine(), 77);
+        $this->assertEquals($classDocblock->getEndLine(), 87);
 
     }
 

--- a/tests/Zend/Reflection/FileTest.php
+++ b/tests/Zend/Reflection/FileTest.php
@@ -113,7 +113,7 @@ class Zend_Reflection_FileTest extends PHPUnit_Framework_TestCase
         require_once $fileToRequire;
         $reflectionFile = new Zend_Reflection_File($fileToRequire);
         $this->assertEquals(9, $reflectionFile->getStartLine());
-        $this->assertEquals(196, $reflectionFile->getEndLine());
+        $this->assertEquals(197, $reflectionFile->getEndLine());
     }
 
     public function testFileGetDocblockReturnsFileDocblock()

--- a/tests/Zend/Reflection/MethodTest.php
+++ b/tests/Zend/Reflection/MethodTest.php
@@ -71,8 +71,8 @@ class Zend_Reflection_MethodTest extends PHPUnit_Framework_TestCase
     {
         $reflectionMethod = new Zend_Reflection_Method('Zend_Reflection_TestSampleClass5', 'doSomething');
 
-        $this->assertEquals($reflectionMethod->getStartLine(), 106);
-        $this->assertEquals($reflectionMethod->getStartLine(true), 90);
+        $this->assertEquals($reflectionMethod->getStartLine(), 107);
+        $this->assertEquals($reflectionMethod->getStartLine(true), 91);
     }
 
     public function testGetBodyReturnsCorrectBody()

--- a/tests/Zend/Reflection/_files/TestSampleClass.php
+++ b/tests/Zend/Reflection/_files/TestSampleClass.php
@@ -44,6 +44,7 @@ class Zend_Reflection_TestSampleClass2 implements IteratorAggregate
         return $this->_prop2;
     }
 
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return array();

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -1040,6 +1040,7 @@ class Zend_Soap_Server_TestLocalSoapClient extends SoapClient
         parent::__construct($wsdl, $options);
     }
 
+    #[ReturnTypeWillChange]
     function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
         ob_start();

--- a/tests/Zend/Soap/TestAsset/commontypes.php
+++ b/tests/Zend/Soap/TestAsset/commontypes.php
@@ -621,6 +621,7 @@ class Zend_Soap_TestAsset_TestLocalSoapClient extends SoapClient
         parent::__construct($wsdl, $options);
     }
 
+    #[ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = 0)
     {
         ob_start();

--- a/tests/Zend/UriTest.php
+++ b/tests/Zend/UriTest.php
@@ -215,11 +215,13 @@ class Zend_Uri_Mock extends Zend_Uri
 {
     protected function __construct($scheme, $schemeSpecific = '') { }
     public function getUri() { }
+    #[ReturnTypeWillChange]
     public function valid() { }
 }
 class Zend_Uri_ExceptionCausing extends Zend_Uri
 {
     protected function __construct($scheme, $schemeSpecific = '') { }
+    #[ReturnTypeWillChange]
     public function valid() { }
     public function getUri()
     {

--- a/tests/Zend/View/Helper/PartialLoopTest.php
+++ b/tests/Zend/View/Helper/PartialLoopTest.php
@@ -411,26 +411,31 @@ class Zend_View_Helper_PartialLoop_IteratorTest implements Iterator
         $this->items = $array;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (current($this->items) !== false);
@@ -457,26 +462,31 @@ class Zend_View_Helper_PartialLoop_RecursiveIteratorTest implements Iterator
         return $this;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (current($this->items) !== false);
@@ -514,26 +524,31 @@ class Zend_View_Helper_PartialLoop_IteratorWithToArrayTest implements Iterator
         return $this->items;
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->items);
     }
 
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return (current($this->items) !== false);


### PR DESCRIPTION
replaces #120 & #141
fixes #125

- added `#[ReturnTypeWillChange]` attribute where necessary https://php.watch/versions/8.1/ReturnTypeWillChange
- additionally, to mitigate fatal errors, switched to [zf1s/dbunit](https://github.com/zf1s/dbunit/pull/1) fork for php8.x compatibility and bump zf1s/phpunit to [3.7.42](https://github.com/zf1s/phpunit/releases/tag/3.7.42) which allows newer `symfony/yaml` package to be installed for php 8.x
