### PR TITLE
[zend-timesync] fix ntp time sync

### DIFF
--- a/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
+++ b/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
@@ -67,6 +67,7 @@ class Zend_TimeSync_Ntp extends Zend_TimeSync_Protocol
     protected function _prepare()
     {
         list($frac, $sec) = explode(' ', microtime());
+        $frac = (int) round((float) $frac * 4294967296);
         $fracba = ($frac & 0xff000000) >> 24;
         $fracbb = ($frac & 0x00ff0000) >> 16;
         $fracbc = ($frac & 0x0000ff00) >> 8;

--- a/tests/Zend/TimeSyncTest.php
+++ b/tests/Zend/TimeSyncTest.php
@@ -344,4 +344,10 @@ class Zend_TimeSyncTest extends PHPUnit_Framework_TestCase
             // nothing
         }
     }
+
+    public function testMicrotimeToNtp()
+    {
+        $ntp = Zend_TimeSync_Ntp::microtimeToNtp('0.123456 1234567890');
+        $this->assertSame(pack('NN', 0xcd408152, 0x1f9acffa), $ntp);
+    }
 }


### PR DESCRIPTION
NTP timestamps are represented as a 64-bit fixed-point number, in seconds relative to 0000 UT on 1 January 1900.  The integer part is in the first 32 bits and the fraction part in the last 32 bits.

https://www.eecis.udel.edu/~mills/time.html
https://tickelton.gitlab.io/articles/ntp-timestamps/

But calculation of the fractional part was broken since forever, always sending 00000000 to a ntp server - fractional seconds were not being multiplied by max value of 32-bit+1 to represent the fraction in 0-[(2^32)-1] range, as expected by ntp protocol. In result, Zent_TimeSync_Ntp has always been reporting time in full-second resolution to ntp servers when syncing time.

Moreover, it triggered `Implicit conversion from float-string "0.xyz" to int loses precision` in `Zend/TimeSync/Ntp.php:70` on PHP 8.1 and that's how I started my investigation.