### PR TITLE
[zend-db] update $_schema type hint from array to string

### DIFF
--- a/packages/zend-db/library/Zend/Db/Table/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Abstract.php
@@ -119,7 +119,7 @@ abstract class Zend_Db_Table_Abstract
     /**
      * The schema name (default null means current schema)
      *
-     * @var array
+     * @var string
      */
     protected $_schema = null;
 


### PR DESCRIPTION
Update $_schema type hint from array to string.
It's only ever used like a string and never as an array.

I discovered this while using phpstan on my codebase.
I have over 500 tables that inherited from this class and all of them define the schema property.
