### PR TITLE
update required and suggested deps according to usage (closes #175)

### DIFF
--- a/packages/zend-uri/composer.json
+++ b/packages/zend-uri/composer.json
@@ -9,7 +9,6 @@
         "ext-ctype": "*",
         "zf1s/zend-exception": "^1.15.2",
         "zf1s/zend-loader": "^1.15.2",
-        "zf1s/zend-locale": "^1.15.2",
         "zf1s/zend-validate": "^1.15.2"
     },
     "autoload": {
@@ -18,9 +17,8 @@
         }
     },
     "suggest": {
-        "zf1s/zend-date": "Used in special situations or with special adapters",
-        "zf1s/zend-filter": "Used in special situations or with special adapters",
-        "zf1s/zend-registry": "Used in special situations or with special adapters"
+        "zf1s/zend-config": "Used in special situations or with special adapters",
+        "zf1s/zend-filter": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-uri": "^1.12"


### PR DESCRIPTION
This updates the dependencies of `Zend_Uri` to what I can find in the source. The findings:

- `Zend_Locale` is never used (-require)
- `Zend_Date` is never used (-suggest)
- `Zend_Registry` is never used (-suggest)
- `Zend_Config` is used in some circumstances (+suggest)