### PR TITLE
php 8.1 compatibility fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,9 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
         include:
-          - php: "8.1"
-            experimental: true
           - php: "8.2"
             experimental: true
 

--- a/packages/zend-amf/library/Zend/Amf/Value/Messaging/AbstractMessage.php
+++ b/packages/zend-amf/library/Zend/Amf/Value/Messaging/AbstractMessage.php
@@ -31,6 +31,19 @@
  */
 class Zend_Amf_Value_Messaging_AbstractMessage
 {
+    // Copied the `correlationId` property definition from Zend_Amf_Value_Messaging_AsyncMessage,
+    // to keep the order of properties when they are being serialized same as PHP <8.1
+    // https://github.com/php/php-src/blob/578b67da49af51b2f796a48782e51ceb62860943/UPGRADING#L334-L341
+    // In PHP 8.1, the order of properties is the same as in the class definition, but properties from parent class
+    // always go after properties from the current class.
+    // `correlationId` prop is expected to be at the beginning of serialized messages,
+    // otherwise it breaks Zend_Amf_ResponseTest cases for php 8.1+.
+    /**
+     * The message id to be responded to.
+     * @var String
+     */
+    public $correlationId;
+
     /**
      * @var string Client identifier
      */

--- a/packages/zend-barcode/library/Zend/Barcode/Object/ObjectAbstract.php
+++ b/packages/zend-barcode/library/Zend/Barcode/Object/ObjectAbstract.php
@@ -616,7 +616,7 @@ abstract class Zend_Barcode_Object_ObjectAbstract
      */
     public function getText()
     {
-        $text = $this->_text;
+        $text = (string) $this->_text;
         if ($this->_withChecksum) {
             $text .= $this->getChecksum($this->_text);
         }
@@ -986,7 +986,7 @@ abstract class Zend_Barcode_Object_ObjectAbstract
     protected function _checkText($value = null)
     {
         if ($value === null) {
-            $value = $this->_text;
+            $value = (string) $this->_text;
         }
         if (!strlen($value)) {
             // require_once 'Zend/Barcode/Object/Exception.php';

--- a/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
+++ b/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
@@ -217,8 +217,8 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
             throw $e;
         }
 
-        $barcodeWidth  = $this->_barcode->getWidth(true);
-        $barcodeHeight = $this->_barcode->getHeight(true);
+        $barcodeWidth  = (int) $this->_barcode->getWidth(true);
+        $barcodeHeight = (int) $this->_barcode->getHeight(true);
 
         if ($this->_resource !== null) {
             $foreColor       = $this->_barcode->getForeColor();
@@ -377,7 +377,11 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
         );
 
         if ($filled) {
-            imagefilledpolygon($this->_resource, $newPoints, 4, $allocatedColor);
+            if (PHP_VERSION_ID >= 80100) {
+                imagefilledpolygon($this->_resource, $newPoints, $allocatedColor);
+            } else {
+                imagefilledpolygon($this->_resource, $newPoints, 4, $allocatedColor);
+            }
         } else {
             imagepolygon($this->_resource, $newPoints, 4, $allocatedColor);
         }
@@ -463,8 +467,8 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
                 $this->_resource,
                 $size,
                 $orientation,
-                $position[0] - ($width * cos(pi() * $orientation / 180)),
-                $position[1] + ($width * sin(pi() * $orientation / 180)),
+                round($position[0] - ($width * cos(pi() * $orientation / 180))),
+                round($position[1] + ($width * sin(pi() * $orientation / 180))),
                 $allocatedColor,
                 $font,
                 $text

--- a/packages/zend-captcha/library/Zend/Captcha/Image.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Image.php
@@ -506,7 +506,7 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
         $textbox = imageftbbox($fsize, 0, $font, $word);
         $x = ($w - ($textbox[2] - $textbox[0])) / 2;
         $y = ($h - ($textbox[7] - $textbox[1])) / 2;
-        imagefttext($img, $fsize, 0, $x, $y, $text_color, $font, $word);
+        imagefttext($img, $fsize, 0, (int) $x, (int) $y, $text_color, $font, $word);
 
        // generate noise
         for ($i=0; $i<$this->_dotNoiseLevel; $i++) {
@@ -542,10 +542,12 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
                 if ($sx < 0 || $sy < 0 || $sx >= $w - 1 || $sy >= $h - 1) {
                     continue;
                 } else {
-                    $color    = (imagecolorat($img, $sx, $sy) >> 16)         & 0xFF;
-                    $color_x  = (imagecolorat($img, $sx + 1, $sy) >> 16)     & 0xFF;
-                    $color_y  = (imagecolorat($img, $sx, $sy + 1) >> 16)     & 0xFF;
-                    $color_xy = (imagecolorat($img, $sx + 1, $sy + 1) >> 16) & 0xFF;
+                    $intsx = floor($sx);
+                    $intsy = floor($sy);
+                    $color    = (imagecolorat($img, $intsx, $intsy) >> 16)         & 0xFF;
+                    $color_x  = (imagecolorat($img, $intsx + 1, $intsy) >> 16)     & 0xFF;
+                    $color_y  = (imagecolorat($img, $intsx, $intsy + 1) >> 16)     & 0xFF;
+                    $color_xy = (imagecolorat($img, $intsx + 1, $intsy + 1) >> 16) & 0xFF;
                 }
                 if ($color == 255 && $color_x == 255 && $color_y == 255 && $color_xy == 255) {
                     // ignore background
@@ -564,6 +566,7 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
                               + $color_x  * $frac_x  * $frac_y1
                               + $color_y  * $frac_x1 * $frac_y
                               + $color_xy * $frac_x  * $frac_y;
+                    $newcolor = round($newcolor);
                 }
                 imagesetpixel($img2, $x, $y, imagecolorallocate($img2, $newcolor, $newcolor, $newcolor));
             }

--- a/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/File.php
+++ b/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/File.php
@@ -351,7 +351,7 @@ class Zend_CodeGenerator_Php_File extends Zend_CodeGenerator_Php_Abstract
      */
     public function getBody()
     {
-        return $this->_body;
+        return is_string($this->_body) ? $this->_body : '';
     }
 
     /**

--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
@@ -231,7 +231,7 @@ abstract class Zend_Controller_Dispatcher_Abstract implements Zend_Controller_Di
     {
         // preserve directories
         if (!$isAction) {
-            $segments = explode($this->getPathDelimiter(), $unformatted);
+            $segments = explode($this->getPathDelimiter(), (string) $unformatted);
         } else {
             $segments = (array) $unformatted;
         }

--- a/packages/zend-controller/library/Zend/Controller/Request/Http.php
+++ b/packages/zend-controller/library/Zend/Controller/Request/Http.php
@@ -503,7 +503,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
             }
 
             // Does the baseUrl have anything in common with the request_uri?
-            $requestUri = $this->getRequestUri();
+            $requestUri = (string) $this->getRequestUri();
 
             if (0 === strpos($requestUri, $baseUrl)) {
                 // full $baseUrl matches

--- a/packages/zend-controller/library/Zend/Controller/Router/Rewrite.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Rewrite.php
@@ -488,7 +488,7 @@ class Zend_Controller_Router_Rewrite extends Zend_Controller_Router_Abstract
         $url   = $route->assemble($params, $reset, $encode);
 
         if (!preg_match('|^[a-z]+://|', $url)) {
-            $url = rtrim($this->getFrontController()->getBaseUrl(), self::URI_DELIMITER) . self::URI_DELIMITER . $url;
+            $url = rtrim((string) $this->getFrontController()->getBaseUrl(), self::URI_DELIMITER) . self::URI_DELIMITER . $url;
         }
 
         return $url;

--- a/packages/zend-controller/library/Zend/Controller/Router/Route.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route.php
@@ -272,11 +272,11 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
                 // Translate value if required
                 $part = $this->_parts[$pos];
                 if ($this->_isTranslated
-                    && (substr($part, 0, 1) === '@' && substr($part, 1, 1) !== '@'
+                    && ($part !== null && substr($part, 0, 1) === '@' && substr($part, 1, 1) !== '@'
                         && $name === null)
                     || $name !== null && in_array($name, $this->_translatable)
                 ) {
-                    if (substr($part, 0, 1) === '@') {
+                    if ($part !== null && substr($part, 0, 1) === '@') {
                         $part = substr($part, 1);
                     }
 
@@ -285,7 +285,7 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
                     }
                 }
 
-                if (substr($part, 0, 2) === '@@') {
+                if ($part !== null && substr($part, 0, 2) === '@@') {
                     $part = substr($part, 1);
                 }
 

--- a/packages/zend-date/library/Zend/Date.php
+++ b/packages/zend-date/library/Zend/Date.php
@@ -3304,23 +3304,8 @@ class Zend_Date extends Zend_Date_DateObject
             throw new Zend_Date_Exception('Latitude must be between -90 and 90', 0, null, $location);
         }
 
-        if (!isset($location['horizon'])){
-            $location['horizon'] = 'effective';
-        }
-
-        switch ($location['horizon']) {
-            case 'civil' :
-                return -0.104528;
-                break;
-            case 'nautic' :
-                return -0.207912;
-                break;
-            case 'astronomic' :
-                return -0.309017;
-                break;
-            default :
-                return -0.0145439;
-                break;
+        if (isset($location['horizon']) && !in_array($location['horizon'], array('civil', 'nautic', 'astronomic', 'effective'))) {
+            throw new Zend_Date_Exception('Invalid value for \'horizon\', must be one of: \'civil\', \'nautic\', \'astronomic\', \'effective\'', 0, null, $location);
         }
     }
 
@@ -3330,7 +3315,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of sunrise
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return Zend_Date
@@ -3338,9 +3323,9 @@ class Zend_Date extends Zend_Date_DateObject
      */
     public function getSunrise($location)
     {
-        $horizon = $this->_checkLocation($location);
+        $this->_checkLocation($location);
         $result = clone $this;
-        $result->set($this->calcSun($location, $horizon, true), self::TIMESTAMP);
+        $result->set($this->calcSun($location, true), self::TIMESTAMP);
         return $result;
     }
 
@@ -3350,7 +3335,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of sunset
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return Zend_Date
@@ -3358,9 +3343,9 @@ class Zend_Date extends Zend_Date_DateObject
      */
     public function getSunset($location)
     {
-        $horizon = $this->_checkLocation($location);
+        $this->_checkLocation($location);
         $result = clone $this;
-        $result->set($this->calcSun($location, $horizon, false), self::TIMESTAMP);
+        $result->set($this->calcSun($location, false), self::TIMESTAMP);
         return $result;
     }
 
@@ -3370,7 +3355,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of suninfo
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return array - [sunset|sunrise][effective|civil|nautic|astronomic]
@@ -3394,12 +3379,13 @@ class Zend_Date extends Zend_Date_DateObject
                     $location['horizon'] = 'astronomic';
                     break;
             }
-            $horizon = $this->_checkLocation($location);
+            $this->_checkLocation($location);
+
             $result = clone $this;
-            $result->set($this->calcSun($location, $horizon, true), self::TIMESTAMP);
+            $result->set($this->calcSun($location, true), self::TIMESTAMP);
             $suninfo['sunrise'][$location['horizon']] = $result;
             $result = clone $this;
-            $result->set($this->calcSun($location, $horizon, false), self::TIMESTAMP);
+            $result->set($this->calcSun($location, false), self::TIMESTAMP);
             $suninfo['sunset'][$location['horizon']]  = $result;
         }
         return $suninfo;

--- a/packages/zend-date/library/Zend/Date.php
+++ b/packages/zend-date/library/Zend/Date.php
@@ -1195,12 +1195,12 @@ class Zend_Date extends Zend_Date_DateObject
         }
 
         $match = array();
