### PR TITLE
[zend-openid] fix for `Zend_OpenId_Consumer_Storage_File` when symlinks are not used (i.e. on windows)

### DIFF
--- a/packages/zend-openid/library/Zend/OpenId/Consumer/Storage/File.php
+++ b/packages/zend-openid/library/Zend/OpenId/Consumer/Storage/File.php
@@ -153,7 +153,6 @@ class Zend_OpenId_Consumer_Storage_File extends Zend_OpenId_Consumer_Storage
             if ($f2) {
                 fwrite($f2, $data);
                 fclose($f2);
-                @unlink($name1);
                 $ret = true;
             } else {
                 $ret = false;


### PR DESCRIPTION
fix for `Zend_OpenId_Consumer_Storage_File` when symlinks are not used (i.e. on windows) One of the files created in `Zend_OpenId_Consumer_Storage_File::addAssociations()` was being deleted for some unknown reason, but `Zend_OpenId_Consumer` relies on it to be there.

Fixes errors in OpenId tests when running on windows. i.a.
```
Zend_Auth_Adapter_OpenIdTest::testAuthenticateLoginValid
Failed asserting that false is true.
```