### PR TITLE
[zend-ldap] removes calls to `ldap_sort` while keeping sort features

### DIFF
--- a/packages/zend-ldap/library/Zend/Ldap.php
+++ b/packages/zend-ldap/library/Zend/Ldap.php
@@ -1012,23 +1012,17 @@ class Zend_Ldap
             // require_once 'Zend/Ldap/Exception.php';
             throw new Zend_Ldap_Exception($this, 'searching: ' . $filter);
         }
-        // ldap_sort: This function has been DEPRECATED as of PHP 7.0.0 and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.
-        if (PHP_VERSION_ID < 70000 && $sort !== null && is_string($sort)) {
-            $isSorted = @ldap_sort($this->getResource(), $search, $sort);
-            if($isSorted === false) {
-                /**
-                 * @see Zend_Ldap_Exception
-                 */
-                // require_once 'Zend/Ldap/Exception.php';
-                throw new Zend_Ldap_Exception($this, 'sorting: ' . $sort);
-            }
-        }
 
         /**
          * Zend_Ldap_Collection_Iterator_Default
          */
         // require_once 'Zend/Ldap/Collection/Iterator/Default.php';
         $iterator = new Zend_Ldap_Collection_Iterator_Default($this, $search);
+        
+        if ($sort !== null && is_string($sort)) {
+            $iterator->sort($sort);
+        }
+        
         return $this->_createCollection($iterator, $collectionClass);
     }
 

--- a/packages/zend-ldap/library/Zend/Ldap/Collection.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Collection.php
@@ -96,12 +96,12 @@ class Zend_Ldap_Collection implements Iterator, Countable
      */
     public function getFirst()
     {
-        if ($this->count() > 0) {
-            $this->rewind();
-            return $this->current();
-        } else {
+        if ($this->count() < 1) {
             return null;
         }
+
+        $this->rewind();
+        return $this->current();
     }
 
     /**
@@ -136,21 +136,23 @@ class Zend_Ldap_Collection implements Iterator, Countable
     #[ReturnTypeWillChange]
     public function current()
     {
-        if ($this->count() > 0) {
-            if ($this->_current < 0) {
-                $this->rewind();
-            }
-            if (!array_key_exists($this->_current, $this->_cache)) {
-                $current = $this->_iterator->current();
-                if ($current === null) {
-                    return null;
-                }
-                $this->_cache[$this->_current] = $this->_createEntry($current);
-            }
-            return $this->_cache[$this->_current];
-        } else {
+        if ($this->count() < 1) {
             return null;
         }
+
+        if ($this->_current < 0) {
+            $this->rewind();
+        }
+
+        if (! array_key_exists($this->_current, $this->_cache)) {
+            $current = $this->_iterator->current();
+            if ($current === null) {
+                return null;
+            }
+            $this->_cache[$this->_current] = $this->_createEntry($current);
+        }
+
+        return $this->_cache[$this->_current];
     }
 
     /**

--- a/packages/zend-ldap/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -68,6 +68,27 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      * @var  integer|callback
      */
     protected $_attributeNameTreatment = self::ATTRIBUTE_TO_LOWER;
+    
+    /**
+     * This array holds a list of resources and sorting-values.
+     *
+     * Each result is represented by an array containing the keys <var>resource</var>
+     * which holds a resource of a result-item and the key <var>sortValue</var>
+     * which holds the value by which the array will be sorted.
+     *
+     * The resources will be filled on creating the instance and the sorting values
+     * on sorting.
+     *
+     * @var array
+     */
+    protected $_entries = array();
+
+    /**
+     * The function to sort the entries by
+     *
+     * @var callable
+     */
+    protected $_sortFunction;
 
     /**
      * Constructor.
@@ -78,6 +99,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      */
     public function __construct(Zend_Ldap $ldap, $resultId)
     {
+        $this->setSortFunction('strnatcasecmp');
         $this->_ldap = $ldap;
         $this->_resultId = $resultId;
         $this->_itemCount = @ldap_count_entries($ldap->getResource(), $resultId);
@@ -87,6 +109,23 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
              */
             // require_once 'Zend/Ldap/Exception.php';
             throw new Zend_Ldap_Exception($this->_ldap, 'counting entries');
+        }
+        
+        $identifier = ldap_first_entry(
+            $ldap->getResource(),
+            $resultId
+        );
+        
+        while (false !== $identifier) {
+            $this->_entries[] = array(
+                'resource' => $identifier,
+                'sortValue' => '',
+            );
+            
+            $identifier = ldap_next_entry(
+                $ldap->getResource(),
+                $identifier
+            );
         }
     }
 