-        preg_match('/\dZ$/', $zone, $match);
+        preg_match('/\dZ$/', (string) $zone, $match);
         if (!empty($match)) {
             return "Etc/UTC";
         }
 
-        preg_match('/([+-]\d{2}):{0,1}\d{2}/', $zone, $match);
+        preg_match('/([+-]\d{2}):{0,1}\d{2}/', (string) $zone, $match);
         if (!empty($match) and ($match[count($match) - 1] <= 14) and ($match[count($match) - 1] >= -12)) {
             $zone = "Etc/GMT";
             $zone .= ($match[count($match) - 1] < 0) ? "+" : "-";
@@ -1208,7 +1208,7 @@ class Zend_Date extends Zend_Date_DateObject
             return $zone;
         }
 
-        preg_match('/([[:alpha:]\/_]{3,30})(?!.*([[:alpha:]\/]{3,30}))/', $zone, $match);
+        preg_match('/([[:alpha:]\/_]{3,30})(?!.*([[:alpha:]\/]{3,30}))/', (string) $zone, $match);
         try {
             if (!empty($match) and (!is_int($match[count($match) - 1]))) {
                 $oldzone = $this->getTimezone();
@@ -3004,7 +3004,7 @@ class Zend_Date extends Zend_Date_DateObject
                     }
 
                     $parsed = Zend_Locale_Format::getDate($date, array('date_format' => $format, 'locale' => $locale, 'format_type' => 'iso'));
-                    if ((strpos(strtoupper($format), 'YY') !== false) and (strpos(strtoupper($format), 'YYYY') === false)) {
+                    if (is_string($format) && (strpos(strtoupper($format), 'YY') !== false) and (strpos(strtoupper($format), 'YYYY') === false)) {
                         $parsed['year'] = self::getFullYear($parsed['year']);
                     }
                 } catch (Zend_Locale_Exception $e) {

--- a/packages/zend-date/library/Zend/Date/Cities.php
+++ b/packages/zend-date/library/Zend/Date/Cities.php
@@ -291,18 +291,20 @@ class Zend_Date_Cities
      * Returns the location from the selected city
      *
      * @param  string $city    City to get location for
-     * @param  string $horizon Horizon to use :
+     * @param  string|null $horizon Horizon to use :
      *                         default: effective
      *                         others are civil, nautic, astronomic
      * @return array
      * @throws Zend_Date_Exception When city is unknown
      */
-    public static function City($city, $horizon = false)
+    public static function City($city, $horizon = null)
     {
         foreach (self::$cities as $key => $value) {
             if (strtolower($key) === strtolower($city)) {
                 $return            = $value;
-                $return['horizon'] = $horizon;
+                if ($horizon !== null) {
+                    $return['horizon'] = $horizon;
+                }
                 return $return;
             }
         }

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli.php
@@ -424,8 +424,12 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
      */
     protected function _beginTransaction()
     {
-        $this->_connect();
-        $this->_connection->autocommit(false);
+        try {
+            $this->_connect();
+            $this->_connection->autocommit(false);
+        } catch (mysqli_sql_exception $e) {
+            throw Zend_Db_Adapter_Mysqli_Exception::fromMysqliException($e);
+        }
     }
 
     /**
@@ -435,9 +439,13 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
      */
     protected function _commit()
     {
-        $this->_connect();
-        $this->_connection->commit();
-        $this->_connection->autocommit(true);
+        try {
+            $this->_connect();
+            $this->_connection->commit();
+            $this->_connection->autocommit(true);
+        } catch (mysqli_sql_exception $e) {
+            throw Zend_Db_Adapter_Mysqli_Exception::fromMysqliException($e);
+        }
     }
 
     /**
@@ -447,9 +455,13 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
      */
     protected function _rollBack()
     {
-        $this->_connect();
-        $this->_connection->rollback();
-        $this->_connection->autocommit(true);
+        try {
+            $this->_connect();
+            $this->_connection->rollback();
+            $this->_connection->autocommit(true);
+        } catch (mysqli_sql_exception $e) {
+            throw Zend_Db_Adapter_Mysqli_Exception::fromMysqliException($e);
+        }
     }
 
     /**

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
@@ -37,7 +37,7 @@
  */
 class Zend_Db_Adapter_Mysqli_Exception extends Zend_Db_Adapter_Exception
 {
-    public static function fromMysqliException($exception)
+    public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
         $p->setAccessible(true);

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
@@ -37,4 +37,16 @@
  */
 class Zend_Db_Adapter_Mysqli_Exception extends Zend_Db_Adapter_Exception
 {
+    public static function fromMysqliException($exception)
+    {
+        $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
+        $p->setAccessible(true);
+        $sqlstate = $p->getValue($exception);
+
+        return new self(
+            'Mysqli error:' . $exception->getMessage() . ' SQLSTATE: ' . $sqlstate,
+            $exception->getCode(),
+            $exception
+        );
+    }
 }

--- a/packages/zend-db/library/Zend/Db/Adapter/Pdo/Pgsql.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Pdo/Pgsql.php
@@ -196,14 +196,14 @@ class Zend_Db_Adapter_Pdo_Pgsql extends Zend_Db_Adapter_Pdo_Abstract
         foreach ($result as $key => $row) {
             $defaultValue = $row[$default_value];
             if ($row[$type] == 'varchar' || $row[$type] == 'bpchar' ) {
-                if (preg_match('/character(?: varying)?(?:\((\d+)\))?/', $row[$complete_type], $matches)) {
+                if (preg_match('/character(?: varying)?(?:\((\d+)\))?/', (string) $row[$complete_type], $matches)) {
                     if (isset($matches[1])) {
                         $row[$length] = $matches[1];
                     } else {
                         $row[$length] = null; // unlimited
                     }
                 }
-                if (preg_match("/^'(.*?)'::(?:character varying|bpchar)$/", $defaultValue, $matches)) {
+                if (preg_match("/^'(.*?)'::(?:character varying|bpchar)$/", (string) $defaultValue, $matches)) {
                     $defaultValue = $matches[1];
                 }
             }
@@ -211,7 +211,7 @@ class Zend_Db_Adapter_Pdo_Pgsql extends Zend_Db_Adapter_Pdo_Abstract
             if ($row[$contype] == 'p') {
                 $primary = true;
                 $primaryPosition = array_search($row[$attnum], explode(',', $row[$conkey])) + 1;
-                $identity = (bool) (preg_match('/^nextval/', $row[$default_value]));
+                $identity = (bool) (preg_match('/^nextval/', (string) $row[$default_value]));
             }
             $desc[$this->foldCase($row[$colname])] = array(
                 'SCHEMA_NAME'      => $this->foldCase($row[$nspname]),

--- a/packages/zend-db/library/Zend/Db/Profiler.php
+++ b/packages/zend-db/library/Zend/Db/Profiler.php
@@ -258,7 +258,7 @@ class Zend_Db_Profiler
 
         // make sure we have a query type
         if (null === $queryType) {
-            switch (strtolower(substr(ltrim($queryText), 0, 6))) {
+            switch (strtolower(substr(ltrim((string) $queryText), 0, 6))) {
                 case 'insert':
                     $queryType = self::INSERT;
                     break;

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
@@ -67,7 +67,11 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
     {
         $mysqli = $this->_adapter->getConnection();
 
-        $this->_stmt = $mysqli->prepare($sql);
+        try {
+            $this->_stmt = $mysqli->prepare($sql);
+        } catch (mysqli_sql_exception $e) {
+            throw Zend_Db_Statement_Mysqli_Exception::fromMysqliException($e);
+        }
 
         if ($this->_stmt === false || $mysqli->errno) {
             /**
@@ -204,8 +208,13 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
                 );
         }
 
-        // execute the statement
-        $retval = $this->_stmt->execute();
+        try {
+            // execute the statement
+            $retval = $this->_stmt->execute();
+        } catch (mysqli_sql_exception $e) {
+            throw Zend_Db_Statement_Mysqli_Exception::fromMysqliException($e);
+        }
+
         if ($retval === false) {
             /**
              * @see Zend_Db_Statement_Mysqli_Exception

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
@@ -34,7 +34,7 @@
 
 class Zend_Db_Statement_Mysqli_Exception extends Zend_Db_Statement_Exception
 {
-    public static function fromMysqliException($exception)
+    public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
         $p->setAccessible(true);

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
@@ -34,5 +34,16 @@
 
 class Zend_Db_Statement_Mysqli_Exception extends Zend_Db_Statement_Exception
 {
-}
+    public static function fromMysqliException($exception)
+    {
+        $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
+        $p->setAccessible(true);
+        $sqlstate = $p->getValue($exception);
 
+        return new self(
+            'Mysqli statement error:' . $exception->getMessage() . ' SQLSTATE: ' . $sqlstate,
+            $exception->getCode(),
+            $exception
+        );
+    }
+}

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -111,12 +111,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
                     $type = PDO::PARAM_STR;
                 }
             }
-            if ($length === null) {
-                // PDOStatement::bindParam(): Passing null to parameter #4 ($maxLength) of type int is deprecated
-                // since php 8.1.0
-                $length = 0;
-            }
-            return $this->_stmt->bindParam($parameter, $variable, $type, $length, $options);
+            return $this->_stmt->bindParam($parameter, $variable, $type, (int) $length, $options);
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -111,6 +111,11 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
                     $type = PDO::PARAM_STR;
                 }
             }
+            if ($length === null) {
+                // PDOStatement::bindParam(): Passing null to parameter #4 ($maxLength) of type int is deprecated
+                // since php 8.1.0
+                $length = 0;
+            }
             return $this->_stmt->bindParam($parameter, $variable, $type, $length, $options);
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
@@ -245,10 +250,13 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = null, $cursor = null, $offset = null)
+    public function fetch($style = null, $cursor = null, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;
+        }
+        if ($cursor === null) {
+            $cursor = PDO::FETCH_ORI_NEXT;
         }
         try {
             return $this->_stmt->fetch($style, $cursor, $offset);

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo/Ibm.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo/Ibm.php
@@ -83,7 +83,7 @@ class Zend_Db_Statement_Pdo_Ibm extends Zend_Db_Statement_Pdo
             if (($type === null) && ($length === null) && ($options === null)) {
                 return $this->_stmt->bindParam($parameter, $variable);
             } else {
-                return $this->_stmt->bindParam($parameter, $variable, $type, $length === null ? 0 : $length, $options);
+                return $this->_stmt->bindParam($parameter, $variable, $type, (int) $length, $options);
             }
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo/Ibm.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo/Ibm.php
@@ -83,7 +83,7 @@ class Zend_Db_Statement_Pdo_Ibm extends Zend_Db_Statement_Pdo
             if (($type === null) && ($length === null) && ($options === null)) {
                 return $this->_stmt->bindParam($parameter, $variable);
             } else {
-                return $this->_stmt->bindParam($parameter, $variable, $type, $length, $options);
+                return $this->_stmt->bindParam($parameter, $variable, $type, $length === null ? 0 : $length, $options);
             }
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';

--- a/packages/zend-dom/library/Zend/Dom/Query.php
+++ b/packages/zend-dom/library/Zend/Dom/Query.php
@@ -129,7 +129,7 @@ class Zend_Dom_Query
         if ($document instanceof DOMDocument) {
             return $this->setDocumentDom($document);
         }
-        if (0 === strlen($document)) {
+        if (!is_string($document) || 0 === strlen($document)) {
             return $this;
         }
         // breaking XML declaration to make syntax highlighting work

--- a/packages/zend-exception/library/Zend/Exception.php
+++ b/packages/zend-exception/library/Zend/Exception.php
@@ -37,6 +37,6 @@ class Zend_Exception extends Exception
      */
     public function __construct($msg = '', $code = 0, $previous = null)
     {
-        parent::__construct($msg, (int) $code, $previous);
+        parent::__construct((string) $msg, (int) $code, $previous);
     }
 }

--- a/packages/zend-feed/library/Zend/Feed/Element.php
+++ b/packages/zend-feed/library/Zend/Feed/Element.php
@@ -134,8 +134,8 @@ class Zend_Feed_Element implements ArrayAccess
     public function saveXml()
     {
         // Return a complete document including XML prologue.
-        $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+        $doc = new DOMDocument((string) $this->_element->ownerDocument->version,
+                               (string) $this->_element->ownerDocument->actualEncoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         return $doc->saveXML();
     }

--- a/packages/zend-feed/library/Zend/Feed/Reader/Extension/Atom/Entry.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/Extension/Atom/Entry.php
@@ -163,7 +163,7 @@ class Zend_Feed_Reader_Extension_Atom_Entry
             $content = $this->getDescription();
         }
 
-        $this->_data['content'] = trim($content);
+        $this->_data['content'] = trim((string) $content);
 
         return $this->_data['content'];
     }

--- a/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -185,7 +185,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type)
     {
-        $type = is_string($type) ? strtoupper($type) : $type;
+        $type = strtoupper((string) $type);
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:
@@ -209,7 +209,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
      */
     public function getPluginLoader($type)
     {
-        $type = is_string($type) ? strtoupper($type) : $type;
+        $type = strtoupper((string) $type);
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:

--- a/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -185,7 +185,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:
@@ -209,7 +209,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
      */
     public function getPluginLoader($type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:
@@ -256,7 +256,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
      */
     public function addPrefixPath($prefix, $path, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:

--- a/packages/zend-filter/library/Zend/Filter/Compress/Bz2.php
+++ b/packages/zend-filter/library/Zend/Filter/Compress/Bz2.php
@@ -151,6 +151,7 @@ class Zend_Filter_Compress_Bz2 extends Zend_Filter_Compress_CompressAbstract
     public function decompress($content)
     {
         $archive = $this->getArchive();
+        $content = (string) $content;
         // check $content for NULL bytes or else file_exists will error out
         if ((0 === preg_match('/\0/', $content)) && @file_exists($content)) {
             $archive = $content;

--- a/packages/zend-filter/library/Zend/Filter/Compress/Gz.php
+++ b/packages/zend-filter/library/Zend/Filter/Compress/Gz.php
@@ -182,6 +182,7 @@ class Zend_Filter_Compress_Gz extends Zend_Filter_Compress_CompressAbstract
     {
         $archive = $this->getArchive();
         $mode    = $this->getMode();
+        $content = (string) $content;
         // check $content for NULL bytes or else file_exists will error out
         if ((0 === preg_match('/\0/', $content)) && @file_exists($content)) {
             $archive = $content;

--- a/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
+++ b/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
@@ -128,7 +128,7 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
         }
 
         foreach ($keys as $type => $key) {
-            if (ctype_print($key) && is_file(realpath($key)) && is_readable($key)) {
+            if (ctype_print((string) $key) && is_file(realpath($key)) && is_readable($key)) {
                 $file = fopen($key, 'r');
                 $cert = fread($file, 8192);
                 fclose($file);

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -417,7 +417,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::DECORATOR:
             case self::ELEMENT:
@@ -445,7 +445,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function getPluginLoader($type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         if (!isset($this->_loaders[$type])) {
             switch ($type) {
                 case self::DECORATOR:
@@ -495,7 +495,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function addPrefixPath($prefix, $path, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::DECORATOR:
             case self::ELEMENT:
@@ -911,7 +911,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
         $id = $this->getFullyQualifiedName();
 
         // Bail early if no array notation detected
-        if (!strstr($id, '[')) {
+        if ($id === null || !strstr($id, '[')) {
             return $id;
         }
 
@@ -2123,7 +2123,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     protected function _dissolveArrayValue($value, $arrayPath)
     {
         // As long as we have more levels
-        while ($arrayPos = strpos($arrayPath, '[')) {
+        while ($arrayPos = strpos((string) $arrayPath, '[')) {
             // Get the next key in the path
             $arrayKey = trim(substr($arrayPath, 0, $arrayPos), ']');
 

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -417,7 +417,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type = null)
     {
-        $type = is_string($type) ? strtoupper($type) : $type;
+        $type = strtoupper((string) $type);
         switch ($type) {
             case self::DECORATOR:
             case self::ELEMENT:
@@ -445,7 +445,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function getPluginLoader($type = null)
     {
-        $type = is_string($type) ? strtoupper($type) : $type;
+        $type = strtoupper((string) $type);
         if (!isset($this->_loaders[$type])) {
             switch ($type) {
                 case self::DECORATOR:

--- a/packages/zend-form/library/Zend/Form/Decorator/Description.php
+++ b/packages/zend-form/library/Zend/Form/Decorator/Description.php
@@ -159,7 +159,7 @@ class Zend_Form_Decorator_Description extends Zend_Form_Decorator_Abstract
         }
 
         $description = $element->getDescription();
-        $description = is_string($description) ? trim($description) : '';
+        $description = trim((string) $description);
 
         if (!empty($description) && (null !== ($translator = $element->getTranslator()))) {
             $description = $translator->translate($description);

--- a/packages/zend-form/library/Zend/Form/Decorator/Description.php
+++ b/packages/zend-form/library/Zend/Form/Decorator/Description.php
@@ -159,7 +159,7 @@ class Zend_Form_Decorator_Description extends Zend_Form_Decorator_Abstract
         }
 
         $description = $element->getDescription();
-        $description = trim($description);
+        $description = is_string($description) ? trim($description) : '';
 
         if (!empty($description) && (null !== ($translator = $element->getTranslator()))) {
             $description = $translator->translate($description);

--- a/packages/zend-form/library/Zend/Form/Decorator/Label.php
+++ b/packages/zend-form/library/Zend/Form/Decorator/Label.php
@@ -302,7 +302,7 @@ class Zend_Form_Decorator_Label extends Zend_Form_Decorator_Abstract
         }
 
         $label = $element->getLabel();
-        $label = trim($label);
+        $label = is_string($label) ? trim($label) : '';
 
         if (empty($label)) {
             return '';

--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -1023,7 +1023,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::DECORATOR:
             case self::FILTER:
@@ -1048,7 +1048,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function getPluginLoader($type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:
@@ -1091,7 +1091,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function addPrefixPath($prefix, $path, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case self::DECORATOR:
             case self::FILTER:
@@ -2277,6 +2277,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
                     $aggregateMessages[] = str_replace('%value%', $val, $message);
                 }
                 if (count($aggregateMessages)) {
+                    $aggregateMessages = array_unique($aggregateMessages); //prevent repeating the identical error message for multichoice-items
                     if ($this->_concatJustValuesInErrorMessage) {
                         $values = implode($this->getErrorMessageSeparator(), $value);
                         $messages[$key] = str_replace('%value%', $values, $message);
@@ -2285,7 +2286,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
                     }
                 }
             } else {
-                $messages[$key] = str_replace('%value%', $value, $message);
+                $messages[$key] = str_replace('%value%', (string) $value, $message);
             }
         }
         return $messages;

--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -1048,7 +1048,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function getPluginLoader($type)
     {
-        $type = is_string($type) ? strtoupper($type) : $type;
+        $type = strtoupper((string) $type);
         switch ($type) {
             case self::FILTER:
             case self::VALIDATE:

--- a/packages/zend-form/library/Zend/Form/Element/Captcha.php
+++ b/packages/zend-form/library/Zend/Form/Element/Captcha.php
@@ -201,7 +201,7 @@ class Zend_Form_Element_Captcha extends Zend_Form_Element_Xhtml
      */
     public function getPluginLoader($type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         if ($type == self::CAPTCHA) {
             if (!isset($this->_loaders[$type])) {
                 // require_once 'Zend/Loader/PluginLoader.php';
@@ -228,7 +228,7 @@ class Zend_Form_Element_Captcha extends Zend_Form_Element_Xhtml
      */
     public function addPrefixPath($prefix, $path, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         switch ($type) {
             case null:
                 $loader = $this->getPluginLoader(self::CAPTCHA);

--- a/packages/zend-form/library/Zend/Form/Element/File.php
+++ b/packages/zend-form/library/Zend/Form/Element/File.php
@@ -104,7 +104,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      */
     public function setPluginLoader(Zend_Loader_PluginLoader_Interface $loader, $type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
 
         if ($type != self::TRANSFER_ADAPTER) {
             return parent::setPluginLoader($loader, $type);
@@ -122,7 +122,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      */
     public function getPluginLoader($type)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
 
         if ($type != self::TRANSFER_ADAPTER) {
             return parent::getPluginLoader($type);
@@ -149,7 +149,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      */
     public function addPrefixPath($prefix, $path, $type = null)
     {
-        $type = strtoupper($type);
+        $type = is_string($type) ? strtoupper($type) : $type;
         if (!empty($type) && ($type != self::TRANSFER_ADAPTER)) {
             return parent::addPrefixPath($prefix, $path, $type);
         }

--- a/packages/zend-gdata/library/Zend/Gdata/App/Base.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App/Base.php
@@ -124,7 +124,7 @@ abstract class Zend_Gdata_App_Base
     public function getText($trim = true)
     {
         if ($trim) {
-            return trim($this->_text);
+            return trim((string) $this->_text);
         } else {
             return $this->_text;
         }

--- a/packages/zend-http/library/Zend/Http/Client.php
+++ b/packages/zend-http/library/Zend/Http/Client.php
@@ -1038,7 +1038,7 @@ class Zend_Http_Client
                    if (! empty($query)) {
                        $query .= '&';
                    }
-                $query .= http_build_query($this->paramsGet, null, '&');
+                $query .= http_build_query($this->paramsGet, '', '&');
                 if ($this->config['rfc3986_strict']) {
                     $query = str_replace('+', '%20', $query);
                 }

--- a/packages/zend-http/library/Zend/Http/Response.php
+++ b/packages/zend-http/library/Zend/Http/Response.php
@@ -260,7 +260,7 @@ class Zend_Http_Response
         $body = '';
 
         // Decode the body if it was transfer-encoded
-        switch (strtolower($this->getHeader('transfer-encoding'))) {
+        switch (strtolower((string) $this->getHeader('transfer-encoding'))) {
 
             // Handle chunked body
             case 'chunked':
@@ -275,7 +275,7 @@ class Zend_Http_Response
         }
 
         // Decode any content-encoding (gzip or deflate) if needed
-        switch (strtolower($this->getHeader('content-encoding'))) {
+        switch (strtolower((string) $this->getHeader('content-encoding'))) {
 
             // Handle gzip encoding
             case 'gzip':

--- a/packages/zend-http/library/Zend/Http/UserAgent.php
+++ b/packages/zend-http/library/Zend/Http/UserAgent.php
@@ -165,11 +165,21 @@ class Zend_Http_UserAgent implements Serializable
     }
 
     /**
-     * Serialized representation of the object
+     * Serialize object
      *
      * @return string
      */
     public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Serialize object
+     *
+     * @return array
+     */
+    public function __serialize()
     {
         $device = $this->getDevice();
         $spec = array(
@@ -180,19 +190,28 @@ class Zend_Http_UserAgent implements Serializable
             'user_agent'   => $this->getServerValue('http_user_agent'),
             'http_accept'  => $this->getServerValue('http_accept'),
         );
-        return serialize($spec);
+        return $spec;
     }
 
     /**
      * Unserialize a previous representation of the object
      *
-     * @param  string $serialized
+     * @param  string $data
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($data)
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($data));
+    }
 
+    /**
+     * Unserialize a previous representation of the object
+     *
+     * @param  array $spec
+     * @return void
+     */
+    public function __unserialize($spec)
+    {
         $this->setOptions($spec);
 
         // Determine device class and ensure the class is loaded

--- a/packages/zend-http/library/Zend/Http/UserAgent/AbstractDevice.php
+++ b/packages/zend-http/library/Zend/Http/UserAgent/AbstractDevice.php
@@ -126,6 +126,16 @@ abstract class Zend_Http_UserAgent_AbstractDevice
      */
     public function serialize()
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Serialize object
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
         $spec = array(
             '_aFeatures'      => $this->_aFeatures,
             '_aGroup'         => $this->_aGroup,
@@ -134,18 +144,28 @@ abstract class Zend_Http_UserAgent_AbstractDevice
             '_userAgent'      => $this->_userAgent,
             '_images'         => $this->_images,
         );
-        return serialize($spec);
+        return $spec;
     }
 
     /**
      * Unserialize
      *
-     * @param  string $serialized
+     * @param  string $data
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($data)
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * Unserialize
+     *
+     * @param  array $spec
+     * @return void
+     */
+    public function __unserialize($spec)
+    {
         $this->_restoreFromArray($spec);
     }
 

--- a/packages/zend-ldap/library/Zend/Ldap.php
+++ b/packages/zend-ldap/library/Zend/Ldap.php
@@ -304,7 +304,7 @@ class Zend_Ldap
                                 $val === '1' || strcasecmp($val, 'true') == 0);
                         break;
                     default:
-                        $permittedOptions[$key] = trim($val);
+                        $permittedOptions[$key] = trim((string) $val);
                         break;
                 }
             }

--- a/packages/zend-locale/library/Zend/Locale/Data.php
+++ b/packages/zend-locale/library/Zend/Locale/Data.php
@@ -333,14 +333,14 @@ class Zend_Locale_Data
             $val = implode('_' , $value);
         }
 
-        $val = urlencode($val);
+        $val = urlencode((string) $val);
         $id  = self::_filterCacheId('Zend_LocaleL_' . $locale . '_' . $path . '_' . $val);
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
             return unserialize($result);
         }
 
         $temp = array();
-        switch(strtolower($path)) {
+        switch(strtolower((string) $path)) {
             case 'language':
                 $temp = self::_getFile($locale, '/ldml/localeDisplayNames/languages/language', 'type');
                 break;
@@ -982,13 +982,13 @@ class Zend_Locale_Data
         if (is_array($value)) {
             $val = implode('_' , $value);
         }
-        $val = urlencode($val);
+        $val = urlencode((string) $val);
         $id  = self::_filterCacheId('Zend_LocaleC_' . $locale . '_' . $path . '_' . $val);
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
             return unserialize($result);
         }
 
-        switch(strtolower($path)) {
+        switch(strtolower((string) $path)) {
             case 'language':
                 $temp = self::_getFile($locale, '/ldml/localeDisplayNames/languages/language[@type=\'' . $value . '\']', 'type');
                 break;

--- a/packages/zend-locale/library/Zend/Locale/Math/PhpMath.php
+++ b/packages/zend-locale/library/Zend/Locale/Math/PhpMath.php
@@ -195,8 +195,10 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op2)) {
             return NULL;
         }
-        $op1 = self::floatalize($op1);
-        $op2 = self::floatalize($op2);
+        // this is stupid, but historically it was meant to operate only on integers.
+        // php modulo operator does not handle floats correctly
+        $op1 = (int) self::floatalize($op1);
+        $op2 = (int) self::floatalize($op2);
         if ((int)$op2 == 0) {
             return NULL;
         }

--- a/packages/zend-mail/library/Zend/Mail.php
+++ b/packages/zend-mail/library/Zend/Mail.php
@@ -1239,7 +1239,7 @@ class Zend_Mail extends Zend_Mime_Message
                       '>'  => ']',
         );
 
-        return trim(strtr($name, $rule));
+        return trim(strtr((string) $name, $rule));
     }
 
     /**

--- a/packages/zend-markup/library/Zend/Markup/Parser/Bbcode.php
+++ b/packages/zend-markup/library/Zend/Markup/Parser/Bbcode.php
@@ -215,7 +215,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_SCAN:
                     $matches = array();
                     $regex   = '#\G(?<text>[^\[]*)(?<open>\[(?<name>[' . self::NAME_CHARSET . ']+)?)?#';
-                    preg_match($regex, $this->_value, $matches, null, $this->_pointer);
+                    preg_match($regex, $this->_value, $matches, 0, $this->_pointer);
 
                     $this->_pointer += strlen($matches[0]);
 
@@ -257,7 +257,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_SCANATTRS:
                     $matches = array();
                     $regex   = '#\G((?<end>\s*\])|\s+(?<attribute>[' . self::NAME_CHARSET . ']+)(?<eq>=?))#';
-                    if (!preg_match($regex, $this->_value, $matches, null, $this->_pointer)) {
+                    if (!preg_match($regex, $this->_value, $matches, 0, $this->_pointer)) {
                         break 2;
                     }
 
@@ -296,7 +296,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_PARSEVALUE:
                     $matches = array();
                     $regex   = '#\G((?<quote>"|\')(?<valuequote>.*?)\\2|(?<value>[^\]\s]+))#';
-                    if (!preg_match($regex, $this->_value, $matches, null, $this->_pointer)) {
+                    if (!preg_match($regex, $this->_value, $matches, 0, $this->_pointer)) {
                         $this->_state = self::STATE_SCANATTRS;
                         break;
                     }

--- a/packages/zend-mime/library/Zend/Mime/Decode.php
+++ b/packages/zend-mime/library/Zend/Mime/Decode.php
@@ -218,7 +218,7 @@ class Zend_Mime_Decode
         $field, $wantedPart = null, $firstName = 0
     )
     {
-        $wantedPart = strtolower($wantedPart);
+        $wantedPart = strtolower((string) $wantedPart);
         $firstName  = strtolower($firstName);
 
         // special case - a bit optimized

--- a/packages/zend-navigation/library/Zend/Navigation/Container.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Container.php
@@ -338,7 +338,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
             
             // Use regex?
             if (true === $useRegex) {
-                if (preg_match($value, $pageProperty)) {
+                if (preg_match($value, (string) $pageProperty)) {
                     return $page;
                 }
             } else {
@@ -409,7 +409,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
             
             // Use regex?
             if (true === $useRegex) {
-                if (0 !== preg_match($value, $pageProperty)) {
+                if (0 !== preg_match($value, (string) $pageProperty)) {
                     $found[] = $page;
                 }
             } else {

--- a/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
@@ -210,7 +210,7 @@ class Zend_Oauth_Http_Utility
      */
     public static function urlEncode($value)
     {
-        $encoded = rawurlencode($value);
+        $encoded = rawurlencode((string) $value);
         $encoded = str_replace('%7E', '~', $encoded);
         return $encoded;
     }

--- a/packages/zend-paginator/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/packages/zend-paginator/library/Zend/Paginator/Adapter/DbSelect.php
@@ -86,7 +86,7 @@ class Zend_Paginator_Adapter_DbSelect implements Zend_Paginator_Adapter_Interfac
     public function __construct(Zend_Db_Select $select)
     {
         $this->_select = $select;
-        $this->_cacheIdentifier = md5($select->assemble());
+        $this->_cacheIdentifier = md5((string) $select->assemble());
     }
 
     /**

--- a/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
+++ b/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
@@ -62,20 +62,37 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      */
     public function serialize()
     {
-        return serialize(array(
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * @return array representation of the instance
+     */
+    public function __serialize()
+    {
+        return array(
             'it'     => $this->getInnerIterator(),
             'offset' => $this->_offset,
             'count'  => $this->_count,
             'pos'    => $this->getPosition(),
-        ));
+        );
     }
 
     /**
+     * Unserialize
+     *
      * @param string $data representation of the instance
      */
     public function unserialize($data)
     {
-        $dataArr = unserialize($data);
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * @param array $dataArr representation of the instance
+     */
+    public function __unserialize($dataArr)
+    {
         $this->__construct($dataArr['it'], $dataArr['offset'], $dataArr['count']);
         $this->seek($dataArr['pos']+$dataArr['offset']);
     }

--- a/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
+++ b/packages/zend-paginator/library/Zend/Paginator/SerializableLimitIterator.php
@@ -106,7 +106,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
     #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
-        $currentOffset = $this->key();
+        $currentOffset = (int) $this->key();
         $this->seek($offset);
         $current = $this->current();
         $this->seek($currentOffset);

--- a/packages/zend-progressbar/library/Zend/ProgressBar/Adapter/Console.php
+++ b/packages/zend-progressbar/library/Zend/ProgressBar/Adapter/Console.php
@@ -243,9 +243,9 @@ class Zend_ProgressBar_Adapter_Console extends Zend_ProgressBar_Adapter
                 $this->_width = 80;
 
                 // Try to determine the width through stty
-                if (preg_match('#\d+ (\d+)#', @shell_exec('stty size 2>/dev/null'), $match) === 1) {
+                if (preg_match('#\d+ (\d+)#', (string) @shell_exec('stty size 2>/dev/null'), $match) === 1) {
                     $this->_width = (int) $match[1];
-                } else if (preg_match('#columns = (\d+);#', @shell_exec('stty 2>/dev/null'), $match) === 1) {
+                } else if (preg_match('#columns = (\d+);#', (string) @shell_exec('stty 2>/dev/null'), $match) === 1) {
                     $this->_width = (int) $match[1];
                 }
             }

--- a/packages/zend-reflection/library/Zend/Reflection/Docblock.php
+++ b/packages/zend-reflection/library/Zend/Reflection/Docblock.php
@@ -57,12 +57,12 @@ class Zend_Reflection_Docblock implements Reflector
     /**
      * @var string
      */
-    protected $_longDescription = null;
+    protected $_longDescription = '';
 
     /**
      * @var string
      */
-    protected $_shortDescription = null;
+    protected $_shortDescription = '';
 
     /**
      * @var array

--- a/packages/zend-server/library/Zend/Server/Reflection/Method.php
+++ b/packages/zend-server/library/Zend/Server/Reflection/Method.php
@@ -61,6 +61,7 @@ class Zend_Server_Reflection_Method extends Zend_Server_Reflection_Function_Abst
     {
         $this->_classReflection = $class;
         $this->_reflection      = $r;
+        $this->name = $r->name;
 
         $classNamespace = $class->getNamespace();
 

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/SimpleDb/Page.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/SimpleDb/Page.php
@@ -88,7 +88,7 @@ class Zend_Service_Amazon_SimpleDb_Page
      */
     public function setToken($token)
     {
-        $this->_token = (trim($token) === '') ? null : $token;
+        $this->_token = (trim((string) $token) === '') ? null : $token;
     }
 
     /**

--- a/packages/zend-service-twitter/library/Zend/Service/Twitter.php
+++ b/packages/zend-service-twitter/library/Zend/Service/Twitter.php
@@ -1187,7 +1187,7 @@ class Zend_Service_Twitter
      */
     protected function validInteger($int)
     {
-        if (preg_match("/(\d+)/", $int)) {
+        if ($int !== null && preg_match("/(\d+)/", $int)) {
             return $int;
         }
         return 0;

--- a/packages/zend-stdlib/library/Zend/Stdlib/PriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/PriorityQueue.php
@@ -186,7 +186,17 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      */
     public function serialize()
     {
-        return serialize($this->items);
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Serialize the data structure
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->items;
     }
 
     /**
@@ -199,7 +209,20 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * Unserialize a string into a Zend_Stdlib_PriorityQueue object
+     *
+     * Serialization format is compatible with {@link Zend_Stdlib_SplPriorityQueue}
+     * 
+     * @param  array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -96,6 +96,16 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      */
     public function serialize()
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Serialize
+     * 
+     * @return array
+     */
+    public function __serialize()
+    {
         $data = array();
         $this->setExtractFlags(self::EXTR_BOTH);
         while ($this->valid()) {
@@ -109,7 +119,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
             $this->insert($item['data'], $item['priority']);
         }
 
-        return serialize($data);
+        return $data;
     }
 
     /**
@@ -120,7 +130,18 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      */
     public function unserialize($data)
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * Deserialize
+     * 
+     * @param  array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -280,7 +280,7 @@ class Zend_Tag_Cloud_Decorator_HtmlTag extends Zend_Tag_Cloud_Decorator_Tag
                 $attribute = sprintf('class="%s"', htmlspecialchars($tag->getParam('weightValue'), ENT_COMPAT, $enc));
             }
 
-            $tagHtml = sprintf('<a href="%s" %s>%s</a>', htmlSpecialChars($tag->getParam('url'), ENT_COMPAT, $enc), $attribute, $tag->getTitle());
+            $tagHtml = sprintf('<a href="%s" %s>%s</a>', htmlSpecialChars((string) $tag->getParam('url'), ENT_COMPAT, $enc), $attribute, $tag->getTitle());
 
             foreach ($this->getHtmlTags() as $key => $data) {
                 if (is_array($data)) {

--- a/packages/zend-text/library/Zend/Text/Figlet.php
+++ b/packages/zend-text/library/Zend/Text/Figlet.php
@@ -461,7 +461,7 @@ class Zend_Text_Figlet
                     $nextChar = null;
                 }
 
-                $char = (ctype_space($nextChar)) ? "\n" : ' ';
+                $char = (ctype_space((string) $nextChar)) ? "\n" : ' ';
             }
 
             $lastCharWasEol = (ctype_space($char) && $char !== "\t" && $char !== ' ');

--- a/packages/zend-translate/library/Zend/Translate/Adapter.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter.php
@@ -831,7 +831,7 @@ abstract class Zend_Translate_Adapter {
      */
     protected function _log($message, $locale) {
         if ($this->_options['logUntranslated']) {
-            $message = str_replace('%message%', $message, $this->_options['logMessage']);
+            $message = str_replace('%message%', (string) $message, $this->_options['logMessage']);
             $message = str_replace('%locale%', $locale, $message);
             if ($this->_options['log']) {
                 $this->_options['log']->log($message, $this->_options['logPriority']);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
@@ -90,7 +90,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
         }
 
         while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'])) !== false) {
-            if (substr($data[0], 0, 1) === '#') {
+            if (is_string($data[0]) && substr($data[0], 0, 1) === '#') {
                 continue;
             }
 

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
@@ -154,7 +154,7 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
 
     private function _findEncoding($filename)
     {
-        $file = file_get_contents($filename, null, null, 0, 100);
+        $file = file_get_contents($filename, false, null, 0, 100);
         if (strpos($file, "encoding") !== false) {
             $encoding = substr($file, strpos($file, "encoding") + 9);
             $encoding = substr($encoding, 1, strpos($encoding, $encoding[0], 1) - 1);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
@@ -159,7 +159,7 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
 
     private function _findEncoding($filename)
     {
-        $file = file_get_contents($filename, null, null, 0, 100);
+        $file = file_get_contents($filename, false, null, 0, 100);
         if (strpos($file, "encoding") !== false) {
             $encoding = substr($file, strpos($file, "encoding") + 9);
             $encoding = substr($encoding, 1, strpos($encoding, $encoding[0], 1) - 1);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -227,7 +227,7 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
      */
     protected function _findEncoding($filename)
     {
-        $file = file_get_contents($filename, null, null, 0, 100);
+        $file = file_get_contents($filename, false, null, 0, 100);
         if (strpos($file, "encoding") !== false) {
             $encoding = substr($file, strpos($file, "encoding") + 9);
             $encoding = substr($encoding, 1, strpos($encoding, $encoding[0], 1) - 1);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
@@ -223,7 +223,7 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
 
     private function _findEncoding($filename)
     {
-        $file = file_get_contents($filename, null, null, 0, 100);
+        $file = file_get_contents($filename, false, null, 0, 100);
         if (strpos($file, "encoding") !== false) {
             $encoding = substr($file, strpos($file, "encoding") + 9);
             $encoding = substr($encoding, 1, strpos($encoding, $encoding[0], 1) - 1);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
@@ -133,7 +133,7 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
 
     private function _findEncoding($filename)
     {
-        $file = file_get_contents($filename, null, null, 0, 100);
+        $file = file_get_contents($filename, false, null, 0, 100);
         if (strpos($file, "encoding") !== false) {
             $encoding = substr($file, strpos($file, "encoding") + 9);
             $encoding = substr($encoding, 1, strpos($encoding, $encoding[0], 1) - 1);

--- a/packages/zend-validate/library/Zend/Validate/File/Extension.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Extension.php
@@ -121,6 +121,10 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      */
     public function getExtension()
     {
+        if ($this->_extension === null) {
+            return array();
+        }
+
         $extension = explode(',', $this->_extension);
 
         return $extension;

--- a/packages/zend-view/library/Zend/View/Abstract.php
+++ b/packages/zend-view/library/Zend/View/Abstract.php
@@ -904,7 +904,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
     public function escape($var)
     {
         if (in_array($this->_escape, array('htmlspecialchars', 'htmlentities'))) {
-            return call_user_func($this->_escape, $var, ENT_COMPAT, $this->_encoding);
+            return call_user_func($this->_escape, (string) $var, ENT_COMPAT, $this->_encoding);
         }
 
         if (1 == func_num_args()) {

--- a/packages/zend-view/library/Zend/View/Helper/FormElement.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormElement.php
@@ -142,8 +142,8 @@ abstract class Zend_View_Helper_FormElement extends Zend_View_Helper_HtmlElement
         // Set ID for element
         if (array_key_exists('id', $attribs)) {
             $info['id'] = (string)$attribs['id'];
-        } else if ('' !== $info['name']) {
-            $info['id'] = trim(strtr($info['name'],
+        } else if ('' !== (string)$info['name']) {
+            $info['id'] = trim(strtr((string)$info['name'],
                                      array('[' => '-', ']' => '')), '-');
         }
         

--- a/packages/zend-view/library/Zend/View/Helper/Gravatar.php
+++ b/packages/zend-view/library/Zend/View/Helper/Gravatar.php
@@ -310,7 +310,7 @@ class Zend_View_Helper_Gravatar extends Zend_View_Helper_HtmlElement
     {
         $src = $this->_getGravatarUrl()
              . '/'
-             . md5(strtolower(trim($this->getEmail())))
+             . md5(strtolower(trim((string) $this->getEmail())))
              . '?s='
              . $this->getImgSize()
              . '&d='

--- a/tests/Zend/CodeGenerator/Php/ClassTest.php
+++ b/tests/Zend/CodeGenerator/Php/ClassTest.php
@@ -85,7 +85,7 @@ class Zend_CodeGenerator_Php_ClassTest extends PHPUnit_Framework_TestCase
 
         $properties = $codeGenClass->getProperties();
         $this->assertEquals(count($properties), 2);
-        $this->isInstanceOf(current($properties), 'Zend_CodeGenerator_Php_Property');
+        $this->isInstanceOf($properties->getIterator()->current(), 'Zend_CodeGenerator_Php_Property');
 
         $property = $codeGenClass->getProperty('propTwo');
         $this->isInstanceOf($property, 'Zend_CodeGenerator_Php_Property');
@@ -124,7 +124,7 @@ class Zend_CodeGenerator_Php_ClassTest extends PHPUnit_Framework_TestCase
 
         $methods = $codeGenClass->getMethods();
         $this->assertEquals(count($methods), 2);
-        $this->isInstanceOf(current($methods), 'Zend_CodeGenerator_Php_Method');
+        $this->isInstanceOf($methods->getIterator()->current(), 'Zend_CodeGenerator_Php_Method');
 
         $method = $codeGenClass->getMethod('methodOne');
         $this->isInstanceOf($method, 'Zend_CodeGenerator_Php_Method');

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -284,77 +284,120 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         // (which was later reverted in php < 7.2.0)
         // Example of the difference: https://3v4l.org/v46rk
         // Not really something we can test the same in all versions, so doing a version_compare here.
-        if (PHP_VERSION_ID >= 70200) {
-            $this->assertSame( 9961716, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10010341, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9966981, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10005077, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9947808, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9996412, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9953052, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9991169, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9923830, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9972397, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9929036, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9967190, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9985695, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10034357, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame( 9990996, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10029056, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        //
+        // Moreover, when php 8.1.0 deprecated date_sunset() and date_sunrise() functions,
+        // Zend_Date::calcSun() got modified to use recommended date_sun_info() function instead (which is available in php since v5.1)
+        // but that function yields slightly different results since zenith angles for sunrise/sunset/twilights are hardcoded internally
+        // and they are different to what zf used before (see $horizonDeclination in Zend_Date::calcSun() - moved from Zend_Date::_checkLocation())
+        // but ONLY NOW they are accurate! (calculations for civil / nautical / astronomical twilight were totally wrong before)
+        //
+        // Still values returned by date_sun_info() are slightly different in php 8.0+, (but only for sunrise/sunset, not for twilight)
+        // so yet another set of conditions is added to this test and DateTest::testSunFunc().
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame( 9961443, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010614, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966709, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005348, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947536, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996685, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952780, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991440, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923557, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972669, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928765, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967461, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985422, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034630, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990725, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame( 9961524, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010533, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966789, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005268, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947616, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996604, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952860, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991360, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923637, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972589, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928845, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967381, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985502, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034549, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990805, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029247, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         } else {
-            $this->assertSame( 9961681, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10010367, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9967006, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10005042, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9947773, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9996438, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9953077, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9991134, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9923795, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9972422, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9929062, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9967155, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9985660, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10034383, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame( 9991022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10029021, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame( 9961489, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010559, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966815, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005234, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947581, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996630, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952886, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991326, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923602, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972615, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928870, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967347, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985468, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034575, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990830, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029213, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         }
 
         $date = new Zend_Date_DateObjectTestHelper(-148309884);
-        if (PHP_VERSION_ID >= 70200) {
-            $this->assertSame(-148322626, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148274784, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148318143, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148279267, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148336533, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148288713, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148332072, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148293174, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148360510, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148312728, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148356087, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148317151, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148298649, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148250768, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame(-148294127, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148255290, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame(-148322895, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274514, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318410, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148278999, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336802, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288444, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332339, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148292906, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360779, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312459, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356355, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148316884, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298918, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250499, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294395, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame(-148322816, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274594, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318332, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148279078, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336723, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288523, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332261, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148292985, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360700, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312539, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356276, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148316963, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298839, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250578, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294316, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         } else {
-            $this->assertSame(-148322663, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148274758, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148318117, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148279304, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148336570, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148288687, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148332046, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148293211, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148360548, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148312703, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148356061, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148317189, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148298686, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148250742, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame(-148294101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148255327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame(-148322853, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274568, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318306, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148279115, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336760, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288497, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332235, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148293022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360738, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312513, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356250, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148317000, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298876, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250552, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294291, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255138, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         }
     }
 
@@ -663,9 +706,9 @@ class Zend_Date_DateObjectTestHelper extends Zend_Date
         return Zend_Date_DateObject::dayOfWeek($y, $m, $d);
     }
 
-    public function calcSun($location, $horizon, $rise = false)
+    public function calcSun($location, $rise = false)
     {
-        return parent::calcSun($location, $horizon, $rise);
+        return parent::calcSun($location, $rise);
     }
 
     public function date($format, $timestamp = null, $gmt = false)

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -3815,82 +3815,101 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $date = new Zend_Date(1010101010,$locale);
         $date->setTimezone(date_default_timezone_get());
 
+        // PHP's internal sunrise/sunset calculation changed in 7.2.0 and 8.0.0
+        // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal()
+
+        // Compare with: https://www.timeanddate.com/sun/austria/vienna?month=1&year=2002
         $result = Zend_Date_Cities::City('vienna');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        // PHP's internal sunrise/sunset calculation changed in 7.2.0
-        // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal
-        // This applies to all of the version_compare blocks in this test
-        $isPhp72 = PHP_VERSION_ID >= 70200;
-
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:09:40+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T20:15:51+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T20:14:02+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:09:59+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T20:14:21+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'civil');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:09:01+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T20:50:03+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T20:50:03+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:09:20+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T20:50:21+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'nautic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:08:15+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T21:29:34+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T21:29:34+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:08:34+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:29:51+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'astronomic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:07:30+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T22:07:20+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T22:07:20+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:07:49+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T22:07:36+05:00', $result->get(Zend_Date::W3C));
         }
 
+        // Compare with: https://www.timeanddate.com/sun/germany/berlin?month=1&year=2002
         unset($result);
         $result = Zend_Date_Cities::City('BERLIN');
         $this->assertTrue(is_array($result));
         $result = $date->getSunrise($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T12:21:26+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T12:14:21+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T12:16:25+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T12:21:21+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T12:16:20+05:00', $result->get(Zend_Date::W3C));
         }
 
+        // Compare with: https://www.timeanddate.com/sun/uk/london?month=1&year=2002
         unset($result);
         $result = Zend_Date_Cities::City('London');
         $this->assertTrue(is_array($result));
         $result = $date->getSunInfo($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T13:10:15+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
-            $this->assertSame('2002-01-04T13:10:59+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T13:11:50+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
-            $this->assertSame('2002-01-04T13:12:40+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
-            $this->assertSame('2002-01-04T21:00:32+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
-            $this->assertSame('2002-01-04T20:59:48+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
-            $this->assertSame('2002-01-04T20:58:57+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T20:58:07+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+        if (PHP_VERSION_ID >= 70200) {
+            if (PHP_VERSION_ID >= 80000) {
+                $this->assertSame('2002-01-04T13:03:25+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C));
+            } else {
+                $this->assertSame('2002-01-04T13:05:25+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C));
+            }
+            $this->assertSame('2002-01-04T12:25:53+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T11:43:09+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T11:02:38+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            if (PHP_VERSION_ID >= 80000) {
+                $this->assertSame('2002-01-04T21:07:22+05:00', $result['sunset']['effective']->get(Zend_Date::W3C));
+            } else {
+                $this->assertSame('2002-01-04T21:05:22+05:00', $result['sunset']['effective']->get(Zend_Date::W3C));
+            }
+            $this->assertSame('2002-01-04T21:44:54+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T22:27:38+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T23:08:09+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
         } else {
-            $this->assertSame('2002-01-04T13:10:10+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
-            $this->assertSame('2002-01-04T13:10:54+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T13:11:45+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
-            $this->assertSame('2002-01-04T13:12:35+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
-            $this->assertSame('2002-01-04T21:00:52+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
-            $this->assertSame('2002-01-04T21:00:08+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
-            $this->assertSame('2002-01-04T20:59:18+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T20:58:28+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T13:05:20+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T12:25:50+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T11:43:07+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T11:02:36+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:05:42+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
+            $this->assertSame('2002-01-04T21:45:13+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T22:27:56+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T23:08:26+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
         }
 
         unset($result);

--- a/tests/Zend/Db/Adapter/Db2Test.php
+++ b/tests/Zend/Db/Adapter/Db2Test.php
@@ -235,7 +235,7 @@ class Zend_Db_Adapter_Db2Test extends Zend_Db_Adapter_TestCommon
      */
     public function testAdapterZendConfigEmptyDriverOptions()
     {
-        Zend_Loader::loadClass('Zend_Config');
+        // Zend_Loader::loadClass('Zend_Config');
         $params = $this->_util->getParams();
         $params['driver_options'] = '';
         $params = new Zend_Config($params);

--- a/tests/Zend/Db/Adapter/TestCommon.php
+++ b/tests/Zend/Db/Adapter/TestCommon.php
@@ -48,7 +48,7 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
      */
     public function testAdapterZendConfig()
     {
-        Zend_Loader::loadClass('Zend_Config');
+        // Zend_Loader::loadClass('Zend_Config');
         $params = new Zend_Config($this->_util->getParams());
 
         $db = Zend_Db::factory($this->getDriver(), $params);
@@ -61,7 +61,7 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
      */
     public function testAdapterZendConfigEmptyNamespace()
     {
-        Zend_Loader::loadClass('Zend_Config');
+        // Zend_Loader::loadClass('Zend_Config');
         $params = $this->_util->getParams();
         $params['adapterNamespace'] = '';
         $params = new Zend_Config($params);
@@ -76,7 +76,7 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
      */
     public function testAdapterZendConfigEmptyDriverOptions()
     {
-        Zend_Loader::loadClass('Zend_Config');
+        // Zend_Loader::loadClass('Zend_Config');
         $params = $this->_util->getParams();
         $params['driver_options'] = '';
         $params = new Zend_Config($params);
@@ -203,8 +203,8 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
         $params = $this->_util->getParams();
         unset($params[$param]);
 
-        Zend_Loader::loadClass($adapterClass);
-        Zend_Loader::loadClass($exceptionClass);
+        // Zend_Loader::loadClass($adapterClass);
+        // Zend_Loader::loadClass($exceptionClass);
 
         try {
             $db = new $adapterClass($params);

--- a/tests/Zend/Db/Select/StaticTest.php
+++ b/tests/Zend/Db/Select/StaticTest.php
@@ -61,7 +61,7 @@ class Zend_Db_Select_StaticTest extends Zend_Db_Select_TestCommon
         $sql = preg_replace('/\\s+/', ' ', $select->__toString());
         $this->assertEquals('SELECT "zfproducts".* FROM "zfproducts"', $sql);
         $stmt = $select->query();
-        Zend_Loader::loadClass('Zend_Db_Statement_Static');
+        // Zend_Loader::loadClass('Zend_Db_Statement_Static');
         $this->assertTrue($stmt instanceof Zend_Db_Statement_Static);
     }
 
@@ -77,7 +77,7 @@ class Zend_Db_Select_StaticTest extends Zend_Db_Select_TestCommon
         $this->assertEquals('SELECT "zfproducts".* FROM "zfproducts" WHERE (product_id = :product_id)', $sql);
 
         $stmt = $select->query();
-        Zend_Loader::loadClass('Zend_Db_Statement_Static');
+        // Zend_Loader::loadClass('Zend_Db_Statement_Static');
         $this->assertTrue($stmt instanceof Zend_Db_Statement_Static);
     }
 

--- a/tests/Zend/Db/Table/Select/StaticTest.php
+++ b/tests/Zend/Db/Table/Select/StaticTest.php
@@ -62,7 +62,7 @@ class Zend_Db_Table_Select_StaticTest extends Zend_Db_Select_TestCommon
         $sql = preg_replace('/\\s+/', ' ', $select->__toString());
         $this->assertEquals('SELECT "zfproducts".* FROM "zfproducts"', $sql);
         $stmt = $select->query();
-        Zend_Loader::loadClass('Zend_Db_Statement_Static');
+        // Zend_Loader::loadClass('Zend_Db_Statement_Static');
         $this->assertTrue($stmt instanceof Zend_Db_Statement_Static);
     }
 
@@ -78,7 +78,7 @@ class Zend_Db_Table_Select_StaticTest extends Zend_Db_Select_TestCommon
         $this->assertEquals('SELECT "zfproducts".* FROM "zfproducts" WHERE (product_id = :product_id)', $sql);
 
         $stmt = $select->query();
-        Zend_Loader::loadClass('Zend_Db_Statement_Static');
+        // Zend_Loader::loadClass('Zend_Db_Statement_Static');
         $this->assertTrue($stmt instanceof Zend_Db_Statement_Static);
     }
 

--- a/tests/Zend/Filter/InputTest.php
+++ b/tests/Zend/Filter/InputTest.php
@@ -295,7 +295,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array(
             'month' => '6abc '
         );
-        Zend_Loader::loadClass('Zend_Filter_Digits');
+        // Zend_Loader::loadClass('Zend_Filter_Digits');
         $filters = array(
             'month' => array(new Zend_Filter_Digits())
         );
@@ -442,7 +442,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array(
             'month' => '6'
         );
-        Zend_Loader::loadClass('Zend_Validate_Digits');
+        // Zend_Loader::loadClass('Zend_Validate_Digits');
         $validators = array(
             'month' => array(
                 new Zend_Validate_Digits()
@@ -498,7 +498,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
             'field2' => 'abc123',
             'field3' => 150,
         );
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $btw = new Zend_Validate_Between(1, 100);
         $validators = array(
             'field1' => array('digits', $btw),
@@ -527,7 +527,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array(
             'field2' => 'abc123',
         );
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'field2a' => array(
                 'digits',
@@ -705,7 +705,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
             'field2' => '150'
         );
 
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
 
         $btw1 = new Zend_Validate_Between(1, 100);
 
@@ -1047,7 +1047,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array('month' => '13abc');
         $digitsMesg = 'Month should consist of digits';
         $betweenMesg = 'Month should be between 1 and 12';
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'month' => array(
                 'digits',
@@ -1078,7 +1078,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array('field1' => array('13abc', '234'));
         $digitsMesg = 'Field1 should consist of digits';
         $betweenMesg = 'Field1 should be between 1 and 12';
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'field1' => array(
                 'digits',
@@ -1108,7 +1108,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
     {
         $data = array('month' => '13abc');
         $betweenMesg = 'Month should be between 1 and 12';
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'month' => array(
                 'digits',
@@ -1164,7 +1164,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array('month' => '13abc');
         $digitsMesg = 'Month should consist of digits';
         $betweenMesg = 'Month should be between 1 and 12';
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'month' => array(
                 'digits',
@@ -1195,7 +1195,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array('month' => '13abc');
         $digitsMesg = 'Month should consist of digits';
         $betweenMesg = 'Month should be between 1 and 12';
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $validators = array(
             'month' => array(
                 'digits',
@@ -1582,7 +1582,7 @@ class Zend_Filter_InputTest extends PHPUnit_Framework_TestCase
         $data = array(
             'field1' => '150'
         );
-        Zend_Loader::loadClass('Zend_Validate_Between');
+        // Zend_Loader::loadClass('Zend_Validate_Between');
         $btw1 = new Zend_Validate_Between(1, 100);
         $btw2 = new Zend_Validate_Between(1, 125);
         $validators = array(

--- a/tests/Zend/Loader/PluginLoaderTest.php
+++ b/tests/Zend/Loader/PluginLoaderTest.php
@@ -61,7 +61,7 @@ class Zend_Loader_PluginLoaderTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        if (file_exists($this->_includeCache)) {
+        if ($this->_includeCache && file_exists($this->_includeCache)) {
             unlink($this->_includeCache);
         }
         Zend_Loader_PluginLoader::setIncludeFileCache(null);
@@ -80,7 +80,7 @@ class Zend_Loader_PluginLoaderTest extends PHPUnit_Framework_TestCase
     {
         $this->clearStaticPaths();
         Zend_Loader_PluginLoader::setIncludeFileCache(null);
-        if (file_exists($this->_includeCache)) {
+        if ($this->_includeCache && file_exists($this->_includeCache)) {
             unlink($this->_includeCache);
         }
     }


### PR DESCRIPTION
- fix deprecation notices for `Serializable` interface
  `Deprecated: Test implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)`
  https://php.watch/versions/8.1/serializable-deprecated
- [zend-amf] fix for php 8.1+ keep the order of properties when they are being serialized same as PHP <8.1

  In PHP 8.1, the order of properties is the same as in the class definition, but properties from parent class always go after properties from the current class.
  From PHP upgrade notes: https://github.com/php/php-src/blob/578b67da49af51b2f796a48782e51ceb62860943/UPGRADING#L334-L341

  Copied the `correlationId` property definition from `Zend_Amf_Value_Messaging_AsyncMessage` to parent `Zend_Amf_Value_Messaging_AbstractMessage`.
  `correlationId` prop is expected to be at the beginning of serialized messages, otherwise it breaks Zend_Amf_ResponseTest cases for php 8.1+.
  
  This was causing 14 failures in `Zend_Amf` test suite due to serialized binary data was different than expected, due to changed order of properties of serialized objects.

- [zend-server] fix issue with `Zend_Server_Reflection_Method`

  Method name was not set in constructor, but it was being read in tests (there is no property defined for it, but `__set` magic method is defined in the base class)
  resulting in `substr(): Passing null to parameter https://github.com/zf1s/zf1/pull/1 ($string) of type string is deprecated` and similar errors in various places

- [fixing errors and warnings for php 8.1](https://github.com/zf1s/zf1/pull/149/commits/37d353f8e6af3c629fdea7828ad48ef1f3c71f4b)

- includes #151 and #156