### PR TITLE
php8.2 compat: remaining compatibility fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,10 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
         include:
-          - php: "8.2"
+          - php: "8.3"
             experimental: true
 
     env:

--- a/packages/zend-console-getopt/composer.json
+++ b/packages/zend-console-getopt/composer.json
@@ -14,6 +14,7 @@
         }
     },
     "suggest": {
+        "ext-mbstring": "Required only if toXml() method is used",
         "zf1s/zend-json": "Used in special situations or with special adapters"
     },
     "replace": {

--- a/packages/zend-console-getopt/library/Zend/Console/Getopt.php
+++ b/packages/zend-console-getopt/library/Zend/Console/Getopt.php
@@ -524,9 +524,9 @@ class Zend_Console_Getopt
         $doc->appendChild($optionsNode);
         foreach ($this->_options as $flag => $value) {
             $optionNode = $doc->createElement('option');
-            $optionNode->setAttribute('flag', utf8_encode($flag));
+            $optionNode->setAttribute('flag', mb_convert_encoding($flag, 'UTF-8', 'ISO-8859-1'));
             if ($value !== true) {
-                $optionNode->setAttribute('parameter', utf8_encode($value));
+                $optionNode->setAttribute('parameter', mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1'));
             }
             $optionsNode->appendChild($optionNode);
         }

--- a/packages/zend-gdata/library/Zend/Gdata/App.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App.php
@@ -1082,11 +1082,11 @@ class Zend_Gdata_App
             } else {
                 // require_once 'Zend/Gdata/App/Exception.php';
                 throw new Zend_Gdata_App_Exception(
-                        "Unable to find '${class}' in registered packages");
+                        "Unable to find '{$class}' in registered packages");
             }
         } else {
             // require_once 'Zend/Gdata/App/Exception.php';
-            throw new Zend_Gdata_App_Exception("No such method ${method}");
+            throw new Zend_Gdata_App_Exception("No such method {$method}");
         }
     }
 

--- a/packages/zend-gdata/library/Zend/Gdata/App/Base.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App/Base.php
@@ -482,7 +482,7 @@ abstract class Zend_Gdata_App_Base
         $method = 'get'.ucfirst($name);
         if (method_exists($this, $method)) {
             return call_user_func(array(&$this, $method));
-        } else if (property_exists($this, "_${name}")) {
+        } else if (property_exists($this, "_{$name}")) {
             return $this->{'_' . $name};
         } else {
             // require_once 'Zend/Gdata/App/InvalidArgumentException.php';

--- a/packages/zend-gdata/library/Zend/Gdata/App/BaseMediaSource.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App/BaseMediaSource.php
@@ -113,7 +113,7 @@ abstract class Zend_Gdata_App_BaseMediaSource implements Zend_Gdata_App_MediaSou
         $method = 'get'.ucfirst($name);
         if (method_exists($this, $method)) {
             return call_user_func(array(&$this, $method));
-        } else if (property_exists($this, "_${name}")) {
+        } else if (property_exists($this, "_{$name}")) {
             return $this->{'_' . $name};
         } else {
             // require_once 'Zend/Gdata/App/InvalidArgumentException.php';

--- a/packages/zend-gdata/library/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
+++ b/packages/zend-gdata/library/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
@@ -73,7 +73,7 @@ class Zend_Gdata_App_LoggingHttpClientAdapterSocket extends Zend_Http_Client_Ada
      */
     public function connect($host, $port = 80, $secure = false)
     {
-        $this->log("Connecting to: ${host}:${port}");
+        $this->log("Connecting to: {$host}:{$port}");
         return parent::connect($host, $port, $secure);
     }
 
@@ -102,7 +102,7 @@ class Zend_Gdata_App_LoggingHttpClientAdapterSocket extends Zend_Http_Client_Ada
     public function read()
     {
         $response = parent::read();
-        $this->log("${response}\n\n");
+        $this->log("{$response}\n\n");
         return $response;
     }
 

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps.php
@@ -877,7 +877,7 @@ class Zend_Gdata_Gapps extends Zend_Gdata
             } else {
                 // require_once 'Zend/Gdata/App/Exception.php';
                 throw new Zend_Gdata_App_Exception(
-                        "Unable to find '${class}' in registered packages");
+                        "Unable to find '{$class}' in registered packages");
             }
         } else {
             return parent::__call($method, $args);

--- a/packages/zend-service-amazon/composer.json
+++ b/packages/zend-service-amazon/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
+        "ext-mbstring": "*",
         "zf1s/zend-exception": "^1.15.2",
         "zf1s/zend-http": "^1.15.2",
         "zf1s/zend-rest": "^1.15.2",

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/Authentication/S3.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/Authentication/S3.php
@@ -104,7 +104,7 @@ class Zend_Service_Amazon_Authentication_S3 extends Zend_Service_Amazon_Authenti
                     $sig_str .= '?torrent';
                 }
 
