### PR TITLE
[zend-date] properly calculate sunrise, sunset and twilight times

### DIFF
--- a/packages/zend-date/library/Zend/Date.php
+++ b/packages/zend-date/library/Zend/Date.php
@@ -3304,23 +3304,8 @@ class Zend_Date extends Zend_Date_DateObject
             throw new Zend_Date_Exception('Latitude must be between -90 and 90', 0, null, $location);
         }
 
-        if (!isset($location['horizon'])){
-            $location['horizon'] = 'effective';
-        }
-
-        switch ($location['horizon']) {
-            case 'civil' :
-                return -0.104528;
-                break;
-            case 'nautic' :
-                return -0.207912;
-                break;
-            case 'astronomic' :
-                return -0.309017;
-                break;
-            default :
-                return -0.0145439;
-                break;
+        if (isset($location['horizon']) && !in_array($location['horizon'], array('civil', 'nautic', 'astronomic', 'effective'))) {
+            throw new Zend_Date_Exception('Invalid value for \'horizon\', must be one of: \'civil\', \'nautic\', \'astronomic\', \'effective\'', 0, null, $location);
         }
     }
 
@@ -3330,7 +3315,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of sunrise
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return Zend_Date
@@ -3338,9 +3323,9 @@ class Zend_Date extends Zend_Date_DateObject
      */
     public function getSunrise($location)
     {
-        $horizon = $this->_checkLocation($location);
+        $this->_checkLocation($location);
         $result = clone $this;
-        $result->set($this->calcSun($location, $horizon, true), self::TIMESTAMP);
+        $result->set($this->calcSun($location, true), self::TIMESTAMP);
         return $result;
     }
 
@@ -3350,7 +3335,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of sunset
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return Zend_Date
@@ -3358,9 +3343,9 @@ class Zend_Date extends Zend_Date_DateObject
      */
     public function getSunset($location)
     {
-        $horizon = $this->_checkLocation($location);
+        $this->_checkLocation($location);
         $result = clone $this;
-        $result->set($this->calcSun($location, $horizon, false), self::TIMESTAMP);
+        $result->set($this->calcSun($location, false), self::TIMESTAMP);
         return $result;
     }
 
@@ -3370,7 +3355,7 @@ class Zend_Date extends Zend_Date_DateObject
      * For a list of cities and correct locations use the class Zend_Date_Cities
      *
      * @param array $location location of suninfo
-     *                   ['horizon']   -> civil, nautic, astronomical, effective (default)
+     *                   ['horizon']   -> (optional) civil, nautic, astronomic, effective (default)
      *                   ['longitude'] -> longitude of location
      *                   ['latitude']  -> latitude of location
      * @return array - [sunset|sunrise][effective|civil|nautic|astronomic]
@@ -3394,12 +3379,13 @@ class Zend_Date extends Zend_Date_DateObject
                     $location['horizon'] = 'astronomic';
                     break;
             }
-            $horizon = $this->_checkLocation($location);
+            $this->_checkLocation($location);
+
             $result = clone $this;
-            $result->set($this->calcSun($location, $horizon, true), self::TIMESTAMP);
+            $result->set($this->calcSun($location, true), self::TIMESTAMP);
             $suninfo['sunrise'][$location['horizon']] = $result;
             $result = clone $this;
-            $result->set($this->calcSun($location, $horizon, false), self::TIMESTAMP);
+            $result->set($this->calcSun($location, false), self::TIMESTAMP);
             $suninfo['sunset'][$location['horizon']]  = $result;
         }
         return $suninfo;

--- a/packages/zend-date/library/Zend/Date/Cities.php
+++ b/packages/zend-date/library/Zend/Date/Cities.php
@@ -291,18 +291,20 @@ class Zend_Date_Cities
      * Returns the location from the selected city
      *
      * @param  string $city    City to get location for
-     * @param  string $horizon Horizon to use :
+     * @param  string|null $horizon Horizon to use :
      *                         default: effective
      *                         others are civil, nautic, astronomic
      * @return array
      * @throws Zend_Date_Exception When city is unknown
      */
