### PR TITLE
make zend-filter dep required because of default usage

### DIFF
--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -10,6 +10,7 @@
         "ext-session": "*",
         "zf1s/zend-config": "^1.15.2",
         "zf1s/zend-exception": "^1.15.2",
+        "zf1s/zend-filter": "^1.15.2",
         "zf1s/zend-loader": "^1.15.2",
         "zf1s/zend-registry": "^1.15.2",
         "zf1s/zend-uri": "^1.15.2",
@@ -23,7 +24,6 @@
     },
     "suggest": {
         "zf1s/zend-dojo": "Used in special situations or with special adapters",
-        "zf1s/zend-filter": "Used in special situations or with special adapters",
         "zf1s/zend-json": "Used in special situations or with special adapters",
         "zf1s/zend-layout": "Used in special situations or with special adapters"
     },


### PR DESCRIPTION
ViewRenderer in zf1s/zend-controller directly depends on Zend_Filter Classes

See [this PR](https://github.com/zf1s/zend-controller/pull/2) for more info. (originally submitted by @Anyqax)