### PR TITLE
 php8.2 compat: allow dynamic props in Zend_Form, Zend_Form_Element and Zend_View_Abstract

### DIFF
--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -30,6 +30,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
+#[AllowDynamicProperties]
 class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
 {
     /**#@+

--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -40,6 +40,7 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
+#[AllowDynamicProperties]
 class Zend_Form_Element implements Zend_Validate_Interface
 {
     /**

--- a/packages/zend-view/library/Zend/View/Abstract.php
+++ b/packages/zend-view/library/Zend/View/Abstract.php
@@ -36,6 +36,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 abstract class Zend_View_Abstract implements Zend_View_Interface
 {
     /**


### PR DESCRIPTION
followup to #170

It looks like it's safe to use the `#[AllowDynamicProperties]` attribute, and it should still be valid for php 9.0 and not throw an error, contrary to what I understood at first.

As per RFC:
https://wiki.php.net/rfc/deprecate_dynamic_properties#proposal "The creation of dynamic properties on classes that aren't marked with the #[AllowDynamicProperties] attribute is deprecated in PHP 8.2 and becomes an Error exception in PHP 9.0."

Related issues from zf1-future where they went with refactoring those classes to use a defined property to store all previously dynamic props in an array, which introduced breaking changes:
https://github.com/Shardj/zf1-future/issues/307#issuecomment-1430108870
https://github.com/Shardj/zf1-future/pull/261
https://github.com/Shardj/zf1-future/pull/268
https://github.com/Shardj/zf1-future/issues/328
https://github.com/Shardj/zf1-future/pull/329