### PR TITLE
[zend-form] fix instantiating filters with options via `addFilter()` in php 8.0+

### DIFF
--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -2113,7 +2113,22 @@ class Zend_Form_Element implements Zend_Validate_Interface
         } else {
             $r = new ReflectionClass($name);
             if ($r->hasMethod('__construct')) {
-                $instance = $r->newInstanceArgs((array) $filter['options']);
+                $numeric = false;
+                if (is_array($filter['options'])) {
+                    $keys    = array_keys($filter['options']);
+                    foreach($keys as $key) {
+                        if (is_numeric($key)) {
+                            $numeric = true;
+                            break;
+                        }
+                    }
+                }
+
+                if ($numeric) {
+                   $instance = $r->newInstanceArgs((array) $filter['options']);
+                } else {
+                    $instance = $r->newInstance($filter['options']);
+                }
             } else {
                 $instance = $r->newInstance();
             }

--- a/tests/Zend/Form/ElementTest.php
+++ b/tests/Zend/Form/ElementTest.php
@@ -1226,15 +1226,57 @@ class Zend_Form_ElementTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($filter->allowWhiteSpace);
     }
 
-    public function testShouldUseFilterConstructorOptionsAsPassedToAddFilter()
+    public function testCanPassFirstAndSecondArgument()
     {
-        $this->element->addFilter('HtmlEntities', array(array('quotestyle' => ENT_QUOTES, 'charset' => 'UTF-8')));
+        try {
+            // public function __construct($searchSeparator = ' ', $replacementSeparator = '-')
+            $this->element->addFilter('Word_SeparatorToSeparator', array('-', '_'));
+        } catch (Exception $e) {
+            $this->fail('Should be able to add array filter options');
+        }
+        $filter = $this->element->getFilter('SeparatorToSeparator');
+        $this->assertEquals('-', $filter->getSearchSeparator());
+        $this->assertEquals('_', $filter->getReplacementSeparator());
+    }    
+    
+    public function testCanPassFirstOptionAsFirstArgument()
+    {
+        try {
+            // public function __construct($options = null)
+            $this->element->addFilter('Boolean', array('type' => Zend_Filter_Boolean::PHP + Zend_Filter_Boolean::FALSE_STRING));
+        } catch (Exception $e) {
+            $this->fail('Should be able to add array filter options');
+        }
+        $filter = $this->element->getFilter('Boolean');
+        $this->assertTrue($filter instanceof Zend_Filter_Boolean);
+        $this->assertSame($filter->getType(), Zend_Filter_Boolean::PHP + Zend_Filter_Boolean::FALSE_STRING);
+    }
+    
+    public function testCanPassMultipleOptionsAsAnAssociativeArray()
+    {
+        // public function __construct($options = array())
+        $this->element->addFilter('HtmlEntities', array('quotestyle' => ENT_QUOTES, 'charset' => 'MacRoman'));
         $filter = $this->element->getFilter('HtmlEntities');
         $this->assertTrue($filter instanceof Zend_Filter_HtmlEntities);
         $this->assertEquals(ENT_QUOTES, $filter->getQuoteStyle());
-        $this->assertEquals('UTF-8', $filter->getCharSet());
+        $this->assertEquals('MacRoman', $filter->getCharSet());
     }
 
+    public function testAnyOptionIsHandledByConstructorWhenPassedInOptionsArray()
+    {
+        try {
+            // pass an option, which is not the same as first argument, and it's value is not the same as default one
+            // to check if it's really set
+            // public function __construct($options = array())
+            $this->element->addFilter('HtmlEntities', array('encoding' => 'MacRoman'));
+        } catch (Exception $e) {
+            $this->fail('Should be able to add array filter options');
+        }
+        $filter = $this->element->getFilter('HtmlEntities');
+        $this->assertTrue($filter instanceof Zend_Filter_HtmlEntities);
+        $this->assertSame($filter->getEncoding(), 'MacRoman');
+    }
+    
     public function testCanAddMultipleFilters()
     {
         $this->_checkZf2794();


### PR DESCRIPTION
 PHP 8.0+ changes behaviour of ReflectionClass::newInstanceArgs, which now assumes that an associative array is an array of named parameters, trying to match array keys to names of arguments in the constructor. This leads to errors in Zend_Form_Element::_loadFilter.

```php
$this->addFilter('Boolean', array('type' => Zend_Filter_Boolean::PHP + Zend_Filter_Boolean::FALSE_STRING));
```

```
zend-form\library\Zend\Form\Element.php:2117
Error: Unknown named parameter $type
```

Zend_Form_Element::_loadFilter has to be altered in the same manner as _loadValidator to call newInstanceArgs only or numerical arrays and call newInstance on associative arrays.