### PR TITLE
php8.3 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
-        # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations
-        include:
-          - php: "8.3"
-            experimental: true
+          - "8.3"
 
     env:
       MYSQL_USER: "zftest"

--- a/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
+++ b/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
@@ -261,7 +261,7 @@ class Zend_OpenId_Extension_Sreg extends Zend_OpenId_Extension
      */
     public function getTrustData(&$data)
     {
-        $data[get_class()] = $this->getProperties();
+        $data[get_class($this)] = $this->getProperties();
         return true;
     }
 
@@ -277,7 +277,7 @@ class Zend_OpenId_Extension_Sreg extends Zend_OpenId_Extension
     {
         if (is_array($this->_props) && count($this->_props) > 0) {
             $props = array();
-            $name = get_class();
+            $name = get_class($this);
             if (isset($data[$name])) {
                 $props = $data[$name];
             } else {

--- a/tests/Zend/Form/FormTest.php
+++ b/tests/Zend/Form/FormTest.php
@@ -4004,7 +4004,15 @@ class Zend_Form_FormTest extends PHPUnit_Framework_TestCase
         $form->reset();
         $test = $form->getValues();
         $this->assertNotEquals($values, $test);
-        $this->assertEquals(0, array_sum($test));
+        $this->assertEquals(array(
+            'bar' => null,
+            'baz' => null,
+            'bat' => null,
+            'foo' => array(
+                'one' => null,
+                'two' => null,
+            ),
+        ), $test);
     }
 
     /**

--- a/tests/Zend/Markup/BbcodeAndHtmlTest.php
+++ b/tests/Zend/Markup/BbcodeAndHtmlTest.php
@@ -264,6 +264,14 @@ class Zend_Markup_BbcodeAndHtmlTest extends PHPUnit_Framework_TestCase
     {
         $input = "[code][b][/code][list][*]Foo[/*][/list]";
         $expected = "<code><span style=\"color: #000000\">\n[b]</span>\n</code><ul><li>Foo</li></ul>";
+
+        if (PHP_VERSION_ID >= 80300) {
+            // Zend_Markup_Renderer_Html_Code uses `highlight_string` function internally
+            // and output of that function has changed in PHP 8.3
+            // https://php.watch/versions/8.3/highlight_file-highlight_string-html-changes
+            $expected = "<pre><code style=\"color: #000000\">[b]</code></pre><ul><li>Foo</li></ul>";
+        }
+
         $this->assertEquals($expected, $this->_markup->render($input));
     }
 
@@ -319,6 +327,14 @@ class Zend_Markup_BbcodeAndHtmlTest extends PHPUnit_Framework_TestCase
         $expected = '<code><span style="color: #000000">' . "\n"
                   . '<span style="color: #0000BB">&lt;?php<br /></span>'
                   . "<span style=\"color: #007700\">exit;</span>\n</span>\n</code>";
+
+        if (PHP_VERSION_ID >= 80300) {
+            // Zend_Markup_Renderer_Html_Code uses `highlight_string` function internally
+            // and output of that function has changed in PHP 8.3
+            // https://php.watch/versions/8.3/highlight_file-highlight_string-html-changes
+            $expected = '<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php' . "\n"
+                      . '</span><span style="color: #007700">exit;</span></code></pre>';
+        }
 
         $this->assertEquals($expected, $m->render("[code]<?php\nexit;[/code]"));
         $this->assertEquals('<p>I</p>', $m->render('[p]I[/p]'));


### PR DESCRIPTION
#### 1. adjusted zend_form test to fix:
  ```
  1) Zend_Form_FormTest::testFormsShouldAllowResetting
  array_sum(): Addition is not supported on type array
  ```
  
#### 2. address differences in `Zend_Markup` rendering
  Zend_Markup_Renderer_Html_Code uses `highlight_string` function internally
  and output of that function has changed in PHP 8.3
  https://php.watch/versions/8.3/highlight_file-highlight_string-html-changes

#### 3. `Zend_OpenId` - `get_class()` calls without arguments are deprecated
https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated