### PR TITLE
PHP 8.4: E_STRICT constant deprecated

### DIFF
--- a/packages/zend-log/library/Zend/Log.php
+++ b/packages/zend-log/library/Zend/Log.php
@@ -594,7 +594,6 @@ class Zend_Log
             E_USER_ERROR        => Zend_Log::ERR,
             E_CORE_ERROR        => Zend_Log::ERR,
             E_RECOVERABLE_ERROR => Zend_Log::ERR,
-            E_STRICT            => Zend_Log::DEBUG,
         );
         // PHP 5.3.0+
         if (defined('E_DEPRECATED')) {
@@ -602,6 +601,10 @@ class Zend_Log
         }
         if (defined('E_USER_DEPRECATED')) {
             $this->_errorHandlerMap['E_USER_DEPRECATED'] = Zend_Log::DEBUG;
+        }
+        // E_STRICT has been deprecated in PHP 8.4
+        if (defined('E_STRICT')) {
+            $this->_errorHandlerMap['E_STRICT'] = Zend_Log::DEBUG;
         }
 
         $this->_registeredErrorHandler = true;

--- a/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
@@ -92,9 +92,13 @@ class Zend_Stdlib_CallbackHandler
      */
     protected function registerCallback($callback)
     {
-        set_error_handler(array($this, 'errorHandler'), E_STRICT);
+        if (PHP_VERSION_ID < 70400) {
+            set_error_handler(array($this, 'errorHandler'), E_STRICT);
+        }
         $callable = is_callable($callback);
-        restore_error_handler();
+        if (PHP_VERSION_ID < 70400) {
+            restore_error_handler();
+        }
         if (!$callable || $this->error) {
             // require_once 'Zend/Stdlib/Exception/InvalidCallbackException.php';
             throw new Zend_Stdlib_Exception_InvalidCallbackException('Invalid callback provided; not callable');

--- a/packages/zend-tool/library/Zend/Tool/Framework/Loader/Abstract.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Loader/Abstract.php
@@ -95,10 +95,14 @@ abstract class Zend_Tool_Framework_Loader_Abstract
             }
 
             $classesLoadedBefore = get_declared_classes();
-            $oldLevel = error_reporting(E_ALL | ~E_STRICT); // remove strict so that other packages wont throw warnings
+            if (PHP_VERSION_ID < 70400) {
+                $oldLevel = error_reporting(E_ALL | ~E_STRICT); // remove strict so that other packages wont throw warnings
+            }
             // should we lint the files here? i think so
             include_once $file;
-            error_reporting($oldLevel); // restore old error level
+            if (PHP_VERSION_ID < 70400) {
+                error_reporting($oldLevel); // restore old error level
+            }
             $classesLoadedAfter = get_declared_classes();
             $loadedClasses = array_merge($loadedClasses, array_diff($classesLoadedAfter, $classesLoadedBefore));
         }

--- a/tests/Zend/Json/JsonXMLTest.php
+++ b/tests/Zend/Json/JsonXMLTest.php
@@ -20,7 +20,10 @@
  * @version    $Id$
  */
 
-error_reporting( E_ALL | E_STRICT ); // now required for each test suite
+error_reporting(E_ALL); // now required for each test suite
+if (PHP_VERSION_ID < 70400) {
+    error_reporting(E_ALL | E_STRICT);
+}
 
 /**
  * Zend_Json

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -334,7 +334,11 @@ class Zend_Log_LogTest extends PHPUnit_Framework_TestCase
         $oldErrorLevel = error_reporting();
 
         $this->expectingLogging = true;
-        error_reporting(E_ALL | E_STRICT);
+        
+        error_reporting(E_ALL);
+        if (PHP_VERSION_ID < 70400) {
+            error_reporting(E_ALL | E_STRICT);
+        }
 
         $oldHandler = set_error_handler(array($this, 'verifyHandlerData'));
         $logger->registerErrorHandler();

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -93,11 +93,19 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
 
         session_save_path($this->_savePath);
 
-        $this->assertSame(
-            E_ALL | E_STRICT,
-            error_reporting( E_ALL | E_STRICT ),
-            'A test altered error_reporting to something other than E_ALL | E_STRICT'
-            );
+        if (PHP_VERSION_ID < 70400) {
+            $this->assertSame(
+                E_ALL | E_STRICT,
+                error_reporting(E_ALL | E_STRICT),
+                'A test altered error_reporting to something other than E_ALL | E_STRICT'
+                );
+        } else {
+            $this->assertSame(
+                E_ALL,
+                error_reporting(E_ALL),
+                'A test altered error_reporting to something other than E_ALL'
+                );
+        }
     }
 
     /**

--- a/tests/Zend/ViewTest.php
+++ b/tests/Zend/ViewTest.php
@@ -684,7 +684,10 @@ class Zend_ViewTest extends PHPUnit_Framework_TestCase
 
     public function testZf995UndefinedPropertiesReturnNull()
     {
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
+        if (PHP_VERSION_ID < 70400) {
+            error_reporting(E_ALL | E_STRICT);
+        }
         ini_set('display_errors', true);
         $view = new Zend_View();
         $view->setScriptPath(dirname(__FILE__) . '/View/_templates');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,10 @@
 /*
  * Set error reporting to the level to which Zend Framework code must comply.
  */
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
+if (PHP_VERSION_ID < 70400) {
+    error_reporting(E_ALL | E_STRICT);
+}
 
 $rootDir = dirname(__DIR__);
 


### PR DESCRIPTION
PHP 8.4: E_STRICT constant deprecated
https://php.watch/versions/8.4/E_STRICT-deprecated