### PR TITLE
[zend-session] Zend_Session_SaveHandler_DbTable - fix 'Failed to write session data using user defined save handler' warning on php 7+

### DIFF
--- a/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
+++ b/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
@@ -348,9 +348,8 @@ class Zend_Session_SaveHandler_DbTable
         if (count($rows)) {
             $data[$this->_lifetimeColumn] = $this->_getLifetime($rows->current());
 
-            if ($this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-                $return = true;
-            }
+            $this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
+            $return = true;
         } else {
             $data[$this->_lifetimeColumn] = $this->_lifetime;
 


### PR DESCRIPTION
Replaces my original PR #163 

update returns 0 if the data being updated matches the one in the database, which produces a `false` return, which in turn triggers a warning in Zend_Session::writeClose - session_write_close()

Co-Authored-By: Pablo Guzman <26124783+Dringho@users.noreply.github.com>

Original commit: https://github.com/Shardj/zf1-future/commit/9175301058d324bcdcdca0d091b2e6c394273a95

Original pull request: https://github.com/Shardj/zf1-future/pull/23

Originally submitted to zf1-future by @Dringho