### PR TITLE
update zend-view deps according to usage (closes #176)

### DIFF
--- a/packages/zend-view/composer.json
+++ b/packages/zend-view/composer.json
@@ -7,10 +7,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-reflection": "*",
-        "zf1s/zend-controller": "^1.15.2",
         "zf1s/zend-exception": "^1.15.2",
         "zf1s/zend-loader": "^1.15.2",
-        "zf1s/zend-locale": "^1.15.2",
         "zf1s/zend-registry": "^1.15.2"
     },
     "autoload": {
@@ -19,8 +17,19 @@
         }
     },
     "suggest": {
+        "zf1s/zend-controller": "Used in special situations or with special adapters",
+        "zf1s/zend-config": "Used in special situations or with special adapters",
+        "zf1s/zend-currency": "Used in special situations or with special adapters",
         "zf1s/zend-json": "Used in special situations or with special adapters",
-        "zf1s/zend-layout": "Used in special situations or with special adapters"
+        "zf1s/zend-layout": "Used in special situations or with special adapters",
+        "zf1s/zend-locale": "Used in special situations or with special adapters",
+        "zf1s/zend-filter": "Used in special situations or with special adapters",
+        "zf1s/zend-http": "Used in special situations or with special adapters",
+        "zf1s/zend-navigation": "Used in special situations or with special adapters",
+        "zf1s/zend-paginator": "Used in special situations or with special adapters",
+        "zf1s/zend-translate": "Used in special situations or with special adapters",
+        "zf1s/zend-uri": "Used in special situations or with special adapters",
+        "zf1s/zend-validate": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-view": "^1.12"

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
@@ -264,7 +264,7 @@ class Zend_View_Helper_Navigation_Links
      * @param  Zend_Navigation_Page $page       page to find relations for
      * @param  string              $rel         relation, "rel" or "rev"
      * @param  string              $type        link type, e.g. 'start', 'next'
-     * @return Zend_Navigaiton_Page|array|null  page(s), or null if not found
+     * @return Zend_Navigation_Page|array|null  page(s), or null if not found
      * @throws Zend_View_Exception              if $rel is not "rel" or "rev"
      */
     public function findRelation(Zend_Navigation_Page $page, $rel, $type)
@@ -611,7 +611,7 @@ class Zend_View_Helper_Navigation_Links
      * makes sure finder methods will not traverse above the container given
      * to the render method.
      *
-     * @param  Zend_Navigaiton_Page $page  page to find root for
+     * @param  Zend_Navigation_Page $page  page to find root for
      * @return Zend_Navigation_Container   the root container of the given page
      */
     protected function _findRoot(Zend_Navigation_Page $page)


### PR DESCRIPTION
I've listed everything used in view helpers under `suggest`.

That means a lot of additions, but also that `Zend_Controller` and `Zend_Locale` are no longer required dependencies. I can't imagine both are not installed explicitly when needed, but feel free to disagree of course.