### PR TITLE
release 1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 ## Changelog:
 
+### 1.15.1 - 2022-12-12
+- general
+  - php 8.1 compatibility fixes ([#149])
+  - php 8.1 compat: `ReturnTypeWillChange` Attribute ([#147])
+  - require php extensions in dev only - avoid composer warnings for missing extensions when installing `zf1s/zf1` package ([#136])
+  - add missing `@throws` annotations ([#140])
+  - fix psr-0 autoloading issues ([#135])
+  - clean up `zf1s/zf1` package by ignoring unwanted files in export-ignore ([#134])
+- zend-amf
+  - fix for php 8.1+ keep the order of properties when they are being serialized same as PHP <8.1 ([#149])
+  - phpdoc: fix `Zend_Amf_Server_Response` class name, should be `Zend_Amf_Response` ([#137])
+- zend-console-getopt
+  - Fix `str_split('')` logic to keep same as PHP before 8.2 on PHP 8.2 ([#143])
+- zend-date
+  - properly calculate sunrise, sunset and twilight times ([#151])
+- zend-db
+  - fix MySQLi adapter after changing default reporting mode by PHP 8.1 ([#156], [#158])
+- zend-openid
+  -  fix for `Zend_OpenId_Consumer_Storage_File` when symlinks are not used (i.e. on windows) ([#148])
+- zend-progressbar
+  - fix "stty: 'standard input': Inappropriate ioctl for device" spam ([#155])
+- zend-server
+  - fix issues with `Zend_Server_Reflection_Method` ([#149])
+- zend-timesync
+  - fix ntp time sync ([#153])
+- general: CI
+  - enable php 8.1/8.2 builds ([#129])
+  - fix CI warnings: Node.js 12 actions are deprecated ([#139])
+  - utilize continue-on-error for 'experimental' flag ([#142])
+  - enable SQLite tests ([#157])
+- general: tests
+  - fix running tests on windows with composer v2 ([#150])
+  - [zend-loader] fix failing Zend_Loader_PluginLoaderTest on windows ([#154])
+  - [zend-paginator] use a temporary fixture test file for unit testing that git ignores ([#160])
+
+[#129]: https://github.com/zf1s/zf1/pull/129
+[#134]: https://github.com/zf1s/zf1/pull/134
+[#135]: https://github.com/zf1s/zf1/pull/135
+[#136]: https://github.com/zf1s/zf1/pull/136
+[#137]: https://github.com/zf1s/zf1/pull/137
+[#139]: https://github.com/zf1s/zf1/pull/139
+[#140]: https://github.com/zf1s/zf1/pull/140
+[#142]: https://github.com/zf1s/zf1/pull/142
+[#143]: https://github.com/zf1s/zf1/pull/143
+[#147]: https://github.com/zf1s/zf1/pull/147
+[#148]: https://github.com/zf1s/zf1/pull/148
+[#149]: https://github.com/zf1s/zf1/pull/149
+[#150]: https://github.com/zf1s/zf1/pull/150
+[#151]: https://github.com/zf1s/zf1/pull/151
+[#153]: https://github.com/zf1s/zf1/pull/153
+[#154]: https://github.com/zf1s/zf1/pull/154
+[#155]: https://github.com/zf1s/zf1/pull/155
+[#156]: https://github.com/zf1s/zf1/pull/156
+[#157]: https://github.com/zf1s/zf1/pull/157
+[#158]: https://github.com/zf1s/zf1/pull/158
+[#160]: https://github.com/zf1s/zf1/pull/160
+
 ### 1.15.0 - 2022-10-05
 - zend-loader
   - overhaul of zend-loader and autoloader done again ([#116])

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Original README: [click](README.orig.md)
 2. Bump interdependencies of packages to the next version
 
     ```bash
-    ../monorepo-builder/bin/monorepo-builder bump-interdependency "^1.15.1"
+    ../monorepo-builder/bin/monorepo-builder bump-interdependency "^1.15.2"
     ```
    
 3. Add git tag and push to this monorepo
@@ -147,7 +147,7 @@ Original README: [click](README.orig.md)
    
     Split operation:
     ```bash
-    ../monorepo-builder/bin/monorepo-builder split --max-processes=1 --tag=1.15.1
+    ../monorepo-builder/bin/monorepo-builder split --max-processes=1 --tag=1.15.2
     ```
 
 _Note: I had no success splitting this repo on win os, so unix-based system is recommended. (or WSL)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ where `*` may be one of:
 [xmlrpc](https://github.com/zf1s/zend-xmlrpc).
 
 These packages will be maintained as long as we're using them, mainly just to keep it all working on new versions of PHP as they're released.
-Currently everything should be compatible with **PHP 5.3-8.0**. _5.2 support is dropped._
+Currently everything should be compatible with **PHP 5.3-8.1**. _5.2 support is dropped._
 
 They may also contain some fixes, either for long-standing bugs, which haven't made their way into zf1 official repo before EOL, or newly found ones
 and (backwards compatible) adjustments (optimisations for composer autoloader mostly). Maybe even one or two new features.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zf1s/zf1",
-    "description": "Zend Framework 1 complete package, PHP 5.3-8.0 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
+    "description": "Zend Framework 1 complete package, PHP 5.3-8.1 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",

--- a/packages/zend-acl/README.md
+++ b/packages/zend-acl/README.md
@@ -1,7 +1,7 @@
 # zend-acl (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-acl/composer.json
+++ b/packages/zend-acl/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-amf/README.md
+++ b/packages/zend-amf/README.md
@@ -1,7 +1,7 @@
 # zend-amf (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-amf/composer.json
+++ b/packages/zend-amf/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-server": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-server": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-application/README.md
+++ b/packages/zend-application/README.md
@@ -1,7 +1,7 @@
 # zend-application (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-application/composer.json
+++ b/packages/zend-application/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-controller": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-controller": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-auth/README.md
+++ b/packages/zend-auth/README.md
@@ -1,7 +1,7 @@
 # zend-auth (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-auth/composer.json
+++ b/packages/zend-auth/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-barcode/README.md
+++ b/packages/zend-barcode/README.md
@@ -1,7 +1,7 @@
 # zend-barcode (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-barcode/composer.json
+++ b/packages/zend-barcode/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-cache/README.md
+++ b/packages/zend-cache/README.md
@@ -1,7 +1,7 @@
 # zend-cache (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-cache/composer.json
+++ b/packages/zend-cache/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-captcha/README.md
+++ b/packages/zend-captcha/README.md
@@ -1,7 +1,7 @@
 # zend-captcha (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-captcha/composer.json
+++ b/packages/zend-captcha/composer.json
@@ -7,11 +7,11 @@
     "require": {
         "php": ">=5.3.3",
         "ext-gd": "*",
-        "zf1s/zend-crypt": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-service-recaptcha": "^1.15.0",
-        "zf1s/zend-text": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-crypt": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-service-recaptcha": "^1.15.1",
+        "zf1s/zend-text": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-cloud/README.md
+++ b/packages/zend-cloud/README.md
@@ -1,7 +1,7 @@
 # zend-cloud (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-cloud/composer.json
+++ b/packages/zend-cloud/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-queue": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-queue": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-codegenerator/README.md
+++ b/packages/zend-codegenerator/README.md
@@ -1,7 +1,7 @@
 # zend-codegenerator (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-codegenerator/composer.json
+++ b/packages/zend-codegenerator/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-reflection": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-reflection": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-config/README.md
+++ b/packages/zend-config/README.md
@@ -1,7 +1,7 @@
 # zend-config (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-config/composer.json
+++ b/packages/zend-config/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-console-getopt/README.md
+++ b/packages/zend-console-getopt/README.md
@@ -1,7 +1,7 @@
 # zend-console-getopt (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-console-getopt/composer.json
+++ b/packages/zend-console-getopt/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-controller/README.md
+++ b/packages/zend-controller/README.md
@@ -1,7 +1,7 @@
 # zend-controller (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -8,13 +8,13 @@
         "php": ">=5.3.3",
         "ext-reflection": "*",
         "ext-session": "*",
-        "zf1s/zend-config": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-view": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-config": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-view": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-crypt/README.md
+++ b/packages/zend-crypt/README.md
@@ -1,7 +1,7 @@
 # zend-crypt (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-crypt/composer.json
+++ b/packages/zend-crypt/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-currency/README.md
+++ b/packages/zend-currency/README.md
@@ -1,7 +1,7 @@
 # zend-currency (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-currency/composer.json
+++ b/packages/zend-currency/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-date/README.md
+++ b/packages/zend-date/README.md
@@ -1,7 +1,7 @@
 # zend-date (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-date/composer.json
+++ b/packages/zend-date/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-db/README.md
+++ b/packages/zend-db/README.md
@@ -1,7 +1,7 @@
 # zend-db (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-db/composer.json
+++ b/packages/zend-db/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-debug/README.md
+++ b/packages/zend-debug/README.md
@@ -1,7 +1,7 @@
 # zend-debug (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-dojo/README.md
+++ b/packages/zend-dojo/README.md
@@ -1,7 +1,7 @@
 # zend-dojo (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-dojo/composer.json
+++ b/packages/zend-dojo/composer.json
@@ -6,11 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-form": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0",
-        "zf1s/zend-view": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-form": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1",
+        "zf1s/zend-view": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-dom/README.md
+++ b/packages/zend-dom/README.md
@@ -1,7 +1,7 @@
 # zend-dom (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-dom/composer.json
+++ b/packages/zend-dom/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-eventmanager/README.md
+++ b/packages/zend-eventmanager/README.md
@@ -1,7 +1,7 @@
 # zend-eventmanager (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-eventmanager/composer.json
+++ b/packages/zend-eventmanager/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-stdlib": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-stdlib": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-exception/README.md
+++ b/packages/zend-exception/README.md
@@ -1,7 +1,7 @@
 # zend-exception (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-feed/README.md
+++ b/packages/zend-feed/README.md
@@ -1,7 +1,7 @@
 # zend-feed (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-feed/composer.json
+++ b/packages/zend-feed/composer.json
@@ -9,12 +9,12 @@
         "ext-dom": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-version": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-version": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-file-transfer/README.md
+++ b/packages/zend-file-transfer/README.md
@@ -1,7 +1,7 @@
 # zend-file-transfer (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-file-transfer/composer.json
+++ b/packages/zend-file-transfer/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-file/README.md
+++ b/packages/zend-file/README.md
@@ -1,7 +1,7 @@
 # zend-file (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-filter/README.md
+++ b/packages/zend-filter/README.md
@@ -1,7 +1,7 @@
 # zend-filter (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-filter/composer.json
+++ b/packages/zend-filter/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-crypt": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-crypt": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-form/README.md
+++ b/packages/zend-form/README.md
@@ -1,7 +1,7 @@
 # zend-form (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-form/composer.json
+++ b/packages/zend-form/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-filter": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-filter": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-gdata/README.md
+++ b/packages/zend-gdata/README.md
@@ -1,7 +1,7 @@
 # zend-gdata (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-gdata/composer.json
+++ b/packages/zend-gdata/composer.json
@@ -8,11 +8,11 @@
         "php": ">=5.3.3",
         "ext-ctype": "*",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-mime": "^1.15.0",
-        "zf1s/zend-version": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-mime": "^1.15.1",
+        "zf1s/zend-version": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-http/README.md
+++ b/packages/zend-http/README.md
@@ -1,7 +1,7 @@
 # zend-http (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-http/composer.json
+++ b/packages/zend-http/composer.json
@@ -7,9 +7,9 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-json/README.md
+++ b/packages/zend-json/README.md
@@ -1,7 +1,7 @@
 # zend-json (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-json/composer.json
+++ b/packages/zend-json/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-server": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-server": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-layout/README.md
+++ b/packages/zend-layout/README.md
@@ -1,7 +1,7 @@
 # zend-layout (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-layout/composer.json
+++ b/packages/zend-layout/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-ldap/README.md
+++ b/packages/zend-ldap/README.md
@@ -1,7 +1,7 @@
 # zend-ldap (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-ldap/composer.json
+++ b/packages/zend-ldap/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ldap": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-loader/README.md
+++ b/packages/zend-loader/README.md
@@ -1,7 +1,7 @@
 # zend-loader (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-loader/composer.json
+++ b/packages/zend-loader/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-locale/README.md
+++ b/packages/zend-locale/README.md
@@ -1,7 +1,7 @@
 # zend-locale (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-locale/composer.json
+++ b/packages/zend-locale/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0",
-        "zf1s/zend-cache": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1",
+        "zf1s/zend-cache": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-log/README.md
+++ b/packages/zend-log/README.md
@@ -1,7 +1,7 @@
 # zend-log (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-log/composer.json
+++ b/packages/zend-log/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mail/README.md
+++ b/packages/zend-mail/README.md
@@ -1,7 +1,7 @@
 # zend-mail (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-mail/composer.json
+++ b/packages/zend-mail/composer.json
@@ -6,11 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-mime": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-mime": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-markup/README.md
+++ b/packages/zend-markup/README.md
@@ -1,7 +1,7 @@
 # zend-markup (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-markup/composer.json
+++ b/packages/zend-markup/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-filter": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-filter": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-measure/README.md
+++ b/packages/zend-measure/README.md
@@ -1,7 +1,7 @@
 # zend-measure (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-measure/composer.json
+++ b/packages/zend-measure/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-memory/README.md
+++ b/packages/zend-memory/README.md
@@ -1,7 +1,7 @@
 # zend-memory (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-memory/composer.json
+++ b/packages/zend-memory/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-cache": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-cache": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mime/README.md
+++ b/packages/zend-mime/README.md
@@ -1,7 +1,7 @@
 # zend-mime (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-mime/composer.json
+++ b/packages/zend-mime/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-mobile/README.md
+++ b/packages/zend-mobile/README.md
@@ -1,7 +1,7 @@
 # zend-mobile (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-mobile/composer.json
+++ b/packages/zend-mobile/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-navigation/README.md
+++ b/packages/zend-navigation/README.md
@@ -1,7 +1,7 @@
 # zend-navigation (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-navigation/composer.json
+++ b/packages/zend-navigation/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-controller": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-controller": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-oauth/README.md
+++ b/packages/zend-oauth/README.md
@@ -1,7 +1,7 @@
 # zend-oauth (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-oauth/composer.json
+++ b/packages/zend-oauth/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-crypt": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-crypt": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-openid/README.md
+++ b/packages/zend-openid/README.md
@@ -1,7 +1,7 @@
 # zend-openid (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-openid/composer.json
+++ b/packages/zend-openid/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-session": "^1.15.0"
+        "zf1s/zend-controller": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-session": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-paginator/README.md
+++ b/packages/zend-paginator/README.md
@@ -1,7 +1,7 @@
 # zend-paginator (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-paginator/composer.json
+++ b/packages/zend-paginator/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-pdf/README.md
+++ b/packages/zend-pdf/README.md
@@ -1,7 +1,7 @@
 # zend-pdf (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-pdf/composer.json
+++ b/packages/zend-pdf/composer.json
@@ -10,9 +10,9 @@
         "ext-gd": "*",
         "ext-iconv": "*",
         "ext-zlib": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-log": "^1.15.0",
-        "zf1s/zend-memory": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-log": "^1.15.1",
+        "zf1s/zend-memory": "^1.15.1",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-progressbar/README.md
+++ b/packages/zend-progressbar/README.md
@@ -1,7 +1,7 @@
 # zend-progressbar (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-progressbar/composer.json
+++ b/packages/zend-progressbar/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-config": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0"
+        "zf1s/zend-config": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-queue/README.md
+++ b/packages/zend-queue/README.md
@@ -1,7 +1,7 @@
 # zend-queue (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-queue/composer.json
+++ b/packages/zend-queue/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-reflection/README.md
+++ b/packages/zend-reflection/README.md
@@ -1,7 +1,7 @@
 # zend-reflection (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-reflection/composer.json
+++ b/packages/zend-reflection/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-registry/README.md
+++ b/packages/zend-registry/README.md
@@ -1,7 +1,7 @@
 # zend-registry (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-registry/composer.json
+++ b/packages/zend-registry/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-rest/README.md
+++ b/packages/zend-rest/README.md
@@ -1,7 +1,7 @@
 # zend-rest (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-rest/composer.json
+++ b/packages/zend-rest/composer.json
@@ -10,11 +10,11 @@
         "ext-dom": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-server": "^1.15.0",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-server": "^1.15.1",
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-search-lucene/README.md
+++ b/packages/zend-search-lucene/README.md
@@ -1,7 +1,7 @@
 # zend-search-lucene (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-search-lucene/composer.json
+++ b/packages/zend-search-lucene/composer.json
@@ -9,9 +9,9 @@
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-search": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-search": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1",
         "symfony/polyfill-php70": "^1.19"
     },
     "autoload": {

--- a/packages/zend-search/README.md
+++ b/packages/zend-search/README.md
@@ -1,7 +1,7 @@
 # zend-search (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-search/composer.json
+++ b/packages/zend-search/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-serializer/README.md
+++ b/packages/zend-serializer/README.md
@@ -1,7 +1,7 @@
 # zend-serializer (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-serializer/composer.json
+++ b/packages/zend-serializer/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-server/README.md
+++ b/packages/zend-server/README.md
@@ -1,7 +1,7 @@
 # zend-server (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-server/composer.json
+++ b/packages/zend-server/composer.json
@@ -8,7 +8,7 @@
         "php": ">=5.3.3",
         "ext-spl": "*",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-akismet/README.md
+++ b/packages/zend-service-akismet/README.md
@@ -1,7 +1,7 @@
 # zend-service-akismet (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-akismet/composer.json
+++ b/packages/zend-service-akismet/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-version": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-version": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-amazon/README.md
+++ b/packages/zend-service-amazon/README.md
@@ -1,7 +1,7 @@
 # zend-service-amazon (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-amazon/composer.json
+++ b/packages/zend-service-amazon/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-rest": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-rest": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-audioscrobbler/README.md
+++ b/packages/zend-service-audioscrobbler/README.md
@@ -1,7 +1,7 @@
 # zend-service-audioscrobbler (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-audioscrobbler/composer.json
+++ b/packages/zend-service-audioscrobbler/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-iconv": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-console/README.md
+++ b/packages/zend-service-console/README.md
@@ -1,7 +1,7 @@
 # zend-service-console (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-delicious/README.md
+++ b/packages/zend-service-delicious/README.md
@@ -1,7 +1,7 @@
 # zend-service-delicious (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-delicious/composer.json
+++ b/packages/zend-service-delicious/composer.json
@@ -7,12 +7,12 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "zf1s/zend-date": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0",
-        "zf1s/zend-rest": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-date": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1",
+        "zf1s/zend-rest": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-ebay/README.md
+++ b/packages/zend-service-ebay/README.md
@@ -1,7 +1,7 @@
 # zend-service-ebay (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-ebay/composer.json
+++ b/packages/zend-service-ebay/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-rest": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-rest": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-flickr/README.md
+++ b/packages/zend-service-flickr/README.md
@@ -1,7 +1,7 @@
 # zend-service-flickr (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-flickr/composer.json
+++ b/packages/zend-service-flickr/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-livedocx/README.md
+++ b/packages/zend-service-livedocx/README.md
@@ -1,7 +1,7 @@
 # zend-service-livedocx (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-livedocx/composer.json
+++ b/packages/zend-service-livedocx/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-date": "^1.15.0",
-        "zf1s/zend-soap": "^1.15.0"
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-date": "^1.15.1",
+        "zf1s/zend-soap": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-rackspace/README.md
+++ b/packages/zend-service-rackspace/README.md
@@ -1,7 +1,7 @@
 # zend-service-rackspace (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-rackspace/composer.json
+++ b/packages/zend-service-rackspace/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-recaptcha/README.md
+++ b/packages/zend-service-recaptcha/README.md
@@ -1,7 +1,7 @@
 # zend-service-recaptcha (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-recaptcha/composer.json
+++ b/packages/zend-service-recaptcha/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-shorturl/README.md
+++ b/packages/zend-service-shorturl/README.md
@@ -1,7 +1,7 @@
 # zend-service-shorturl (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-shorturl/composer.json
+++ b/packages/zend-service-shorturl/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0"
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-slideshare/README.md
+++ b/packages/zend-service-slideshare/README.md
@@ -1,7 +1,7 @@
 # zend-service-slideshare (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-slideshare/composer.json
+++ b/packages/zend-service-slideshare/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-cache": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-cache": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-strikeiron/README.md
+++ b/packages/zend-service-strikeiron/README.md
@@ -1,7 +1,7 @@
 # zend-service-strikeiron (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-strikeiron/composer.json
+++ b/packages/zend-service-strikeiron/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-twitter/README.md
+++ b/packages/zend-service-twitter/README.md
@@ -1,7 +1,7 @@
 # zend-service-twitter (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-twitter/composer.json
+++ b/packages/zend-service-twitter/composer.json
@@ -6,12 +6,12 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-feed": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0",
-        "zf1s/zend-rest": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-feed": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1",
+        "zf1s/zend-rest": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-windowsazure/README.md
+++ b/packages/zend-service-windowsazure/README.md
@@ -1,7 +1,7 @@
 # zend-service-windowsazure (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-windowsazure/composer.json
+++ b/packages/zend-service-windowsazure/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-service": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-service": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-yahoo/README.md
+++ b/packages/zend-service-yahoo/README.md
@@ -1,7 +1,7 @@
 # zend-service-yahoo (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service-yahoo/composer.json
+++ b/packages/zend-service-yahoo/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-rest": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-rest": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service/README.md
+++ b/packages/zend-service/README.md
@@ -1,7 +1,7 @@
 # zend-service (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-service/composer.json
+++ b/packages/zend-service/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-session/README.md
+++ b/packages/zend-session/README.md
@@ -1,7 +1,7 @@
 # zend-session (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-session/composer.json
+++ b/packages/zend-session/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-session": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-soap/README.md
+++ b/packages/zend-soap/README.md
@@ -1,7 +1,7 @@
 # zend-soap (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-soap/composer.json
+++ b/packages/zend-soap/composer.json
@@ -8,10 +8,10 @@
         "php": ">=5.3.3",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-server": "^1.15.0",
-        "zf1s/zend-uri": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-server": "^1.15.1",
+        "zf1s/zend-uri": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-stdlib/README.md
+++ b/packages/zend-stdlib/README.md
@@ -1,7 +1,7 @@
 # zend-stdlib (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-tag/README.md
+++ b/packages/zend-tag/README.md
@@ -1,7 +1,7 @@
 # zend-tag (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-tag/composer.json
+++ b/packages/zend-tag/composer.json
@@ -6,8 +6,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-test/README.md
+++ b/packages/zend-test/README.md
@@ -1,7 +1,7 @@
 # zend-test (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-test/composer.json
+++ b/packages/zend-test/composer.json
@@ -6,12 +6,12 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.15.0",
-        "zf1s/zend-dom": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-layout": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0",
-        "zf1s/zend-session": "^1.15.0"
+        "zf1s/zend-controller": "^1.15.1",
+        "zf1s/zend-dom": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-layout": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1",
+        "zf1s/zend-session": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-text/README.md
+++ b/packages/zend-text/README.md
@@ -1,7 +1,7 @@
 # zend-text (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-text/composer.json
+++ b/packages/zend-text/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-timesync/README.md
+++ b/packages/zend-timesync/README.md
@@ -1,7 +1,7 @@
 # zend-timesync (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-timesync/composer.json
+++ b/packages/zend-timesync/composer.json
@@ -6,9 +6,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-date": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-date": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-tool/README.md
+++ b/packages/zend-tool/README.md
@@ -1,7 +1,7 @@
 # zend-tool (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-translate/README.md
+++ b/packages/zend-translate/README.md
@@ -1,7 +1,7 @@
 # zend-translate (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-translate/composer.json
+++ b/packages/zend-translate/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-uri/README.md
+++ b/packages/zend-uri/README.md
@@ -1,7 +1,7 @@
 # zend-uri (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-uri/composer.json
+++ b/packages/zend-uri/composer.json
@@ -7,10 +7,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-ctype": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0",
-        "zf1s/zend-validate": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1",
+        "zf1s/zend-validate": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-validate/README.md
+++ b/packages/zend-validate/README.md
@@ -1,7 +1,7 @@
 # zend-validate (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-validate/composer.json
+++ b/packages/zend-validate/composer.json
@@ -8,9 +8,9 @@
         "php": ">=5.3.3",
         "ext-ctype": "*",
         "ext-reflection": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-version/README.md
+++ b/packages/zend-version/README.md
@@ -1,7 +1,7 @@
 # zend-version (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-view/README.md
+++ b/packages/zend-view/README.md
@@ -1,7 +1,7 @@
 # zend-view (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-view/composer.json
+++ b/packages/zend-view/composer.json
@@ -7,11 +7,11 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-controller": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0",
-        "zf1s/zend-locale": "^1.15.0",
-        "zf1s/zend-registry": "^1.15.0"
+        "zf1s/zend-controller": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1",
+        "zf1s/zend-locale": "^1.15.1",
+        "zf1s/zend-registry": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-wildfire/README.md
+++ b/packages/zend-wildfire/README.md
@@ -1,7 +1,7 @@
 # zend-wildfire (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-wildfire/composer.json
+++ b/packages/zend-wildfire/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
-        "zf1s/zend-controller": "^1.15.0",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-json": "^1.15.0",
-        "zf1s/zend-loader": "^1.15.0"
+        "zf1s/zend-controller": "^1.15.1",
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-json": "^1.15.1",
+        "zf1s/zend-loader": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-xml/README.md
+++ b/packages/zend-xml/README.md
@@ -1,7 +1,7 @@
 # zend-xml (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-xml/composer.json
+++ b/packages/zend-xml/composer.json
@@ -9,7 +9,7 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
-        "zf1s/zend-exception": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-xmlrpc/README.md
+++ b/packages/zend-xmlrpc/README.md
@@ -1,7 +1,7 @@
 # zend-xmlrpc (Zend Framework 1)
 
 This package is a part of the Zend Framework 1. Each component was separated and put into its own composer package.
-**PHP 5.3-8.0** compatible.
+**PHP 5.3-8.1** compatible.
 
 - [Report issues](https://github.com/zf1s/zf1/issues) and
   [send Pull Requests](https://github.com/zf1s/zf1/pulls)

--- a/packages/zend-xmlrpc/composer.json
+++ b/packages/zend-xmlrpc/composer.json
@@ -10,10 +10,10 @@
         "ext-iconv": "*",
         "ext-reflection": "*",
         "ext-simplexml": "*",
-        "zf1s/zend-exception": "^1.15.0",
-        "zf1s/zend-http": "^1.15.0",
-        "zf1s/zend-server": "^1.15.0",
-        "zf1s/zend-xml": "^1.15.0"
+        "zf1s/zend-exception": "^1.15.1",
+        "zf1s/zend-http": "^1.15.1",
+        "zf1s/zend-server": "^1.15.1",
+        "zf1s/zend-xml": "^1.15.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
- general
  - php 8.1 compatibility fixes ([#149])
  - php 8.1 compat: `ReturnTypeWillChange` Attribute ([#147])
  - require php extensions in dev only - avoid composer warnings for missing extensions when installing `zf1s/zf1` package ([#136])
  - add missing `@throws` annotations ([#140])
  - fix psr-0 autoloading issues ([#135])
  - clean up `zf1s/zf1` package by ignoring unwanted files in export-ignore ([#134])
- zend-amf
  - fix for php 8.1+ keep the order of properties when they are being serialized same as PHP <8.1 ([#149])
  - phpdoc: fix `Zend_Amf_Server_Response` class name, should be `Zend_Amf_Response` ([#137])
- zend-console-getopt
  - Fix `str_split('')` logic to keep same as PHP before 8.2 on PHP 8.2 ([#143])
- zend-date
  - properly calculate sunrise, sunset and twilight times ([#151])
- zend-db
  - fix MySQLi adapter after changing default reporting mode by PHP 8.1 ([#156], [#158])
- zend-openid
  -  fix for `Zend_OpenId_Consumer_Storage_File` when symlinks are not used (i.e. on windows) ([#148])
- zend-progressbar
  - fix "stty: 'standard input': Inappropriate ioctl for device" spam ([#155])
- zend-server
  - fix issues with `Zend_Server_Reflection_Method` ([#149])
- zend-timesync
  - fix ntp time sync ([#153])
- general: CI
  - enable php 8.1/8.2 builds ([#129])
  - fix CI warnings: Node.js 12 actions are deprecated ([#139])
  - utilize continue-on-error for 'experimental' flag ([#142])
  - enable SQLite tests ([#157])
- general: tests
  - fix running tests on windows with composer v2 ([#150])
  - [zend-loader] fix failing Zend_Loader_PluginLoaderTest on windows ([#154])
  - [zend-paginator] use a temporary fixture test file for unit testing that git ignores ([#160])

🎉 Contributors: @falkenhawk @glensc @hungtrinh @jack-worman @marcing @partikus

[#129]: https://github.com/zf1s/zf1/pull/129
[#134]: https://github.com/zf1s/zf1/pull/134
[#135]: https://github.com/zf1s/zf1/pull/135
[#136]: https://github.com/zf1s/zf1/pull/136
[#137]: https://github.com/zf1s/zf1/pull/137
[#139]: https://github.com/zf1s/zf1/pull/139
[#140]: https://github.com/zf1s/zf1/pull/140
[#142]: https://github.com/zf1s/zf1/pull/142
[#143]: https://github.com/zf1s/zf1/pull/143
[#147]: https://github.com/zf1s/zf1/pull/147
[#148]: https://github.com/zf1s/zf1/pull/148
[#149]: https://github.com/zf1s/zf1/pull/149
[#150]: https://github.com/zf1s/zf1/pull/150
[#151]: https://github.com/zf1s/zf1/pull/151
[#153]: https://github.com/zf1s/zf1/pull/153
[#154]: https://github.com/zf1s/zf1/pull/154
[#155]: https://github.com/zf1s/zf1/pull/155
[#156]: https://github.com/zf1s/zf1/pull/156
[#157]: https://github.com/zf1s/zf1/pull/157
[#158]: https://github.com/zf1s/zf1/pull/158
[#160]: https://github.com/zf1s/zf1/pull/160