@@ -254,49 +293,32 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
 
     /**
      * Move forward to next result item
-     * Implements Iterator
      *
-     * @throws Zend_Ldap_Exception
+     * @see Iterator
+     *
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function next()
     {
-        if ($this->_isResultEntry($this->_current) && $this->_itemCount > 0) {
-            $this->_current = @ldap_next_entry($this->_ldap->getResource(), $this->_current);
-            /** @see Zend_Ldap_Exception */
-            // require_once 'Zend/Ldap/Exception.php';
-            if ($this->_current === false) {
-                $msg = $this->_ldap->getLastError($code);
-                if ($code === Zend_Ldap_Exception::LDAP_SIZELIMIT_EXCEEDED) {
-                    // we have reached the size limit enforced by the server
-                    return;
-                } else if ($code > Zend_Ldap_Exception::LDAP_SUCCESS) {
-                     throw new Zend_Ldap_Exception($this->_ldap, 'getting next entry (' . $msg . ')');
-                }
-            }
-        } else {
-            $this->_current = false;
-        }
+        next($this->_entries);
+        $nextEntry = current($this->_entries);
+        $this->_current = isset($nextEntry['resource']) ? $nextEntry['resource'] : null;
     }
 
     /**
      * Rewind the Iterator to the first result item
-     * Implements Iterator
      *
-     * @throws Zend_Ldap_Exception
+     * @see Iterator
+     *
+     * @return void
      */
     #[ReturnTypeWillChange]
     public function rewind()
     {
-        if ($this->_isResult($this->_resultId)) {
-            $this->_current = @ldap_first_entry($this->_ldap->getResource(), $this->_resultId);
-            /** @see Zend_Ldap_Exception */
-            // require_once 'Zend/Ldap/Exception.php';
-            if ($this->_current === false &&
-                    $this->_ldap->getLastErrorCode() > Zend_Ldap_Exception::LDAP_SUCCESS) {
-                throw new Zend_Ldap_Exception($this->_ldap, 'getting first entry');
-            }
-        }
+        reset($this->_entries);
+        $nextEntry = current($this->_entries);
+        $this->_current = isset($nextEntry['resource']) ? $nextEntry['resource'] : null;
     }
 
     /**
@@ -338,5 +360,59 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
         }
         
         return $resource instanceof \LDAP\ResultEntry;
+    }
+    
+    /**
+     * Set a sorting-algorithm for this iterator
+     *
+     * The callable has to accept two parameters that will be compared.
+     *
+     * @param callable $_sortFunction The algorithm to be used for sorting
+     * @return self Provides a fluent interface
+     */
+    public function setSortFunction($_sortFunction)
+    {
+        $this->_sortFunction = $_sortFunction;
+
+        return $this;
+    }
+
+    /**
+     * Sort the iterator
+     *
+     * Sorting is done using the set sortFunction which is by default strnatcasecmp.
+     *
+     * The attribute is determined by lowercasing everything.
+     *
+     * The sort-value will be the first value of the attribute.
+     *
+     * @param string $sortAttribute The attribute to sort by. If not given the
+     *                              value set via setSortAttribute is used.
+     * @return void
+     */
+    public function sort($sortAttribute)
+    {
+        foreach ($this->_entries as $key => $entry) {
+            $attributes = ldap_get_attributes(
+                $this->_ldap->getResource(),
+                $entry['resource']
+            );
+
+            $attributes = array_change_key_case($attributes, CASE_LOWER);
+
+            if (isset($attributes[$sortAttribute][0])) {
+                $this->_entries[$key]['sortValue'] =
+                    $attributes[$sortAttribute][0];
+            }
+        }
+
+        $sortFunction = $this->_sortFunction;
+        $sorted = usort($this->_entries, function($a, $b) use ($sortFunction) {
+            return $sortFunction($a['sortValue'], $b['sortValue']);
+        });
+
+        if (! $sorted) {
+            throw new Zend_Ldap_Exception($this, 'sorting result-set');
+        }
     }
 }

