### PR TITLE
Fix legacy IIS rewrite header vulnerability

### DIFF
--- a/packages/zend-controller/library/Zend/Controller/Request/Http.php
+++ b/packages/zend-controller/library/Zend/Controller/Request/Http.php
@@ -390,19 +390,13 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
     public function setRequestUri($requestUri = null)
     {
         if ($requestUri === null) {
-            if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { 
-                // IIS with Microsoft Rewrite Module
-                $requestUri = $_SERVER['HTTP_X_ORIGINAL_URL'];
-            } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) { 
-                // IIS with ISAPI_Rewrite
-                $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-            } elseif (
-                // IIS7 with URL Rewrite: make sure we get the unencoded url (double slash problem)
+            if (
                 isset($_SERVER['IIS_WasUrlRewritten'])
                 && $_SERVER['IIS_WasUrlRewritten'] == '1'
                 && isset($_SERVER['UNENCODED_URL'])
                 && $_SERVER['UNENCODED_URL'] != ''
                 ) {
+                // IIS7 with URL Rewrite: make sure we get the unencoded url (double slash problem)
                 $requestUri = $_SERVER['UNENCODED_URL'];
             } elseif (isset($_SERVER['REQUEST_URI'])) {
                 $requestUri = $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
Removes the framework support for the legacy IIS headers HTTP_X_ORIGINAL_URL
and
HTTP_X_REWRITE_URL
which can potentially be exploited. 

Fix/removed in laminas here:
https://github.com/laminas/laminas-http/blob/26dd6d1177e25d970058863c2afed12bb9dbff4d/src/PhpEnvironment/Request.php#L464

References:
https://framework.zend.com/security/advisory/ZF2018-01
https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers https://portswigger.net/research/practical-web-cache-poisoning
https://portswigger.net/kb/issues/00400f00_request-url-override