### PR TITLE
Fix invalid session regeneration on wrong session ID

### DIFF
--- a/packages/zend-session/library/Zend/Session.php
+++ b/packages/zend-session/library/Zend/Session.php
@@ -426,7 +426,7 @@ class Zend_Session extends Zend_Session_Abstract
             // Generate a valid, temporary replacement
             self::setId(md5(self::getId()));
             // Force a regenerate after session is started
-            self::$_regenerateIdState = -1;
+            self::regenerateId();
         }
 
         if (self::$_sessionStarted && self::$_destroyed) {
@@ -459,7 +459,7 @@ class Zend_Session extends Zend_Session_Abstract
         }
 
         // See http://www.php.net/manual/en/ref.session.php for explanation
-        if (!self::$_unitTestEnabled && defined('SID')) {
+        if (!self::$_unitTestEnabled && defined('SID') && SID !== '') {
             /** @see Zend_Session_Exception */
             // require_once 'Zend/Session/Exception.php';
             throw new Zend_Session_Exception('session has already been started by session.auto-start or session_start()');
@@ -662,7 +662,7 @@ class Zend_Session extends Zend_Session_Abstract
      */
     public static function setId($id)
     {
-        if (!self::$_unitTestEnabled && defined('SID')) {
+        if (!self::$_unitTestEnabled && defined('SID') && SID !== '') {
             /** @see Zend_Session_Exception */
             // require_once 'Zend/Session/Exception.php';
             throw new Zend_Session_Exception('The session has already been started.  The session id must be set first.');


### PR DESCRIPTION
Fix for https://github.com/zf1s/zf1/issues/165

Zend have a logic in place to create a valid session ID from the orignal value, MD5-ing it. This logic doesn't properly kick in the aforementioned situation of the issue but with this fix it does.

The fix does NOT prevent an initial write through the Session handler. This means that session with invalid keys are created into the database, file or redis instance in use for session storage.

In order to fix that, I'm afraid we would need to refactor the code to always md5 invalid entries pro-actively and since `getId()` is empty at that moment, I'm really not sure how we should to that.

Note that the comment `// Check to see if we've been passed an invalid session ID` at the beginning of the `start()` method only really apply on an already opened session.