--- a/tests/Zend/Ldap/CopyRenameTest.php
+++ b/tests/Zend/Ldap/CopyRenameTest.php
@@ -103,6 +103,8 @@ class Zend_Ldap_CopyRenameTest extends Zend_Ldap_OnlineTestCase
 
     protected function tearDown()
     {
+        if (!$this->_getLdap()) return;
+
         if ($this->_getLdap()->exists($this->_newDn))
             $this->_getLdap()->delete($this->_newDn, false);
         if ($this->_getLdap()->exists($this->_orgDn))

--- a/tests/Zend/Ldap/Node/UpdateTest.php
+++ b/tests/Zend/Ldap/Node/UpdateTest.php
@@ -48,6 +48,8 @@ class Zend_Ldap_Node_UpdateTest extends Zend_Ldap_OnlineTestCase
 
     protected function tearDown()
     {
+        if(!$this->_getLdap()) return;
+
         foreach ($this->_getLdap()->getBaseNode()->searchChildren('objectClass=*') as $child) {
             $this->_getLdap()->delete($child->getDn(), true);
         }

--- a/tests/Zend/Ldap/OnlineTestCase.php
+++ b/tests/Zend/Ldap/OnlineTestCase.php
@@ -135,6 +135,8 @@ abstract class Zend_Ldap_OnlineTestCase extends Zend_Ldap_TestCase
 
     protected function _cleanupLdapServer()
     {
+        if (!$this->_ldap) return;
+
         $ldap=$this->_ldap->getResource();
         foreach (array_reverse($this->_nodes) as $dn => $entry) {
             ldap_delete($ldap, $dn);

--- a/tests/Zend/Ldap/SearchTest.php
+++ b/tests/Zend/Ldap/SearchTest.php
@@ -162,11 +162,6 @@ class Zend_Ldap_SearchTest extends Zend_Ldap_OnlineTestCase
 
     public function testSorting()
     {
-        if (PHP_VERSION_ID >= 70000) {
-            $this->markTestSkipped("Test skipped due to removal of ldap_sort from PHP: https://www.php.net/ldap_sort");
-            return;
-        }
-    
         $lSorted=array('a', 'b', 'c', 'd', 'e');
         $items=$this->_getLdap()->search('(l=*)', TESTS_ZEND_LDAP_WRITEABLE_SUBTREE,
             Zend_Ldap::SEARCH_SCOPE_SUB, array(), 'l');
@@ -366,11 +361,6 @@ class Zend_Ldap_SearchTest extends Zend_Ldap_OnlineTestCase
      */
     public function testReverseSortingWithSearchEntriesShortcut()
     {
-        if (PHP_VERSION_ID >= 70000) {
-            $this->markTestSkipped("Test skipped due to removal of ldap_sort from PHP: https://www.php.net/ldap_sort");
-            return;
-        }
-    
         $lSorted = array('e', 'd', 'c', 'b', 'a');
         $items = $this->_getLdap()->searchEntries('(l=*)', TESTS_ZEND_LDAP_WRITEABLE_SUBTREE,
             Zend_Ldap::SEARCH_SCOPE_SUB, array(), 'l', true);

--- a/tests/Zend/Ldap/SortTest.php
+++ b/tests/Zend/Ldap/SortTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Ldap
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+/**
+ * @category   Zend
+ * @package    Zend_Ldap
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Zend_Ldap
+ */
+class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->_prepareLdapServer();
+    }
+
+    protected function tearDown()
+    {
+        $this->_cleanupLdapServer();
+        parent::tearDown();
+    }
+
+    /**
+     * Test whether a callable is set correctly
+     */
+    public function testSettingCallable()
+    {
+        $search = ldap_search(
+            $this->_getLdap()->getResource(),
+            TESTS_ZEND_LDAP_WRITEABLE_SUBTREE,
+            '(l=*)',
+            array('l')
+        );
+
+        $iterator     = new Zend_Ldap_Collection_Iterator_Default($this->_getLdap(), $search);
+        $sortFunction = function($a, $b) { return 1; };
+
+        $reflectionObject   = new ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
+        $iterator->setSortFunction($sortFunction);
+        $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
+    }
+
+    /**
+     * Test whether sorting works as expected out of the box
+     */
+    public function testSorting()
+    {
+        $lSorted = array('a', 'b', 'c', 'd', 'e');
+
+        $search = ldap_search(
+            $this->_getLdap()->getResource(),
+            TESTS_ZEND_LDAP_WRITEABLE_SUBTREE,
+            '(l=*)',
+            array('l')
+        );
+
+        $iterator = new Zend_Ldap_Collection_Iterator_Default($this->_getLdap(), $search);
+
+        $reflectionObject   = new ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
+
+        $reflectionProperty = $reflectionObject->getProperty('_entries');
+        $reflectionProperty->setAccessible(true);
+
+        $iterator->sort('l');
+
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+        foreach ($lSorted as $index => $value) {
+            $this->assertEquals($value, $reflectionEntries[$index]['sortValue']);
+        }
+    }
+
+    /**
+     * Test sorting with custom sort-function
+     */
+    public function testCustomSorting()
+    {
+        $lSorted = array('d', 'e', 'a', 'b', 'c');
+
+        $search = ldap_search(
+            $this->_getLdap()->getResource(),
+            TESTS_ZEND_LDAP_WRITEABLE_SUBTREE,
+            '(l=*)',
+            array('l')
+        );
+
+        $iterator     = new Zend_Ldap_Collection_Iterator_Default($this->_getLdap(), $search);
+        $sortFunction = function ($a, $b) {
+            // Sort values by the number of "1" in their binary representation
+            // and when that is equals by their position in the alphabet.
+            $f = strlen(str_replace('0', '', decbin(bin2hex($a)))) -
+                 strlen(str_replace('0', '', decbin(bin2hex($b))));
+            if ($f < 0) {
+                return -1;
+            } elseif ($f > 0) {
+                return 1;
+            }
+            return strnatcasecmp($a, $b);
+        };
+        $iterator->setSortFunction($sortFunction);
+
+        $reflectionObject   = new ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
+
+        $reflectionProperty = $reflectionObject->getProperty('_entries');
+        $reflectionProperty->setAccessible(true);
+
+        $iterator->sort('l');
+
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+        foreach ($lSorted as $index => $value) {
+            $this->assertEquals($value, $reflectionEntries[$index]['sortValue']);
+        }
+    }
+}


### PR DESCRIPTION
removes calls to `ldap_sort` while keeping sort features

ldap_sort got deprecated in php 7.0.0, removed in php 8.0.0

ported from https://github.com/laminas/laminas-ldap/commit/35162e69f2685400470bd5d67764050bc521011e and latest version of https://github.com/laminas/laminas-ldap/tree/2.18.x