### PR TITLE
[zend-ldap]: fix failing tests

### DIFF
--- a/tests/Zend/Ldap/BindTest.php
+++ b/tests/Zend/Ldap/BindTest.php
@@ -181,7 +181,7 @@ class Zend_Ldap_BindTest extends PHPUnit_Framework_TestCase
         } catch (Zend_Ldap_Exception $zle) {
             /* Note that if your server actually allows anonymous binds this test will fail.
              */
-            $this->assertContains('No object found for', $zle->getMessage());
+            $this->assertContains('Failed to retrieve DN', $zle->getMessage());
         }
     }
 


### PR DESCRIPTION
[zend-ldap]: fix failing tests due to changes in bitnami/openldap:2.5

```
1) Zend_Ldap_BindTest::testRequiresDnWithoutDnBind
Failed asserting that '0x1: Failed to retrieve DN for account: admin@example.com [0x30 (Inappropriate authentication; anonymous bind disallowed): ldap://localhost:1389]' contains "No object found for".

/home/runner/work/zf1/zf1/tests/Zend/Ldap/BindTest.php:184
```

restore expected message to the previous version, as the error message contains `Failed to retrieve DN` again 🙈
https://github.com/zf1s/zf1/pull/159/files#diff-10a1b3c35fa477d1ad544c164800886583a4162bf83154247e986d59da216ff5L184