-    public static function City($city, $horizon = false)
+    public static function City($city, $horizon = null)
     {
         foreach (self::$cities as $key => $value) {
             if (strtolower($key) === strtolower($city)) {
                 $return            = $value;
-                $return['horizon'] = $horizon;
+                if ($horizon !== null) {
+                    $return['horizon'] = $horizon;
+                }
                 return $return;
             }
         }

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -284,77 +284,120 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         // (which was later reverted in php < 7.2.0)
         // Example of the difference: https://3v4l.org/v46rk
         // Not really something we can test the same in all versions, so doing a version_compare here.
-        if (PHP_VERSION_ID >= 70200) {
-            $this->assertSame( 9961716, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10010341, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9966981, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10005077, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9947808, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9996412, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9953052, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9991169, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9923830, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9972397, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9929036, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9967190, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9985695, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10034357, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame( 9990996, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10029056, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        //
+        // Moreover, when php 8.1.0 deprecated date_sunset() and date_sunrise() functions,
+        // Zend_Date::calcSun() got modified to use recommended date_sun_info() function instead (which is available in php since v5.1)
+        // but that function yields slightly different results since zenith angles for sunrise/sunset/twilights are hardcoded internally
+        // and they are different to what zf used before (see $horizonDeclination in Zend_Date::calcSun() - moved from Zend_Date::_checkLocation())
+        // but ONLY NOW they are accurate! (calculations for civil / nautical / astronomical twilight were totally wrong before)
+        //
+        // Still values returned by date_sun_info() are slightly different in php 8.0+, (but only for sunrise/sunset, not for twilight)
+        // so yet another set of conditions is added to this test and DateTest::testSunFunc().
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame( 9961443, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010614, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966709, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005348, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947536, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996685, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952780, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991440, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923557, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972669, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928765, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967461, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985422, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034630, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990725, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame( 9961524, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010533, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966789, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005268, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947616, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996604, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952860, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991360, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923637, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972589, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928845, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967381, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985502, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034549, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990805, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029247, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         } else {
-            $this->assertSame( 9961681, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10010367, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9967006, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(10005042, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame( 9947773, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9996438, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9953077, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame( 9991134, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame( 9923795, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9972422, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9929062, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame( 9967155, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame( 9985660, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10034383, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame( 9991022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(10029021, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame( 9961489, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(10010559, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame( 9966815, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(10005234, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame( 9947581, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9996630, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9952886, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame( 9991326, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame( 9923602, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9972615, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame( 9928870, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame( 9967347, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame( 9985468, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10034575, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame( 9990830, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(10029213, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         }
 
         $date = new Zend_Date_DateObjectTestHelper(-148309884);
-        if (PHP_VERSION_ID >= 70200) {
-            $this->assertSame(-148322626, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148274784, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148318143, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148279267, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148336533, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148288713, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148332072, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148293174, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148360510, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148312728, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148356087, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148317151, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148298649, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148250768, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame(-148294127, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148255290, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+        if (PHP_VERSION_ID >= 80100) {
+            $this->assertSame(-148322895, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274514, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318410, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148278999, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336802, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288444, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332339, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148292906, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360779, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312459, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356355, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148316884, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298918, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250499, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294395, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame(-148322816, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274594, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318332, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148279078, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336723, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288523, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332261, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148292985, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360700, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312539, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356276, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148316963, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298839, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250578, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294316, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         } else {
-            $this->assertSame(-148322663, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148274758, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148318117, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, true ));
-            $this->assertSame(-148279304, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), -0.0145439, false));
-            $this->assertSame(-148336570, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148288687, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148332046, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, true ));
-            $this->assertSame(-148293211, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), -0.0145439, false));
-            $this->assertSame(-148360548, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148312703, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148356061, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, true ));
-            $this->assertSame(-148317189, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), -0.0145439, false));
-            $this->assertSame(-148298686, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148250742, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), -0.0145439, false));
-            $this->assertSame(-148294101, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, true ));
-            $this->assertSame(-148255327, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), -0.0145439, false));
+            $this->assertSame(-148322853, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148274568, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
+            $this->assertSame(-148318306, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));
+            $this->assertSame(-148279115, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), false));
+            $this->assertSame(-148336760, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148288497, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148332235, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), true ));
+            $this->assertSame(-148293022, $date->calcSun(array('latitude' => -38.4, 'longitude' =>  29), false));
+            $this->assertSame(-148360738, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148312513, $date->calcSun(array('latitude' =>  38.4, 'longitude' => 129), false));
+            $this->assertSame(-148356250, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), true ));
+            $this->assertSame(-148317000, $date->calcSun(array('latitude' => -38.4, 'longitude' => 129), false));
+            $this->assertSame(-148298876, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148250552, $date->calcSun(array('latitude' =>  38.4, 'longitude' =>-129), false));
+            $this->assertSame(-148294291, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), true ));
+            $this->assertSame(-148255138, $date->calcSun(array('latitude' => -38.4, 'longitude' =>-129), false));
         }
     }
 
@@ -663,9 +706,9 @@ class Zend_Date_DateObjectTestHelper extends Zend_Date
         return Zend_Date_DateObject::dayOfWeek($y, $m, $d);
     }
 
-    public function calcSun($location, $horizon, $rise = false)
+    public function calcSun($location, $rise = false)
     {
-        return parent::calcSun($location, $horizon, $rise);
+        return parent::calcSun($location, $rise);
     }
 
     public function date($format, $timestamp = null, $gmt = false)

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -347,7 +347,7 @@ class Zend_Date_DateObjectTest extends PHPUnit_Framework_TestCase
         }
 
         $date = new Zend_Date_DateObjectTestHelper(-148309884);
-        if (PHP_VERSION_ID >= 80100) {
+        if (PHP_VERSION_ID >= 80000) {
             $this->assertSame(-148322895, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), true ));
             $this->assertSame(-148274514, $date->calcSun(array('latitude' =>  38.4, 'longitude' => -29), false));
             $this->assertSame(-148318410, $date->calcSun(array('latitude' => -38.4, 'longitude' => -29), true ));

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -3815,82 +3815,101 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
         $date = new Zend_Date(1010101010,$locale);
         $date->setTimezone(date_default_timezone_get());
 
+        // PHP's internal sunrise/sunset calculation changed in 7.2.0 and 8.0.0
+        // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal()
+
+        // Compare with: https://www.timeanddate.com/sun/austria/vienna?month=1&year=2002
         $result = Zend_Date_Cities::City('vienna');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        // PHP's internal sunrise/sunset calculation changed in 7.2.0
-        // See comment in Zend/Date/DateObjectTest.php::testCalcSunInternal
-        // This applies to all of the version_compare blocks in this test
-        $isPhp72 = PHP_VERSION_ID >= 70200;
-
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:09:40+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T20:15:51+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T20:14:02+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:09:59+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T20:14:21+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'civil');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:09:01+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T20:50:03+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T20:50:03+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:09:20+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T20:50:21+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'nautic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:08:15+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T21:29:34+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T21:29:34+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:08:34+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:29:51+05:00', $result->get(Zend_Date::W3C));
         }
 
         unset($result);
         $result = Zend_Date_Cities::City('vienna', 'astronomic');
         $this->assertTrue(is_array($result));
         $result = $date->getSunset($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T20:07:30+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T22:07:20+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T22:07:20+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T20:07:49+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T22:07:36+05:00', $result->get(Zend_Date::W3C));
         }
 
+        // Compare with: https://www.timeanddate.com/sun/germany/berlin?month=1&year=2002
         unset($result);
         $result = Zend_Date_Cities::City('BERLIN');
         $this->assertTrue(is_array($result));
         $result = $date->getSunrise($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T12:21:26+05:00', $result->get(Zend_Date::W3C));
+        if (PHP_VERSION_ID >= 80000) {
+            $this->assertSame('2002-01-04T12:14:21+05:00', $result->get(Zend_Date::W3C));
+        } else if (PHP_VERSION_ID >= 70200) {
+            $this->assertSame('2002-01-04T12:16:25+05:00', $result->get(Zend_Date::W3C));
         } else {
-            $this->assertSame('2002-01-04T12:21:21+05:00', $result->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T12:16:20+05:00', $result->get(Zend_Date::W3C));
         }
 
+        // Compare with: https://www.timeanddate.com/sun/uk/london?month=1&year=2002
         unset($result);
         $result = Zend_Date_Cities::City('London');
         $this->assertTrue(is_array($result));
         $result = $date->getSunInfo($result);
-        if ($isPhp72) {
-            $this->assertSame('2002-01-04T13:10:15+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
-            $this->assertSame('2002-01-04T13:10:59+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T13:11:50+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
-            $this->assertSame('2002-01-04T13:12:40+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
-            $this->assertSame('2002-01-04T21:00:32+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
-            $this->assertSame('2002-01-04T20:59:48+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
-            $this->assertSame('2002-01-04T20:58:57+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T20:58:07+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+        if (PHP_VERSION_ID >= 70200) {
+            if (PHP_VERSION_ID >= 80000) {
+                $this->assertSame('2002-01-04T13:03:25+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C));
+            } else {
+                $this->assertSame('2002-01-04T13:05:25+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C));
+            }
+            $this->assertSame('2002-01-04T12:25:53+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T11:43:09+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T11:02:38+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            if (PHP_VERSION_ID >= 80000) {
+                $this->assertSame('2002-01-04T21:07:22+05:00', $result['sunset']['effective']->get(Zend_Date::W3C));
+            } else {
+                $this->assertSame('2002-01-04T21:05:22+05:00', $result['sunset']['effective']->get(Zend_Date::W3C));
+            }
+            $this->assertSame('2002-01-04T21:44:54+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T22:27:38+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T23:08:09+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
         } else {
-            $this->assertSame('2002-01-04T13:10:10+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
-            $this->assertSame('2002-01-04T13:10:54+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T13:11:45+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
-            $this->assertSame('2002-01-04T13:12:35+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
-            $this->assertSame('2002-01-04T21:00:52+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
-            $this->assertSame('2002-01-04T21:00:08+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
-            $this->assertSame('2002-01-04T20:59:18+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
-            $this->assertSame('2002-01-04T20:58:28+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T13:05:20+05:00', $result['sunrise']['effective']->get(Zend_Date::W3C ));
+            $this->assertSame('2002-01-04T12:25:50+05:00', $result['sunrise']['civil']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T11:43:07+05:00', $result['sunrise']['nautic']->get(Zend_Date::W3C    ));
+            $this->assertSame('2002-01-04T11:02:36+05:00', $result['sunrise']['astronomic']->get(Zend_Date::W3C));
+            $this->assertSame('2002-01-04T21:05:42+05:00', $result['sunset']['effective']->get(Zend_Date::W3C  ));
+            $this->assertSame('2002-01-04T21:45:13+05:00', $result['sunset']['civil']->get(Zend_Date::W3C      ));
+            $this->assertSame('2002-01-04T22:27:56+05:00', $result['sunset']['nautic']->get(Zend_Date::W3C     ));
+            $this->assertSame('2002-01-04T23:08:26+05:00', $result['sunset']['astronomic']->get(Zend_Date::W3C ));
         }
 
         unset($result);


### PR DESCRIPTION
`date_sunset()` and `date_sunrise()` are deprecated in php 8.1+ - switched to recommended `date_sun_info()` function (which is available since php v5.1)
https://www.php.net/manual/en/function.date-sun-info.php#refsect1-function.date-sun-info-returnvalues

but that function yields slightly different results since zenith angles for sunrise/sunset/twilights are hardcoded internally
and they are different to what zf used before (see `$horizonDeclination` in `Zend_Date::calcSun()` - moved from `Zend_Date::_checkLocation()`)

Yet ONLY NOW they are accurate! (calculations for civil / nautical / astronomical twilight were totally wrong before)