-        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), Zend_Crypt_Hmac::BINARY));
+        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_secretKey, 'sha1', mb_convert_encoding($sig_str, 'UTF-8', 'ISO-8859-1'), Zend_Crypt_Hmac::BINARY));
         $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . $signature;
 
         return $sig_str;

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/S3.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/S3.php
@@ -781,7 +781,7 @@ class Zend_Service_Amazon_S3 extends Zend_Service_Amazon_Abstract
             $sig_str .= '?versions';
         }
 
-        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_getSecretKey(), 'sha1', utf8_encode($sig_str), Zend_Crypt_Hmac::BINARY));
+        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_getSecretKey(), 'sha1', mb_convert_encoding($sig_str, 'UTF-8', 'ISO-8859-1'), Zend_Crypt_Hmac::BINARY));
         $headers['Authorization'] = 'AWS '.$this->_getAccessKey().':'.$signature;
 
         return $sig_str;

--- a/packages/zend-service-amazon/library/Zend/Service/Amazon/SimpleDb.php
+++ b/packages/zend-service-amazon/library/Zend/Service/Amazon/SimpleDb.php
@@ -457,7 +457,7 @@ class Zend_Service_Amazon_SimpleDb extends Zend_Service_Amazon_Abstract
         // UTF-8 encode all parameters and replace '+' characters
         foreach ($params as $name => $value) {
             unset($params[$name]);
-            $params[utf8_encode($name)] = $value;
+            $params[mb_convert_encoding($name, 'UTF-8', 'ISO-8859-1')] = $value;
         }
 
         $params = $this->_addRequiredParameters($params);

--- a/packages/zend-service-windowsazure/composer.json
+++ b/packages/zend-service-windowsazure/composer.json
@@ -6,6 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "ext-mbstring": "*",
         "zf1s/zend-service": "^1.15.2",
         "zf1s/zend-xml": "^1.15.2"
     },

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
@@ -1008,7 +1008,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
     	
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
     	
     	// Clean up the configuration
@@ -1479,7 +1479,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
     	
         if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
     	
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
@@ -1512,7 +1512,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
     	
         if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
     	
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
@@ -1590,7 +1590,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
     	
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
     	
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
@@ -1642,7 +1642,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
     	
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
     	
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -887,12 +887,12 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		}
 
 		// Generate block list request
