### PR TITLE
fix running tests on windows with composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-parallel-lint/php-parallel-lint": "1.3.0",
         "staabm/annotate-pull-request-from-checkstyle": "1.5.0",
         "zf1s/dbunit": "1.3.2",
-        "zf1s/phpunit": "3.7.42"
+        "zf1s/phpunit": "3.7.43"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
- bump zf1s/phpunit to [3.7.43](https://github.com/zf1s/phpunit/releases/tag/3.7.43) to mitigate composer v2 endless-loop issue with tests marked with `@runInSeparateProcess` on windows