### PR TITLE
Fix: Passing null is deprecated in `Zend_Mail::_filterEmail()`

### DIFF
--- a/packages/zend-mail/library/Zend/Mail.php
+++ b/packages/zend-mail/library/Zend/Mail.php
@@ -1220,7 +1220,7 @@ class Zend_Mail extends Zend_Mime_Message
                       '>'  => '',
         );
 
-        return strtr($email, $rule);
+        return strtr((string) $email, $rule);
     }
 
     /**


### PR DESCRIPTION
- closes https://github.com/OpenMage/magento-lts/issues/3706