-		$fileContents = utf8_encode(implode("\n", array(
+		$fileContents = mb_convert_encoding(implode("\n", array(
 				'<?xml version="1.0" encoding="utf-8"?>',
 				'<BlockList>',
 				$blocks,
 				'</BlockList>'
-			)));
+			)), 'UTF-8', 'ISO-8859-1');
 
 			// Create metadata headers
 			$headers = array();

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -88,13 +88,13 @@ class Zend_EventManager_EventManagerTest extends PHPUnit_Framework_TestCase
 
     public function testAttachShouldReturnCallbackHandler()
     {
-        $listener = $this->events->attach('test', array($this, __METHOD__));
+        $listener = $this->events->attach('test', array($this, __FUNCTION__));
         $this->assertTrue($listener instanceof Zend_Stdlib_CallbackHandler);
     }
 
     public function testAttachShouldAddListenerToEvent()
     {
-        $listener  = $this->events->attach('test', array($this, __METHOD__));
+        $listener  = $this->events->attach('test', array($this, __FUNCTION__));
         $listeners = $this->events->getListeners('test');
         $this->assertEquals(1, count($listeners));
         $this->assertContains($listener, $listeners);
@@ -104,7 +104,7 @@ class Zend_EventManager_EventManagerTest extends PHPUnit_Framework_TestCase
     {
         $events = $this->events->getEvents();
         $this->assertTrue(empty($events), var_export($events, 1));
-        $listener = $this->events->attach('test', array($this, __METHOD__));
+        $listener = $this->events->attach('test', array($this, __FUNCTION__));
         $events = $this->events->getEvents();
         $this->assertFalse(empty($events));
         $this->assertContains('test', $events);
@@ -139,7 +139,7 @@ class Zend_EventManager_EventManagerTest extends PHPUnit_Framework_TestCase
 
     public function testDetachShouldRemoveListenerFromEvent()
     {
-        $listener  = $this->events->attach('test', array($this, __METHOD__));
+        $listener  = $this->events->attach('test', array($this, __FUNCTION__));
         $listeners = $this->events->getListeners('test');
         $this->assertContains($listener, $listeners);
         $this->events->detach($listener);
@@ -149,14 +149,14 @@ class Zend_EventManager_EventManagerTest extends PHPUnit_Framework_TestCase
 
     public function testDetachShouldReturnFalseIfEventDoesNotExist()
     {
-        $listener = $this->events->attach('test', array($this, __METHOD__));
+        $listener = $this->events->attach('test', array($this, __FUNCTION__));
         $this->events->clearListeners('test');
         $this->assertFalse($this->events->detach($listener));
     }
 
     public function testDetachShouldReturnFalseIfListenerDoesNotExist()
     {
-        $listener1 = $this->events->attach('test', array($this, __METHOD__));
+        $listener1 = $this->events->attach('test', array($this, __FUNCTION__));
         $this->events->clearListeners('test');
         $listener2 = $this->events->attach('test', array($this, 'handleTestEvent'));
         $this->assertFalse($this->events->detach($listener1));

--- a/tests/Zend/EventManager/FilterChainTest.php
+++ b/tests/Zend/EventManager/FilterChainTest.php
@@ -63,13 +63,13 @@ class Zend_EventManager_FilterChainTest extends PHPUnit_Framework_TestCase
 
     public function testSubscribeShouldReturnCallbackHandler()
     {
-        $handle = $this->filterchain->attach(array( $this, __METHOD__ ));
+        $handle = $this->filterchain->attach(array( $this, __FUNCTION__ ));
         $this->assertTrue($handle instanceof Zend_Stdlib_CallbackHandler);
     }
 
     public function testSubscribeShouldAddCallbackHandlerToFilters()
     {
-        $handler  = $this->filterchain->attach(array($this, __METHOD__));
+        $handler  = $this->filterchain->attach(array($this, __FUNCTION__));
         $handlers = $this->filterchain->getFilters();
         $this->assertEquals(1, count($handlers));
         $this->assertTrue($handlers->contains($handler));
@@ -77,7 +77,7 @@ class Zend_EventManager_FilterChainTest extends PHPUnit_Framework_TestCase
 
     public function testDetachShouldRemoveCallbackHandlerFromFilters()
     {
-        $handle = $this->filterchain->attach(array( $this, __METHOD__ ));
+        $handle = $this->filterchain->attach(array( $this, __FUNCTION__ ));
         $handles = $this->filterchain->getFilters();
         $this->assertTrue($handles->contains($handle));
         $this->filterchain->detach($handle);
@@ -87,7 +87,7 @@ class Zend_EventManager_FilterChainTest extends PHPUnit_Framework_TestCase
 
     public function testDetachShouldReturnFalseIfCallbackHandlerDoesNotExist()
     {
-        $handle1 = $this->filterchain->attach(array( $this, __METHOD__ ));
+        $handle1 = $this->filterchain->attach(array( $this, __FUNCTION__ ));
         $this->filterchain->clearFilters();
         $handle2 = $this->filterchain->attach(array( $this, 'handleTestTopic' ));
         $this->assertFalse($this->filterchain->detach($handle1));

--- a/tests/Zend/Reflection/_files/FunctionWithEmbeddedVariableInString.php
+++ b/tests/Zend/Reflection/_files/FunctionWithEmbeddedVariableInString.php
@@ -2,10 +2,12 @@
 
 function firstOne() {
     $substitute = "Testing";
-    $varA = "${substitute} 123!";
+    // ${var} interpolation is deprecated in PHP 8.2
+    // https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated
+    // $varA = "${substitute} 123!";
     $varB = "{$substitute} 123!";
     $varC = "$substitute 123!";
-    $varD = "${substitute}";
+    // $varD = "${substitute}";
 }
 
 function secondOne() {}


### PR DESCRIPTION
- carried https://github.com/Shardj/zf1-future/pull/285 (thx @hungtrinh)
- ported https://github.com/Shardj/zf1-future/pull/252 (thx @fballiano)
  - but without adding mbstring polyfill, as the usage of utf8_encode/decode functions were really rare.
  - ext-mbstring will be only required when Zend_Console_GetOpt::toXml() is used in your project
  - and in Amazon and WindowsAzure services (are they still functional anyway?)
- fix variable interpolation in strings, deprecated in php 8.2
  - `"Deprecated: Using ${var} in strings is deprecated, use {$var} instead"`