### PR TITLE
[zend-application] update zend-application deps according to usage

### DIFF
--- a/packages/zend-application/composer.json
+++ b/packages/zend-application/composer.json
@@ -6,8 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.3",
+        "zf1s/zend-config": "^1.15.3",
+        "zf1s/zend-controller": "^1.15.3",
         "zf1s/zend-exception": "^1.15.3",
-        "zf1s/zend-controller": "^1.15.3"
+        "zf1s/zend-loader": "^1.15.3",
+        "zf1s/zend-registry": "^1.15.3"
     },
     "autoload": {
         "psr-0": {
@@ -16,7 +19,18 @@
     },
     "suggest": {
         "ext-date": "Used in special situations or with special adapters",
-        "zf1s/zend-config": "Used in special situations or with special adapters"
+        "zf1s/zend-cache": "Used in special situations or with special adapters",
+        "zf1s/zend-db": "Used in special situations or with special adapters",
+        "zf1s/zend-dojo": "Used in special situations or with special adapters",
+        "zf1s/zend-http": "Used in special situations or with special adapters",
+        "zf1s/zend-layout": "Used in special situations or with special adapters",
+        "zf1s/zend-locale": "Used in special situations or with special adapters",
+        "zf1s/zend-log": "Used in special situations or with special adapters",
+        "zf1s/zend-mail": "Used in special situations or with special adapters",
+        "zf1s/zend-navigation": "Used in special situations or with special adapters",
+        "zf1s/zend-session": "Used in special situations or with special adapters",
+        "zf1s/zend-translate": "Used in special situations or with special adapters",
+        "zf1s/zend-view": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-application": "^1.12"


### PR DESCRIPTION
@falkenhawk this brings the Zend_Application deps up to date.
I've put everything used in application resources in the suggested deps.
With one exception: Zend_Controller, as that's used by default. I think it might make some sense to not require that (in light of easier refactoring away from ZF1), but it probably makes very little difference in the real world.