### PR TITLE
[zend-controller] update zend-controller deps according to usage

### DIFF
--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -14,8 +14,7 @@
         "zf1s/zend-loader": "^1.15.3",
         "zf1s/zend-registry": "^1.15.3",
         "zf1s/zend-uri": "^1.15.3",
-        "zf1s/zend-view": "^1.15.3",
-        "zf1s/zend-xml": "^1.15.3"
+        "zf1s/zend-view": "^1.15.3"
     },
     "autoload": {
         "psr-0": {
@@ -23,9 +22,13 @@
         }
     },
     "suggest": {
+        "zf1s/zend-cache": "Used in special situations or with special adapters",
         "zf1s/zend-dojo": "Used in special situations or with special adapters",
         "zf1s/zend-json": "Used in special situations or with special adapters",
-        "zf1s/zend-layout": "Used in special situations or with special adapters"
+        "zf1s/zend-layout": "Used in special situations or with special adapters",
+        "zf1s/zend-locale": "Used in special situations or with special adapters",
+        "zf1s/zend-session": "Used in special situations or with special adapters",
+        "zf1s/zend-translate": "Used in special situations or with special adapters"
     },
     "replace": {
         "zf1/zend-controller": "^1.12"


### PR DESCRIPTION
@falkenhawk this brings Zend_Controller deps up to date.
There is a lot of room for interpretation here... I've taken the least intrusive path.
But in theory Zend_View and Zend_Filter aren't necessarily required dependencies I think.