### PR TITLE
PHP 8.4: Implicitly nullable parameter declarations deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,16 @@
     "name": "zf1s/zf1",
     "description": "Zend Framework 1 complete package, PHP 5.3-8.3 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
     "license": "BSD-3-Clause",
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:zf1s/compat.git"
+        }
+    ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/polyfill-php70": "^1.19"
+        "symfony/polyfill-php70": "^1.19",
+        "zf1s/compat": "^1.0"
     },
     "require-dev": {
         "ext-ctype": "*",

--- a/packages/zend-acl/library/Zend/Acl.php
+++ b/packages/zend-acl/library/Zend/Acl.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -495,12 +498,14 @@ class Zend_Acl
      * @param  Zend_Acl_Role_Interface|string|array     $roles
      * @param  Zend_Acl_Resource_Interface|string|array $resources
      * @param  string|array                             $privileges
-     * @param  Zend_Acl_Assert_Interface                $assert
+     * @param  Zend_Acl_Assert_Interface|null           $assert
      * @uses   Zend_Acl::setRule()
      * @return Zend_Acl Provides a fluent interface
      */
-    public function allow($roles = null, $resources = null, $privileges = null, Zend_Acl_Assert_Interface $assert = null)
+    public function allow($roles = null, $resources = null, $privileges = null, $assert = null)
     {
+        Types::isNullable('assert', $assert, 'Zend_Acl_Assert_Interface');
+
         return $this->setRule(self::OP_ADD, self::TYPE_ALLOW, $roles, $resources, $privileges, $assert);
     }
 
@@ -510,12 +515,14 @@ class Zend_Acl
      * @param  Zend_Acl_Role_Interface|string|array     $roles
      * @param  Zend_Acl_Resource_Interface|string|array $resources
      * @param  string|array                             $privileges
-     * @param  Zend_Acl_Assert_Interface                $assert
+     * @param  Zend_Acl_Assert_Interface|null           $assert
      * @uses   Zend_Acl::setRule()
      * @return Zend_Acl Provides a fluent interface
      */
-    public function deny($roles = null, $resources = null, $privileges = null, Zend_Acl_Assert_Interface $assert = null)
+    public function deny($roles = null, $resources = null, $privileges = null, $assert = null)
     {
+        Types::isNullable('assert', $assert, 'Zend_Acl_Assert_Interface');
+
         return $this->setRule(self::OP_ADD, self::TYPE_DENY, $roles, $resources, $privileges, $assert);
     }
 
@@ -593,15 +600,17 @@ class Zend_Acl
      * @param  Zend_Acl_Role_Interface|string|array     $roles
      * @param  Zend_Acl_Resource_Interface|string|array $resources
      * @param  string|array                             $privileges
-     * @param  Zend_Acl_Assert_Interface                $assert
+     * @param  Zend_Acl_Assert_Interface|null           $assert
      * @throws Zend_Acl_Exception
      * @uses   Zend_Acl_Role_Registry::get()
      * @uses   Zend_Acl::get()
      * @return Zend_Acl Provides a fluent interface
      */
     public function setRule($operation, $type, $roles = null, $resources = null, $privileges = null,
-                            Zend_Acl_Assert_Interface $assert = null)
+                            $assert = null)
     {
+        Types::isNullable('assert', $assert, 'Zend_Acl_Assert_Interface');
+
         // ensure that the rule type is valid; normalize input to uppercase
         $type = strtoupper($type);
         if (self::TYPE_ALLOW !== $type && self::TYPE_DENY !== $type) {
@@ -915,12 +924,14 @@ class Zend_Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  Zend_Acl_Resource_Interface $resource
+     * @param  Zend_Acl_Role_Interface          $role
+     * @param  Zend_Acl_Resource_Interface|null $resource
      * @return boolean|null
      */
-    protected function _roleDFSAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null)
+    protected function _roleDFSAllPrivileges(Zend_Acl_Role_Interface $role, $resource = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         $dfs = array(
             'visited' => array(),
             'stack'   => array()
@@ -949,15 +960,17 @@ class Zend_Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  Zend_Acl_Resource_Interface $resource
-     * @param  array                  $dfs
+     * @param  Zend_Acl_Role_Interface          $role
+     * @param  Zend_Acl_Resource_Interface|null $resource
+     * @param  array                            $dfs
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, $resource = null,
                                                  &$dfs = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         if (null === $dfs) {
             /**
              * @see Zend_Acl_Exception
@@ -992,15 +1005,17 @@ class Zend_Acl
      * This method returns true if a rule is found and allows access. If a rule exists and denies access,
      * then this method returns false. If no applicable rule is found, then this method returns null.
      *
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  Zend_Acl_Resource_Interface $resource
-     * @param  string                      $privilege
+     * @param  Zend_Acl_Role_Interface          $role
+     * @param  Zend_Acl_Resource_Interface|null $resource
+     * @param  string                           $privilege
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, $resource = null,
                                             $privilege = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         if (null === $privilege) {
             /**
              * @see Zend_Acl_Exception
@@ -1037,16 +1052,18 @@ class Zend_Acl
      *
      * This method is used by the internal depth-first search algorithm and may modify the DFS data structure.
      *
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  Zend_Acl_Resource_Interface $resource
-     * @param  string                      $privilege
-     * @param  array                       $dfs
+     * @param  Zend_Acl_Role_Interface          $role
+     * @param  Zend_Acl_Resource_Interface|null $resource
+     * @param  string                           $privilege
+     * @param  array                            $dfs
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, $resource = null,
                                                 $privilege = null, &$dfs = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         if (null === $privilege) {
             /**
              * @see Zend_Acl_Exception
@@ -1093,14 +1110,17 @@ class Zend_Acl
      * If all three parameters are null, then the default ACL rule type is returned,
      * based on whether its assertion method passes.
      *
-     * @param  Zend_Acl_Resource_Interface $resource
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  string                      $privilege
+     * @param  Zend_Acl_Resource_Interface|null $resource
+     * @param  Zend_Acl_Role_Interface|null     $role
+     * @param  string                           $privilege
      * @return string|null
      */
-    protected function _getRuleType(Zend_Acl_Resource_Interface $resource = null, Zend_Acl_Role_Interface $role = null,
+    protected function _getRuleType($resource = null, $role = null,
                                     $privilege = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+        Types::isNullable('role', $role, 'Zend_Acl_Role_Interface');
+
         // get the rules for the $resource and $role
         if (null === ($rules = $this->_getRules($resource, $role))) {
             return null;
@@ -1149,14 +1169,17 @@ class Zend_Acl
      *
      * If the $create parameter is true, then a rule set is first created and then returned to the caller.
      *
-     * @param  Zend_Acl_Resource_Interface $resource
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  boolean                     $create
+     * @param  Zend_Acl_Resource_Interface|null $resource
+     * @param  Zend_Acl_Role_Interface|null     $role
+     * @param  boolean                          $create
      * @return array|null
      */
-    protected function &_getRules(Zend_Acl_Resource_Interface $resource = null, Zend_Acl_Role_Interface $role = null,
+    protected function &_getRules($resource = null, $role = null,
                                   $create = false)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+        Types::isNullable('role', $role, 'Zend_Acl_Role_Interface');
+
         // create a reference to null
         $null = null;
         $nullRef =& $null;

--- a/packages/zend-acl/library/Zend/Acl/Assert/Interface.php
+++ b/packages/zend-acl/library/Zend/Acl/Assert/Interface.php
@@ -54,11 +54,11 @@ interface Zend_Acl_Assert_Interface
      * privileges, respectively.
      *
      * @param  Zend_Acl                    $acl
-     * @param  Zend_Acl_Role_Interface     $role
-     * @param  Zend_Acl_Resource_Interface $resource
+     * @param  null|Zend_Acl_Role_Interface     $role
+     * @param  null|Zend_Acl_Resource_Interface $resource
      * @param  string                      $privilege
      * @return boolean
      */
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $role = null, Zend_Acl_Resource_Interface $resource = null,
+    public function assert(Zend_Acl $acl, $role = null, $resource = null,
                            $privilege = null);
 }

--- a/packages/zend-auth/library/Zend/Auth/Adapter/DbTable.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/DbTable.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -127,15 +130,17 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
     /**
      * __construct() - Sets configuration options
      *
-     * @param  Zend_Db_Adapter_Abstract $zendDb If null, default database adapter assumed
+     * @param  Zend_Db_Adapter_Abstract|null $zendDb If null, default database adapter assumed
      * @param  string                   $tableName
      * @param  string                   $identityColumn
      * @param  string                   $credentialColumn
      * @param  string                   $credentialTreatment
      */
-    public function __construct(Zend_Db_Adapter_Abstract $zendDb = null, $tableName = null, $identityColumn = null,
+    public function __construct($zendDb = null, $tableName = null, $identityColumn = null,
                                 $credentialColumn = null, $credentialTreatment = null)
     {
+        Types::isNullable('zendDb', $zendDb, 'Zend_Db_Adapter_Abstract');
+
         $this->_setDbAdapter($zendDb);
 
         if (null !== $tableName) {
@@ -158,12 +163,14 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
     /**
      * _setDbAdapter() - set the database adapter to be used for quering
      *
-     * @param Zend_Db_Adapter_Abstract
+     * @param Zend_Db_Adapter_Abstract|null $zendDb
      * @throws Zend_Auth_Adapter_Exception
      * @return Zend_Auth_Adapter_DbTable
      */
-    protected function _setDbAdapter(Zend_Db_Adapter_Abstract $zendDb = null)
+    protected function _setDbAdapter($zendDb = null)
     {
+        Types::isNullable('zendDb', $zendDb, 'Zend_Db_Adapter_Abstract');
+
         $this->_zendDb = $zendDb;
 
         /**

--- a/packages/zend-auth/library/Zend/Auth/Adapter/OpenId.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/OpenId.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -106,20 +109,24 @@ class Zend_Auth_Adapter_OpenId implements Zend_Auth_Adapter_Interface
      * Constructor
      *
      * @param string $id the identity value
-     * @param Zend_OpenId_Consumer_Storage $storage an optional implementation
+     * @param Zend_OpenId_Consumer_Storage|null $storage an optional implementation
      *        of a storage object
      * @param string $returnTo HTTP URL to redirect response from server to
      * @param string $root HTTP URL to identify consumer on server
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response an optional response
+     * @param Zend_Controller_Response_Abstract|null $response an optional response
      *        object to perform HTTP or HTML form redirection
      */
     public function __construct($id = null,
-                                Zend_OpenId_Consumer_Storage $storage = null,
+                                $storage = null,
                                 $returnTo = null,
                                 $root = null,
                                 $extensions = null,
-                                Zend_Controller_Response_Abstract $response = null) {
+                                $response = null) {
+
+        Types::isNullable('storage', $storage, 'Zend_OpenId_Consumer_Storage');
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $this->_id         = $id;
         $this->_storage    = $storage;
         $this->_returnTo   = $returnTo;

--- a/packages/zend-cache/library/Zend/Cache.php
+++ b/packages/zend-cache/library/Zend/Cache.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -202,8 +205,10 @@ abstract class Zend_Cache
      * @param  string $msg  Message for the exception
      * @throws Zend_Cache_Exception
      */
-    public static function throwException($msg, Exception $e = null)
+    public static function throwException($msg, $e = null)
     {
+        Types::isNullable('e', $e, 'Exception');
+
         // For perfs reasons, we use this dynamic inclusion
         // require_once 'Zend/Cache/Exception.php';
         throw new Zend_Cache_Exception($msg, 0, $e);

--- a/packages/zend-captcha/library/Zend/Captcha/Adapter.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Adapter.php
@@ -46,11 +46,11 @@ interface Zend_Captcha_Adapter extends Zend_Validate_Interface
     /**
      * Display the captcha
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null);
+    public function render($view = null, $element = null);
 
     /**
      * Set captcha name

--- a/packages/zend-captcha/library/Zend/Captcha/Dumb.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Dumb.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -41,7 +44,7 @@ class Zend_Captcha_Dumb extends Zend_Captcha_Word
      * @type string
      */
     protected $_label = 'Please type this word backwards';
-    
+
     /**
      * Set the label for the CAPTCHA
      * @param string $label
@@ -50,7 +53,7 @@ class Zend_Captcha_Dumb extends Zend_Captcha_Word
     {
         $this->_label = $label;
     }
-    
+
     /**
      * Retrieve the label for the CAPTCHA
      * @return string
@@ -62,12 +65,14 @@ class Zend_Captcha_Dumb extends Zend_Captcha_Word
     /**
      * Render the captcha
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render($view = null, $element = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         return $this->getLabel() . ': <b>'
              . strrev($this->getWord())
              . '</b>';

--- a/packages/zend-captcha/library/Zend/Captcha/Figlet.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Figlet.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -71,12 +74,14 @@ class Zend_Captcha_Figlet extends Zend_Captcha_Word
     /**
      * Display the captcha
      *
-     * @param Zend_View_Interface $view
+     * @param Zend_View_Interface|null $view
      * @param mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render($view = null, $element = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         return '<pre>'
              . $this->_figlet->render($this->getWord())
              . "</pre>\n";

--- a/packages/zend-captcha/library/Zend/Captcha/Image.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Image.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -612,12 +615,14 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
     /**
      * Display the captcha
      *
-     * @param Zend_View_Interface $view
+     * @param Zend_View_Interface|null $view
      * @param mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render($view = null, $element = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $endTag = ' />';
         if (($view instanceof Zend_View_Abstract) && !$view->doctype()->isXhtml()) {
             $endTag = '>';

--- a/packages/zend-captcha/library/Zend/Captcha/ReCaptcha.php
+++ b/packages/zend-captcha/library/Zend/Captcha/ReCaptcha.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -255,12 +258,14 @@ class Zend_Captcha_ReCaptcha extends Zend_Captcha_Base
     /**
      * Render captcha
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render($view = null, $element = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $name = null;
         if ($element instanceof Zend_Form_Element) {
             $name = $element->getBelongsTo();

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter.php
@@ -72,7 +72,7 @@ interface Zend_Cloud_DocumentService_Adapter
      * @param  null|array $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null);
+    public function listDocuments($collectionName, $options = null);
 
     /**
      * Insert document

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * LICENSE
  *
@@ -157,8 +160,10 @@ class Zend_Cloud_DocumentService_Adapter_SimpleDb
      * @param  array|null $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null)
+    public function listDocuments($collectionName, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $query = $this->select('*')->from($collectionName);
         $items = $this->query($collectionName, $query, $options);
         return $items;

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * LICENSE
  *
@@ -265,8 +268,10 @@ class Zend_Cloud_DocumentService_Adapter_WindowsAzure
      * @param  null|array $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null)
+    public function listDocuments($collectionName, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $select = $this->select()->from($collectionName);
         return $this->query($collectionName, $select);
     }

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * @category   Zend
  * @package    Zend_Cloud
@@ -38,11 +41,13 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * Constructor
      *
      * @param  Adapter $adapter
-     * @param  array $instances
+     * @param  array|null $instances
      * @return void
      */
-    public function __construct($adapter, array $instances = null)
+    public function __construct($adapter, $instances = null)
     {
+        Types::isNullable('instances', $instances, 'array');
+
         if (!($adapter instanceof Zend_Cloud_Infrastructure_Adapter)) {
             // require_once 'Zend/Cloud/Infrastructure/Exception.php';
             throw new Zend_Cloud_Infrastructure_Exception('You must pass a Zend_Cloud_Infrastructure_Adapter');

--- a/packages/zend-config/library/Zend/Config/Writer.php
+++ b/packages/zend-config/library/Zend/Config/Writer.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -50,8 +53,10 @@ abstract class Zend_Config_Writer
      *
      * @param null|array $options
      */
-    public function __construct(array $options = null)
+    public function __construct($options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         if (is_array($options)) {
             $this->setOptions($options);
         }

--- a/packages/zend-config/library/Zend/Config/Writer/FileAbstract.php
+++ b/packages/zend-config/library/Zend/Config/Writer/FileAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -76,12 +79,14 @@ class Zend_Config_Writer_FileAbstract extends Zend_Config_Writer
      * Write configuration to file.
      *
      * @param string $filename
-     * @param Zend_Config $config
+     * @param Zend_Config|null $config
      * @param bool $exclusiveLock
      * @return void
      */
-    public function write($filename = null, Zend_Config $config = null, $exclusiveLock = null)
+    public function write($filename = null, $config = null, $exclusiveLock = null)
     {
+        Types::isNullable('config', $config, 'Zend_Config');
+
         if ($filename !== null) {
             $this->setFilename($filename);
         }

--- a/packages/zend-controller/library/Zend/Controller/Action.php
+++ b/packages/zend-controller/library/Zend/Controller/Action.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -103,7 +106,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @var array
      */
     public $contexts;
-    
+
     /**
      * Controller's ajax contexts, managed by Zend_Controller_Action_Helper_AjaxContext
      * @var array
@@ -558,8 +561,11 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * object to use
      * @return Zend_Controller_Response_Abstract
      */
-    public function run(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
+    public function run($request = null, $response = null)
     {
+        Types::isNullable('request', $request, 'Zend_Controller_Request_Abstract');
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         if (null !== $request) {
             $this->setRequest($request);
         } else {
@@ -721,13 +727,15 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param string $action
      * @param string $controller
      * @param string $module
-     * @param array $params
+     * @param array|null $params
      * @return void
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             forward() instead.
      */
-    final protected function _forward($action, $controller = null, $module = null, array $params = null)
+    final protected function _forward($action, $controller = null, $module = null, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $this->forward($action, $controller, $module, $params);
     }
 
@@ -754,11 +762,13 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param string $action
      * @param string $controller
      * @param string $module
-     * @param array $params
+     * @param array|null $params
      * @return void
      */
-    final public function forward($action, $controller = null, $module = null, array $params = null)
+    final public function forward($action, $controller = null, $module = null, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $request = $this->getRequest();
 
         if (null !== $params) {

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/Abstract.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -49,11 +52,13 @@ abstract class Zend_Controller_Action_Helper_Abstract
     /**
      * setActionController()
      *
-     * @param  Zend_Controller_Action $actionController
+     * @param  Zend_Controller_Action|null $actionController
      * @return Zend_Controller_ActionHelper_Abstract Provides a fluent interface
      */
-    public function setActionController(Zend_Controller_Action $actionController = null)
+    public function setActionController($actionController = null)
     {
+        Types::isNullable('actionController', $actionController, 'Zend_Controller_Action');
+
         $this->_actionController = $actionController;
         return $this;
     }

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/Url.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/Url.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -43,11 +46,13 @@ class Zend_Controller_Action_Helper_Url extends Zend_Controller_Action_Helper_Ab
      * @param  string $action
      * @param  string $controller
      * @param  string $module
-     * @param  array  $params
+     * @param  array|null $params
      * @return string
      */
-    public function simple($action, $controller = null, $module = null, array $params = null)
+    public function simple($action, $controller = null, $module = null, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $request = $this->getRequest();
 
         if (null === $controller) {
@@ -107,11 +112,13 @@ class Zend_Controller_Action_Helper_Url extends Zend_Controller_Action_Helper_Ab
      * @param  string $action
      * @param  string $controller
      * @param  string $module
-     * @param  array  $params
+     * @param  array|null $params
      * @return string
      */
-    public function direct($action, $controller = null, $module = null, array $params = null)
+    public function direct($action, $controller = null, $module = null, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         return $this->simple($action, $controller, $module, $params);
     }
 }

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/ViewRenderer.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/ViewRenderer.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -175,12 +178,14 @@ class Zend_Controller_Action_Helper_ViewRenderer extends Zend_Controller_Action_
      *
      * Optionally set view object and options.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @param  array               $options
      * @return void
      */
-    public function __construct(Zend_View_Interface $view = null, array $options = array())
+    public function __construct($view = null, array $options = array())
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             $this->setView($view);
         }
@@ -626,7 +631,7 @@ class Zend_Controller_Action_Helper_ViewRenderer extends Zend_Controller_Action_
         } elseif (null !== $action) {
             $vars['action'] = $action;
         }
-        
+
         $replacePattern = array('/[^a-z0-9]+$/i', '/^[^a-z0-9]+/i');
         $vars['action'] = preg_replace($replacePattern, '', $vars['action']);
 

--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -356,8 +359,10 @@ abstract class Zend_Controller_Dispatcher_Abstract implements Zend_Controller_Di
      * @param Zend_Controller_Response_Abstract|null $response
      * @return Zend_Controller_Dispatcher_Abstract
      */
-    public function setResponse(Zend_Controller_Response_Abstract $response = null)
+    public function setResponse($response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $this->_response = $response;
         return $this;
     }

--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Interface.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Interface.php
@@ -129,7 +129,7 @@ interface Zend_Controller_Dispatcher_Interface
      * @param Zend_Controller_Response_Abstract|null $response
      * @return void
      */
-    public function setResponse(Zend_Controller_Response_Abstract $response = null);
+    public function setResponse($response = null);
 
     /**
      * Retrieve the response object, if any

--- a/packages/zend-controller/library/Zend/Controller/Front.php
+++ b/packages/zend-controller/library/Zend/Controller/Front.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -832,8 +835,11 @@ class Zend_Controller_Front
      * @param Zend_Controller_Response_Abstract|null $response
      * @return void|Zend_Controller_Response_Abstract Returns response object if returnResponse() is true
      */
-    public function dispatch(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
+    public function dispatch($request = null, $response = null)
     {
+        Types::isNullable('request', $request, 'Zend_Controller_Request_Abstract');
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         if (!$this->getParam('noErrorHandler') && !$this->_plugins->hasPlugin('Zend_Controller_Plugin_ErrorHandler')) {
             // Register with stack index of 100
             // require_once 'Zend/Controller/Plugin/ErrorHandler.php';

--- a/packages/zend-controller/library/Zend/Controller/Plugin/ActionStack.php
+++ b/packages/zend-controller/library/Zend/Controller/Plugin/ActionStack.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -69,12 +72,14 @@ class Zend_Controller_Plugin_ActionStack extends Zend_Controller_Plugin_Abstract
     /**
      * Constructor
      *
-     * @param  Zend_Registry $registry
+     * @param  Zend_Registry|null $registry
      * @param  string $key
      * @return void
      */
-    public function __construct(Zend_Registry $registry = null, $key = null)
+    public function __construct($registry = null, $key = null)
     {
+        Types::isNullable('registry', $registry, 'Zend_Registry');
+
         if (null === $registry) {
             $registry = Zend_Registry::getInstance();
         }

--- a/packages/zend-controller/library/Zend/Controller/Router/Route.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -484,11 +487,13 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
     /**
      * Set a default translator
      *
-     * @param  Zend_Translate $translator
+     * @param  Zend_Translate|null $translator
      * @return void
      */
-    public static function setDefaultTranslator(Zend_Translate $translator = null)
+    public static function setDefaultTranslator($translator = null)
     {
+        Types::isNullable('translator', $translator, 'Zend_Translate');
+
         self::$_defaultTranslator = $translator;
     }
 

--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Chain.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Chain.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -183,8 +186,10 @@ class Zend_Controller_Router_Route_Chain extends Zend_Controller_Router_Route_Ab
      * @param  Zend_Controller_Request_Abstract|null $request
      * @return void
      */
-    public function setRequest(Zend_Controller_Request_Abstract $request = null)
+    public function setRequest($request = null)
     {
+        Types::isNullable('request', $request, 'Zend_Controller_Request_Abstract');
+
         $this->_request = $request;
 
         foreach ($this->_routes as $route) {

--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Hostname.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Hostname.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -121,8 +124,10 @@ class Zend_Controller_Router_Route_Hostname extends Zend_Controller_Router_Route
      *
      * @param  Zend_Controller_Request_Abstract|null $request
      */
-    public function setRequest(Zend_Controller_Request_Abstract $request = null)
+    public function setRequest($request = null)
     {
+        Types::isNullable('request', $request, 'Zend_Controller_Request_Abstract');
+
         $this->_request = $request;
     }
 

--- a/packages/zend-crypt/library/Zend/Crypt/Rsa.php
+++ b/packages/zend-crypt/library/Zend/Crypt/Rsa.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -64,11 +67,13 @@ class Zend_Crypt_Rsa
     /**
      * Class constructor
      *
-     * @param array $options
+     * @param array|null $options
      * @throws Zend_Crypt_Rsa_Exception
      */
-    public function __construct(array $options = null)
+    public function __construct($options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         if (!extension_loaded('openssl')) {
             // require_once 'Zend/Crypt/Rsa/Exception.php';
             throw new Zend_Crypt_Rsa_Exception('Zend_Crypt_Rsa requires openssl extension to be loaded.');
@@ -121,12 +126,14 @@ class Zend_Crypt_Rsa
 
     /**
      * @param string $data
-     * @param Zend_Crypt_Rsa_Key_Private $privateKey
+     * @param Zend_Crypt_Rsa_Key_Private|null $privateKey
      * @param string $format
      * @return string
      */
-    public function sign($data, Zend_Crypt_Rsa_Key_Private $privateKey = null, $format = null)
+    public function sign($data, $privateKey = null, $format = null)
     {
+        Types::isNullable('privateKey', $privateKey, 'Zend_Crypt_Rsa_Key_Private');
+
         $signature = '';
         if (isset($privateKey)) {
             $opensslKeyResource = $privateKey->getOpensslKeyResource();
@@ -202,14 +209,16 @@ class Zend_Crypt_Rsa
     }
 
     /**
-     * @param  array $configargs
-     * 
+     * @param  array|null $configargs
+     *
      * @throws Zend_Crypt_Rsa_Exception
-     * 
+     *
      * @return ArrayObject
      */
-    public function generateKeys(array $configargs = null)
+    public function generateKeys($configargs = null)
     {
+        Types::isNullable('configargs', $configargs, 'array');
+
         $config = null;
         $passPhrase = null;
         if ($configargs !== null) {
@@ -320,8 +329,10 @@ class Zend_Crypt_Rsa
         return $this->_hashAlgorithm;
     }
 
-    protected function _parseConfigArgs(array $config = null)
+    protected function _parseConfigArgs($config = null)
     {
+        Types::isNullable('config', $config, 'array');
+
         $configs = array();
         if (isset($config['private_key_bits'])) {
             $configs['private_key_bits'] = $config['private_key_bits'];

--- a/packages/zend-db/library/Zend/Db/Adapter/Db2/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Db2/Exception.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -38,8 +41,10 @@ class Zend_Db_Adapter_Db2_Exception extends Zend_Db_Adapter_Exception
    protected $code = '00000';
    protected $message = 'unknown exception';
 
-   function __construct($message = 'unknown exception', $code = '00000', Exception $e = null)
+   function __construct($message = 'unknown exception', $code = '00000', $e = null)
    {
+        Types::isNullable('e', $e, 'Exception');
+
        parent::__construct($message, $code, $e);
    }
 }

--- a/packages/zend-db/library/Zend/Db/Adapter/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Exception.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -36,8 +39,10 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
 {
     protected $_chainedException = null;
 
-    public function __construct($message = '', $code = 0, Exception $e = null)
+    public function __construct($message = '', $code = 0, $e = null)
     {
+        Types::isNullable('e', $e, 'Exception');
+
         if ($e && (0 === $code)) {
             $code = $e->getCode();
         }

--- a/packages/zend-db/library/Zend/Db/Statement.php
+++ b/packages/zend-db/library/Zend/Db/Statement.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -180,7 +183,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         // get the character for value quoting
         // this should be '
         $q = $this->_adapter->quote('a');
-        $q = $q[0];        
+        $q = $q[0];
         // get the value used as an escaped quote,
         // e.g. \' or ''
         $qe = $this->_adapter->quote($q);
@@ -193,7 +196,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
             // this segfaults only after 65,000 characters instead of 9,000
             $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
         }
-        
+
         // get a version of the SQL statement with all quoted
         // values and delimited identifiers stripped out
         // remove "foo\"bar"
@@ -291,11 +294,13 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      */
-    public function execute(array $params = null)
+    public function execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         /*
          * Simple case - no query profiler to manage.
          */

--- a/packages/zend-db/library/Zend/Db/Statement/Db2.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Db2.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -187,12 +190,14 @@ class Zend_Db_Statement_Db2 extends Zend_Db_Statement
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws Zend_Db_Statement_Db2_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         if (!$this->_stmt) {
             return false;
         }

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -180,12 +183,14 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws Zend_Db_Statement_Mysqli_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         if (!$this->_stmt) {
             return false;
         }

--- a/packages/zend-db/library/Zend/Db/Statement/Oracle.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Oracle.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -222,12 +225,14 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $connection = $this->_adapter->getConnection();
 
         if (!$this->_stmt) {

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -217,12 +220,14 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         try {
             if ($params !== null) {
                 return $this->_stmt->execute($params);

--- a/packages/zend-db/library/Zend/Db/Statement/Sqlsrv.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Sqlsrv.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -170,12 +173,14 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
     /**
      * Executes a prepared statement.
      *
-     * @param array $params OPTIONAL Values to bind to parameter placeholders.
+     * @param array|null $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $connection = $this->_adapter->getConnection();
         if (!$this->_stmt) {
             return false;
@@ -376,7 +381,7 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
             // require_once 'Zend/Db/Statement/Sqlsrv/Exception.php';
             throw new Zend_Db_Statement_Sqlsrv_Exception(sqlsrv_errors());
         }
-        
+
         // reset column keys
         $this->_keys = null;
 
@@ -411,7 +416,7 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
 
         return $num_rows;
     }
-    
+
     /**
      * Returns an array containing all of the result set rows.
      *

--- a/packages/zend-db/library/Zend/Db/Table/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -1583,12 +1586,14 @@ abstract class Zend_Db_Table_Abstract
      * Get table gateway object from string
      *
      * @param  string                 $tableName
-     * @param  Zend_Db_Table_Abstract $referenceTable
+     * @param  Zend_Db_Table_Abstract|null $referenceTable
      * @throws Zend_Db_Table_Row_Exception
      * @return Zend_Db_Table_Abstract
      */
-    public static function getTableFromString($tableName, Zend_Db_Table_Abstract $referenceTable = null)
+    public static function getTableFromString($tableName, $referenceTable = null)
     {
+        Types::isNullable('referenceTable', $referenceTable, 'Zend_Db_Table_Abstract');
+
         if ($referenceTable instanceof Zend_Db_Table_Abstract) {
             $tableDefinition = $referenceTable->getDefinition();
 

--- a/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -332,12 +335,14 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * Set the table object, to re-establish a live connection
      * to the database for a Row that has been de-serialized.
      *
-     * @param Zend_Db_Table_Abstract $table
+     * @param Zend_Db_Table_Abstract|null $table
      * @return boolean
      * @throws Zend_Db_Table_Row_Exception
      */
-    public function setTable(Zend_Db_Table_Abstract $table = null)
+    public function setTable($table = null)
     {
+        Types::isNullable('table', $table, 'Zend_Db_Table_Abstract');
+
         if ($table == null) {
             $this->_table = null;
             $this->_connected = false;
@@ -876,12 +881,14 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      *
      * @param string|Zend_Db_Table_Abstract  $dependentTable
      * @param string                         OPTIONAL $ruleKey
-     * @param Zend_Db_Table_Select           OPTIONAL $select
+     * @param Zend_Db_Table_Select|null      OPTIONAL $select
      * @return Zend_Db_Table_Rowset_Abstract Query result from $dependentTable
      * @throws Zend_Db_Table_Row_Exception If $dependentTable is not a table or is not loadable.
      */
-    public function findDependentRowset($dependentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findDependentRowset($dependentTable, $ruleKey = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $db = $this->_getTable()->getAdapter();
 
         if (is_string($dependentTable)) {
@@ -932,12 +939,14 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      *
      * @param string|Zend_Db_Table_Abstract $parentTable
      * @param string                        OPTIONAL $ruleKey
-     * @param Zend_Db_Table_Select          OPTIONAL $select
+     * @param Zend_Db_Table_Select|null     OPTIONAL $select
      * @return Zend_Db_Table_Row_Abstract   Query result from $parentTable
      * @throws Zend_Db_Table_Row_Exception If $parentTable is not a table or is not loadable.
      */
-    public function findParentRow($parentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findParentRow($parentTable, $ruleKey = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $db = $this->_getTable()->getAdapter();
 
         if (is_string($parentTable)) {
@@ -999,13 +1008,15 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param  string|Zend_Db_Table_Abstract  $intersectionTable
      * @param  string                         OPTIONAL $callerRefRule
      * @param  string                         OPTIONAL $matchRefRule
-     * @param  Zend_Db_Table_Select           OPTIONAL $select
+     * @param  Zend_Db_Table_Select|null      OPTIONAL $select
      * @return Zend_Db_Table_Rowset_Abstract Query result from $matchTable
      * @throws Zend_Db_Table_Row_Exception If $matchTable or $intersectionTable is not a table class or is not loadable.
      */
     public function findManyToManyRowset($matchTable, $intersectionTable, $callerRefRule = null,
-                                         $matchRefRule = null, Zend_Db_Table_Select $select = null)
+                                         $matchRefRule = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $db = $this->_getTable()->getAdapter();
 
         if (is_string($intersectionTable)) {

--- a/packages/zend-dojo/library/Zend/Dojo/Form.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -74,11 +77,13 @@ class Zend_Dojo_Form extends Zend_Form
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {
                 $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend_Dojo_View_Helper');

--- a/packages/zend-dojo/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form/DisplayGroup.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -53,11 +56,13 @@ class Zend_Dojo_Form_DisplayGroup extends Zend_Form_DisplayGroup
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {
                 $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend_Dojo_View_Helper');

--- a/packages/zend-dojo/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form/Element/Dijit.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -174,11 +177,13 @@ abstract class Zend_Dojo_Form_Element_Dijit extends Zend_Form_Element
      *
      * Ensures that the view object has the dojo view helper path set.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {
                 $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend_Dojo_View_Helper');

--- a/packages/zend-eventmanager/library/Zend/EventManager/GlobalEventManager.php
+++ b/packages/zend-eventmanager/library/Zend/EventManager/GlobalEventManager.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -24,7 +27,7 @@
 /**
  * Event manager: notification system
  *
- * Use the EventManager when you want to create a per-instance notification 
+ * Use the EventManager when you want to create a per-instance notification
  * system for your objects.
  *
  * @category   Zend
@@ -41,12 +44,14 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Set the event collection on which this will operate
-     * 
-     * @param  null|Zend_EventManager_EventCollection $events 
+     *
+     * @param  null|Zend_EventManager_EventCollection $events
      * @return void
      */
-    public static function setEventCollection(Zend_EventManager_EventCollection $events = null)
+    public static function setEventCollection($events = null)
     {
+        Types::isNullable('events', $events, 'Zend_EventManager_EventCollection');
+
         self::$events = $events;
     }
 
@@ -65,10 +70,10 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Trigger an event
-     * 
-     * @param  string $event 
-     * @param  object|string $context 
-     * @param  array|object $argv 
+     *
+     * @param  string $event
+     * @param  object|string $context
+     * @param  array|object $argv
      * @return Zend_EventManager_ResponseCollection
      */
     public static function trigger($event, $context, $argv = array())
@@ -77,13 +82,13 @@ class Zend_EventManager_GlobalEventManager
     }
 
     /**
-     * Trigger listeenrs until return value of one causes a callback to evaluate 
+     * Trigger listeenrs until return value of one causes a callback to evaluate
      * to true.
-     * 
-     * @param  string $event 
-     * @param  string|object $context 
-     * @param  array|object $argv 
-     * @param  callback $callback 
+     *
+     * @param  string $event
+     * @param  string|object $context
+     * @param  array|object $argv
+     * @param  callback $callback
      * @return Zend_EventManager_ResponseCollection
      */
     public static function triggerUntil($event, $context, $argv, $callback)
@@ -93,10 +98,10 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Attach a listener to an event
-     * 
-     * @param  string $event 
-     * @param  callback $callback 
-     * @param  int $priority 
+     *
+     * @param  string $event
+     * @param  callback $callback
+     * @param  int $priority
      * @return Zend_Stdlib_CallbackHandler
      */
     public static function attach($event, $callback, $priority = 1)
@@ -106,8 +111,8 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Detach a callback from a listener
-     * 
-     * @param  Zend_Stdlib_CallbackHandler $listener 
+     *
+     * @param  Zend_Stdlib_CallbackHandler $listener
      * @return bool
      */
     public static function detach(Zend_Stdlib_CallbackHandler $listener)
@@ -117,7 +122,7 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Retrieve list of events this object manages
-     * 
+     *
      * @return array
      */
     public static function getEvents()
@@ -127,8 +132,8 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Retrieve all listeners for a given event
-     * 
-     * @param  string $event 
+     *
+     * @param  string $event
      * @return Zend_Stdlib_PriorityQueue|array
      */
     public static function getListeners($event)
@@ -138,8 +143,8 @@ class Zend_EventManager_GlobalEventManager
 
     /**
      * Clear all listeners for a given event
-     * 
-     * @param  string $event 
+     *
+     * @param  string $event
      * @return void
      */
     public static function clearListeners($event)

--- a/packages/zend-feed/library/Zend/Feed/Abstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Abstract.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -67,12 +69,14 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @param  string $uri The full URI of the feed to load, or NULL if not retrieved via HTTP or as an array.
      * @param  string $string The feed as a string, or NULL if retrieved via HTTP or as an array.
-     * @param  Zend_Feed_Builder_Interface $builder The feed as a builder instance or NULL if retrieved as a string or via HTTP.
+     * @param  Zend_Feed_Builder_Interface|null $builder The feed as a builder instance or NULL if retrieved as a string or via HTTP.
      * @return void
      * @throws Zend_Feed_Exception If loading the feed failed.
      */
-    public function __construct($uri = null, $string = null, Zend_Feed_Builder_Interface $builder = null)
+    public function __construct($uri = null, $string = null, $builder = null)
     {
+        Types::isNullable('builder', $builder, 'Zend_Feed_Builder_Interface');
+
         if ($uri !== null) {
             // Retrieve the feed via HTTP
             $client = Zend_Feed::getHttpClient();
@@ -270,8 +274,8 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      * Import a feed from a string
      *
      * Protects against XXE attack vectors.
-     * 
-     * @param  string $feed 
+     *
+     * @param  string $feed
      * @return string
      * @throws Zend_Feed_Exception on detection of an XXE vector
      */

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/CallbackInterface.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/CallbackInterface.php
@@ -34,10 +34,10 @@ interface Zend_Feed_Pubsubhubbub_CallbackInterface
      * unsubscription request. This should be the Hub Server confirming the
      * the request prior to taking action on it.
      *
-     * @param array $httpData GET/POST data if available and not in $_GET/POST
+     * @param array|null $httpData GET/POST data if available and not in $_GET/POST
      * @param bool $sendResponseNow Whether to send response now or when asked
      */
-    public function handle(array $httpData = null, $sendResponseNow = false);
+    public function handle($httpData = null, $sendResponseNow = false);
 
     /**
      * Send the response, including all headers.

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -47,10 +50,12 @@ class Zend_Feed_Pubsubhubbub_Model_ModelAbstract
     /**
      * Constructor
      *
-     * @param  Zend_Db_Table_Abstract $tableGateway
+     * @param  Zend_Db_Table_Abstract|null $tableGateway
      */
-    public function __construct(Zend_Db_Table_Abstract $tableGateway = null)
+    public function __construct($tableGateway = null)
     {
+        Types::isNullable('tableGateway', $tableGateway, 'Zend_Db_Table_Abstract');
+
         if ($tableGateway === null) {
             $parts = explode('_', get_class($this));
             $table = strtolower(array_pop($parts));

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -85,12 +88,14 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * unsubscription request. This should be the Hub Server confirming the
      * the request prior to taking action on it.
      *
-     * @param  array $httpGetData GET data if available and not in $_GET
+     * @param  array|null $httpGetData GET data if available and not in $_GET
      * @param  bool $sendResponseNow Whether to send response now or when asked
      * @return void
      */
-    public function handle(array $httpGetData = null, $sendResponseNow = false)
+    public function handle($httpGetData = null, $sendResponseNow = false)
     {
+        Types::isNullable('httpGetData', $httpGetData, 'array');
+
         if ($httpGetData === null) {
             $httpGetData = $_GET;
         }
@@ -230,12 +235,14 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * Check for a valid verify_token. By default attempts to compare values
      * with that sent from Hub, otherwise merely ascertains its existence.
      *
-     * @param  array $httpGetData
+     * @param  array|null $httpGetData
      * @param  bool $checkValue
      * @return bool
      */
-    protected function _hasValidVerifyToken(array $httpGetData = null, $checkValue = true)
+    protected function _hasValidVerifyToken($httpGetData = null, $checkValue = true)
     {
+        Types::isNullable('httpGetData', $httpGetData, 'array');
+
         $verifyTokenKey = $this->_detectVerifyTokenKey($httpGetData);
         if (empty($verifyTokenKey)) {
             return false;
@@ -264,8 +271,10 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * @param  null|array $httpGetData
      * @return false|string
      */
-    protected function _detectVerifyTokenKey(array $httpGetData = null)
+    protected function _detectVerifyTokenKey($httpGetData = null)
     {
+        Types::isNullable('httpGetData', $httpGetData, 'array');
+
         /**
          * Available when sub keys encoding in Callback URL path
          */

--- a/packages/zend-feed/library/Zend/Feed/Reader/Extension/FeedAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/Extension/FeedAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -78,8 +81,10 @@ abstract class Zend_Feed_Reader_Extension_FeedAbstract
      * @param  string $type Feed type
      * @return void
      */
-    public function __construct(DomDocument $dom, $type = null, DOMXPath $xpath = null)
+    public function __construct(DomDocument $dom, $type = null, $xpath = null)
     {
+        Types::isNullable('xpath', $xpath, 'DOMXPath');
+
         $this->_domDocument = $dom;
 
         if ($type !== null) {

--- a/packages/zend-filter/library/Zend/Filter/Input.php
+++ b/packages/zend-filter/library/Zend/Filter/Input.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -159,11 +162,14 @@ class Zend_Filter_Input
     /**
      * @param array $filterRules
      * @param array $validatorRules
-     * @param array $data       OPTIONAL
-     * @param array $options    OPTIONAL
+     * @param array|null $data       OPTIONAL
+     * @param array|null $options    OPTIONAL
      */
-    public function __construct($filterRules, $validatorRules, array $data = null, array $options = null)
+    public function __construct($filterRules, $validatorRules, $data = null, $options = null)
     {
+        Types::isNullable('data', $data, 'array');
+        Types::isNullable('options', $options, 'array');
+
         if ($options) {
             $this->setOptions($options);
         }
@@ -801,8 +807,8 @@ class Zend_Filter_Input
             $this->_data = array();
             return;
         }
-        
-        // remember the default not empty message in case we want to temporarily change it        
+
+        // remember the default not empty message in case we want to temporarily change it
         $preserveDefaultNotEmptyMessage = $this->_defaults[self::NOT_EMPTY_MESSAGE];
 
         foreach ($this->_validatorRules as $ruleName => &$validatorRule) {
@@ -840,14 +846,14 @@ class Zend_Filter_Input
             }
             if (!isset($validatorRule[self::ALLOW_EMPTY])) {
                 $foundNotEmptyValidator = false;
-                
+
                 foreach ($validatorRule as $rule) {
                     if ($rule === 'NotEmpty') {
                         $foundNotEmptyValidator = true;
                         // field may not be empty, we are ready
                         break 1;
                     }
-                    
+
                     if (is_array($rule)) {
                         $keys      = array_keys($rule);
                         $classKey  = array_shift($keys);
@@ -866,14 +872,14 @@ class Zend_Filter_Input
                         // it cannot be a NotEmpty validator, skip this one
                         continue;
                     }
-                    
+
                     if($rule instanceof Zend_Validate_NotEmpty) {
                         $foundNotEmptyValidator = true;
                         // field may not be empty, we are ready
                         break 1;
                     }
                 }
-                
+
                 if (!$foundNotEmptyValidator) {
                     $validatorRule[self::ALLOW_EMPTY] = $this->_defaults[self::ALLOW_EMPTY];
                 } else {
@@ -923,7 +929,7 @@ class Zend_Filter_Input
                             /** we are changing the defaults here, this is alright if all subsequent validators are also a not empty
                             * validator, but it goes wrong if one of them is not AND is required!!!
                             * that is why we restore the default value at the end of this loop
-                            */ 
+                            */
                             if (is_array($value)) {
                                 $temp = $value; // keep the original value
                                 $this->_defaults[self::NOT_EMPTY_MESSAGE] = array_pop($temp);
@@ -951,11 +957,11 @@ class Zend_Filter_Input
             } else {
                 $this->_validateRule($validatorRule);
             }
-            
+
             // reset the default not empty message
             $this->_defaults[self::NOT_EMPTY_MESSAGE] = $preserveDefaultNotEmptyMessage;
         }
-        
+
 
 
         /**
@@ -1035,8 +1041,8 @@ class Zend_Filter_Input
                     if (!($notEmptyValidator = $this->_getNotEmptyValidatorInstance($validatorRule))) {
                         $notEmptyValidator = $this->_getValidator('NotEmpty');
                         $notEmptyValidator->setMessage($this->_getNotEmptyMessage($validatorRule[self::RULE], $fieldKey));
-                    }            
-                            
+                    }
+
                     if (!$notEmptyValidator->isValid($field)) {
                         foreach ($notEmptyValidator->getMessages() as $messageKey => $message) {
                             if (!isset($messages[$messageKey])) {
@@ -1078,7 +1084,7 @@ class Zend_Filter_Input
                 $notEmptyValidator = $this->_getValidator('NotEmpty');
                 $notEmptyValidator->setMessage($this->_getNotEmptyMessage($validatorRule[self::RULE], $fieldName));
             }
-            
+
             if ($validatorRule[self::ALLOW_EMPTY]) {
                 $validatorChain = $validatorRule[self::VALIDATOR_CHAIN];
             } else {
@@ -1136,10 +1142,10 @@ class Zend_Filter_Input
             }
         }
     }
-    
+
     /**
      * Check a validatorRule for the presence of a NotEmpty validator instance.
-     * The purpose is to preserve things like a custom message, that may have been 
+     * The purpose is to preserve things like a custom message, that may have been
      * set on the validator outside Zend_Filter_Input.
      * @param array $validatorRule
      * @return mixed false if none is found, Zend_Validate_NotEmpty instance if found
@@ -1150,7 +1156,7 @@ class Zend_Filter_Input
                 return $value;
             }
         }
-        
+
         return false;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/LocalizedToNormalized.php
+++ b/packages/zend-filter/library/Zend/Filter/LocalizedToNormalized.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -78,11 +81,13 @@ class Zend_Filter_LocalizedToNormalized implements Zend_Filter_Interface
     /**
      * Sets options to use
      *
-     * @param  array $options (Optional) Options to use
+     * @param  array|null $options (Optional) Options to use
      * @return Zend_Filter_LocalizedToNormalized
      */
-    public function setOptions(array $options = null)
+    public function setOptions($options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $this->_options = $options + $this->_options;
         return $this;
     }

--- a/packages/zend-filter/library/Zend/Filter/NormalizedToLocalized.php
+++ b/packages/zend-filter/library/Zend/Filter/NormalizedToLocalized.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -77,11 +80,13 @@ class Zend_Filter_NormalizedToLocalized implements Zend_Filter_Interface
     /**
      * Sets options to use
      *
-     * @param  array $options (Optional) Options to use
+     * @param  array|null $options (Optional) Options to use
      * @return Zend_Filter_LocalizedToNormalized
      */
-    public function setOptions(array $options = null)
+    public function setOptions($options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $this->_options = $options + $this->_options;
         return $this;
     }

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -1676,7 +1679,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     public function addSubForms(array $subForms)
     {
-        foreach ($subForms as $key => $spec) {          
+        foreach ($subForms as $key => $spec) {
             $name = (string) $key;
             if ($spec instanceof Zend_Form) {
                 $this->addSubForm($spec, $name);
@@ -2671,11 +2674,13 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     /**
      * Set view object
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Form
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->_view = $view;
         return $this;
     }
@@ -2912,8 +2917,10 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @param  bool $include Whether $elements is an inclusion or exclusion list
      * @return Zend_Form
      */
-    public function setElementDecorators(array $decorators, array $elements = null, $include = true)
+    public function setElementDecorators(array $decorators, $elements = null, $include = true)
     {
+        Types::isNullable('elements', $elements, 'array');
+
         if (is_array($elements)) {
             if ($include) {
                 $elementObjs = array();
@@ -2979,11 +2986,13 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     /**
      * Render form
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             $this->setView($view);
         }

--- a/packages/zend-form/library/Zend/Form/Decorator/HtmlTag.php
+++ b/packages/zend-form/library/Zend/Form/Decorator/HtmlTag.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -156,11 +159,13 @@ class Zend_Form_Decorator_HtmlTag extends Zend_Form_Decorator_Abstract
      * Get the formatted open tag
      *
      * @param  string $tag
-     * @param  array $attribs
+     * @param  array|null $attribs
      * @return string
      */
-    protected function _getOpenTag($tag, array $attribs = null)
+    protected function _getOpenTag($tag, $attribs = null)
     {
+        Types::isNullable('attribs', $attribs, 'array');
+
         $html = '<' . $tag;
         if (null !== $attribs) {
             $html .= $this->_htmlAttribs($attribs);

--- a/packages/zend-form/library/Zend/Form/DisplayGroup.php
+++ b/packages/zend-form/library/Zend/Form/DisplayGroup.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -885,11 +888,13 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
     /**
      * Set view
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Form_DisplayGroup
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->_view = $view;
         return $this;
     }
@@ -915,8 +920,10 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             $this->setView($view);
         }

--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -339,8 +342,8 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * Used to resolve and return an element ID
      *
      * Passed to the HtmlTag decorator as a callback in order to provide an ID.
-     * 
-     * @param  Zend_Form_Decorator_Interface $decorator 
+     *
+     * @param  Zend_Form_Decorator_Interface $decorator
      * @return string
      */
     public static function resolveElementId(Zend_Form_Decorator_Interface $decorator)
@@ -1819,11 +1822,13 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Set view object
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Form_Element
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->_view = $view;
         return $this;
     }
@@ -2053,11 +2058,13 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Render form element
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if ($this->_isPartialRendering) {
             return '';
         }

--- a/packages/zend-form/library/Zend/Form/Element/Captcha.php
+++ b/packages/zend-form/library/Zend/Form/Element/Captcha.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -158,11 +161,13 @@ class Zend_Form_Element_Captcha extends Zend_Form_Element_Xhtml
     /**
      * Render form element
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $captcha    = $this->getCaptcha();
         $captcha->setName($this->getFullyQualifiedName());
 

--- a/packages/zend-form/library/Zend/Form/Element/File.php
+++ b/packages/zend-form/library/Zend/Form/Element/File.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -860,12 +863,14 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      * Render form element
      * Checks for decorator interface to prevent errors
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      * @throws Zend_Form_Element_Exception
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $marker = false;
         foreach ($this->getDecorators() as $decorator) {
             if ($decorator instanceof Zend_Form_Decorator_Marker_File_Interface) {

--- a/packages/zend-form/library/Zend/Form/Element/Hash.php
+++ b/packages/zend-form/library/Zend/Form/Element/Hash.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -232,11 +235,13 @@ class Zend_Form_Element_Hash extends Zend_Form_Element_Xhtml
     /**
      * Render CSRF token in form
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->initCsrfToken();
         return parent::render($view);
     }

--- a/packages/zend-layout/library/Zend/Layout/Controller/Action/Helper/Layout.php
+++ b/packages/zend-layout/library/Zend/Layout/Controller/Action/Helper/Layout.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -53,11 +56,13 @@ class Zend_Layout_Controller_Action_Helper_Layout extends Zend_Controller_Action
     /**
      * Constructor
      *
-     * @param  Zend_Layout $layout
+     * @param  Zend_Layout|null $layout
      * @return void
      */
-    public function __construct(Zend_Layout $layout = null)
+    public function __construct($layout = null)
     {
+        Types::isNullable('layout', $layout, 'Zend_Layout');
+
         if (null !== $layout) {
             $this->setLayoutInstance($layout);
         } else {

--- a/packages/zend-layout/library/Zend/Layout/Controller/Plugin/Layout.php
+++ b/packages/zend-layout/library/Zend/Layout/Controller/Plugin/Layout.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -45,11 +48,13 @@ class Zend_Layout_Controller_Plugin_Layout extends Zend_Controller_Plugin_Abstra
     /**
      * Constructor
      *
-     * @param  Zend_Layout $layout
+     * @param  Zend_Layout|null $layout
      * @return void
      */
-    public function __construct(Zend_Layout $layout = null)
+    public function __construct($layout = null)
     {
+        Types::isNullable('layout', $layout, 'Zend_Layout');
+
         if (null !== $layout) {
             $this->setLayout($layout);
         }

--- a/packages/zend-ldap/library/Zend/Ldap.php
+++ b/packages/zend-ldap/library/Zend/Ldap.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -163,7 +165,7 @@ class Zend_Ldap
         if(!$this->isConnection($this->_resource)) {
             return 0;
         }
-    
+
         $ret = @ldap_get_option($this->_resource, LDAP_OPT_ERROR_NUMBER, $err);
         if ($ret === true) {
             if ($err <= -1 && $err >= -17) {
@@ -639,12 +641,14 @@ class Zend_Ldap
     }
 
     /**
-     * @param  array $attrs An array of names of desired attributes
+     * @param  array|null $attrs An array of names of desired attributes
      * @return array An array of the attributes representing the account
      * @throws Zend_Ldap_Exception
      */
-    protected function _getAccount($acctname, array $attrs = null)
+    protected function _getAccount($acctname, $attrs = null)
     {
+        Types::isNullable('attrs', $attrs, 'array');
+
         $baseDn = $this->getBaseDn();
         if (!$baseDn) {
             /**
@@ -708,7 +712,7 @@ class Zend_Ldap
         $this->_boundUser = false;
         return $this;
     }
-    
+
     /**
      * @param $resource
      *
@@ -719,7 +723,7 @@ class Zend_Ldap
         if (PHP_VERSION_ID < 80100) {
             return is_resource($resource);
         }
-        
+
         return $resource instanceof \LDAP\Connection;
     }
 
@@ -1018,11 +1022,11 @@ class Zend_Ldap
          */
         // require_once 'Zend/Ldap/Collection/Iterator/Default.php';
         $iterator = new Zend_Ldap_Collection_Iterator_Default($this, $search);
-        
+
         if ($sort !== null && is_string($sort)) {
             $iterator->sort($sort);
         }
-        
+
         return $this->_createCollection($iterator, $collectionClass);
     }
 

--- a/packages/zend-ldap/library/Zend/Ldap/Exception.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Exception.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -116,12 +119,14 @@ class Zend_Ldap_Exception extends Zend_Exception
     const LDAP_X_EXTENSION_NOT_LOADED         = 0x7002;
 
     /**
-     * @param Zend_Ldap $ldap A Zend_Ldap object
+     * @param Zend_Ldap|null $ldap A Zend_Ldap object
      * @param string    $str  An informtive exception message
      * @param int       $code An LDAP error code
      */
-    public function __construct(Zend_Ldap $ldap = null, $str = null, $code = 0)
+    public function __construct($ldap = null, $str = null, $code = 0)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         $errorMessages = array();
         $message = '';
         if ($ldap !== null) {
@@ -150,11 +155,13 @@ class Zend_Ldap_Exception extends Zend_Exception
 
     /**
      * @deprecated not necessary any more - will be removed
-     * @param Zend_Ldap $ldap A Zend_Ldap object
+     * @param Zend_Ldap|null $ldap A Zend_Ldap object
      * @return int The current error code for the resource
      */
-    public static function getLdapCode(Zend_Ldap $ldap = null)
+    public static function getLdapCode($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             return $ldap->getLastErrorCode();
         }

--- a/packages/zend-ldap/library/Zend/Ldap/Node.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -90,14 +93,16 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * Constructor is protected to enforce the use of factory methods.
      *
-     * @param  Zend_Ldap_Dn $dn
-     * @param  array        $data
-     * @param  boolean      $fromDataSource
-     * @param  Zend_Ldap    $ldap
+     * @param  Zend_Ldap_Dn   $dn
+     * @param  array          $data
+     * @param  boolean        $fromDataSource
+     * @param  Zend_Ldap|null $ldap
      * @throws Zend_Ldap_Exception
      */
-    protected function __construct(Zend_Ldap_Dn $dn, array $data, $fromDataSource, Zend_Ldap $ldap = null)
+    protected function __construct(Zend_Ldap_Dn $dn, array $data, $fromDataSource, $ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         parent::__construct($dn, $data, $fromDataSource);
         if ($ldap !== null) $this->attachLdap($ldap);
         else $this->detachLdap();
@@ -415,12 +420,14 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
     /**
      * Sends all pending changes to the LDAP server
      *
-     * @param  Zend_Ldap $ldap
+     * @param  Zend_Ldap|null $ldap
      * @return Zend_Ldap_Node Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function update(Zend_Ldap $ldap = null)
+    public function update($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             $this->attachLdap($ldap);
         }
@@ -903,12 +910,14 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * This is an online method.
      *
-     * @param  Zend_Ldap $ldap
+     * @param  Zend_Ldap|null $ldap
      * @return boolean
      * @throws Zend_Ldap_Exception
      */
-    public function exists(Zend_Ldap $ldap = null)
+    public function exists($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             $this->attachLdap($ldap);
         }
@@ -921,12 +930,14 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * This is an online method.
      *
-     * @param  Zend_Ldap $ldap
+     * @param  Zend_Ldap|null $ldap
      * @return Zend_Ldap_Node Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function reload(Zend_Ldap $ldap = null)
+    public function reload($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             $this->attachLdap($ldap);
         }
@@ -1053,12 +1064,14 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
     /**
      * Returns the parent of the current node.
      *
-     * @param  Zend_Ldap $ldap
+     * @param  Zend_Ldap|null $ldap
      * @return Zend_Ldap_Node
      * @throws Zend_Ldap_Exception
      */
-    public function getParent(Zend_Ldap $ldap = null)
+    public function getParent($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             $this->attachLdap($ldap);
         }

--- a/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -94,12 +97,14 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      *
      * This is an online method.
      *
-     * @param  Zend_Ldap $ldap
+     * @param  Zend_Ldap|null $ldap
      * @return Zend_Ldap_Node_Abstract Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function reload(Zend_Ldap $ldap = null)
+    public function reload($ldap = null)
     {
+        Types::isNullable('ldap', $ldap, 'Zend_Ldap');
+
         if ($ldap !== null) {
             $data = $ldap->getEntry($this->_getDn(), array('*', '+'), true);
             $this->_loadData($data, true);

--- a/packages/zend-log/library/Zend/Log.php
+++ b/packages/zend-log/library/Zend/Log.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -116,8 +119,10 @@ class Zend_Log
      *
      * @param Zend_Log_Writer_Abstract|null  $writer  default writer
      */
-    public function __construct(Zend_Log_Writer_Abstract $writer = null)
+    public function __construct($writer = null)
     {
+        Types::isNullable('writer', $writer, 'Zend_Log_Writer_Abstract');
+
         $r = new ReflectionClass($this);
         $this->_priorities = array_flip($r->getConstants());
 

--- a/packages/zend-log/library/Zend/Log/Writer/Mail.php
+++ b/packages/zend-log/library/Zend/Log/Writer/Mail.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -120,11 +123,13 @@ class Zend_Log_Writer_Mail extends Zend_Log_Writer_Abstract
      * $this->_layout->events will be set for use in the layout template.
      *
      * @param  Zend_Mail $mail Mail instance
-     * @param  Zend_Layout $layout Layout instance; optional
+     * @param  Zend_Layout|null $layout Layout instance; optional
      * @return void
      */
-    public function __construct(Zend_Mail $mail, Zend_Layout $layout = null)
+    public function __construct(Zend_Mail $mail, $layout = null)
     {
+        Types::isNullable('layout', $layout, 'Zend_Layout');
+
         $this->_mail = $mail;
         if (null !== $layout) {
             $this->setLayout($layout);

--- a/packages/zend-mail/library/Zend/Mail/Transport/Sendmail.php
+++ b/packages/zend-mail/library/Zend/Mail/Transport/Sendmail.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -208,11 +211,13 @@ class Zend_Mail_Transport_Sendmail extends Zend_Mail_Transport_Abstract
      * @param string $errstr
      * @param string $errfile
      * @param string $errline
-     * @param array  $errcontext
+     * @param array|null $errcontext
      * @return true
      */
-    public function _handleMailErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function _handleMailErrors($errno, $errstr, $errfile = null, $errline = null, $errcontext = null)
     {
+        Types::isNullable('errcontext', $errcontext, 'array');
+
         $this->_errstr = $errstr;
         return true;
     }

--- a/packages/zend-mobile/library/Zend/Mobile/Push/Response/Gcm.php
+++ b/packages/zend-mobile/library/Zend/Mobile/Push/Response/Gcm.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -83,12 +86,14 @@ class Zend_Mobile_Push_Response_Gcm
      * Constructor
      *
      * @param string $responseString JSON encoded response
-     * @param Zend_Mobile_Push_Message_Gcm $message
+     * @param Zend_Mobile_Push_Message_Gcm|null $message
      * @return Zend_Mobile_Push_Response_Gcm
      * @throws Zend_Mobile_Push_Exception_ServerUnavailable
      */
-    public function __construct($responseString = null, Zend_Mobile_Push_Message_Gcm $message = null)
+    public function __construct($responseString = null, $message = null)
     {
+        Types::isNullable('message', $message, 'Zend_Mobile_Push_Message_Gcm');
+
         if ($responseString) {
             if (!$response = json_decode($responseString, true)) {
                 // require_once 'Zend/Mobile/Push/Exception/ServerUnavailable.php';
@@ -195,7 +200,7 @@ class Zend_Mobile_Push_Response_Gcm
      *
      * @return array multi dimensional array of:
      *         NOTE: key is registration_id if the message is passed.
-     *         'registration_id' => array( 
+     *         'registration_id' => array(
      *             'message_id' => 'id',
      *             'error' => 'error',
      *             'registration_id' => 'id'

--- a/packages/zend-navigation/library/Zend/Navigation/Page.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Page.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -43,14 +46,14 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
 
     /**
      * Fragment identifier (anchor identifier)
-     * 
-     * The fragment identifier (anchor identifier) pointing to an anchor within 
+     *
+     * The fragment identifier (anchor identifier) pointing to an anchor within
      * a resource that is subordinate to another, primary resource.
      * The fragment identifier introduced by a hash mark "#".
      * Example: http://www.example.org/foo.html#bar ("bar" is the fragment identifier)
-     * 
+     *
      * @link http://www.w3.org/TR/html401/intro/intro.html#fragment-uri
-     * 
+     *
      * @var string|null
      */
     protected $_fragment;
@@ -266,12 +269,12 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
             return new Zend_Navigation_Page_Uri($options);
         } else {
             // require_once 'Zend/Navigation/Exception.php';
-            
+
             $message = 'Invalid argument: Unable to determine class to instantiate';
             if (isset($options['label'])) {
                 $message .= ' (Page label: ' . $options['label'] . ')';
         }
-            
+
             throw new Zend_Navigation_Exception($message);
     }
     }
@@ -382,11 +385,11 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
             throw new Zend_Navigation_Exception(
                     'Invalid argument: $fragment must be a string or null');
         }
- 
+
         $this->_fragment = $fragment;
         return $this;
     }
-    
+
      /**
      * Returns fragment identifier
      *
@@ -537,7 +540,7 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
                 'Invalid argument: $character must be a single character or null'
             );
         }
- 
+
         $this->_accesskey = $character;
         return $this;
     }
@@ -1000,13 +1003,15 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
     /**
      * Sets parent container
      *
-     * @param  Zend_Navigation_Container $parent  [optional] new parent to set.
+     * @param  Zend_Navigation_Container|null $parent  [optional] new parent to set.
      *                                            Default is null which will set
      *                                            no parent.
      * @return Zend_Navigation_Page               fluent interface, returns self
      */
-    public function setParent(Zend_Navigation_Container $parent = null)
+    public function setParent($parent = null)
     {
+        Types::isNullable('parent', $parent, 'Zend_Navigation_Container');
+
         if ($parent === $this) {
             // require_once 'Zend/Navigation/Exception.php';
             throw new Zend_Navigation_Exception(

--- a/packages/zend-navigation/library/Zend/Navigation/Page/Mvc.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Page/Mvc.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -400,8 +403,10 @@ class Zend_Navigation_Page_Mvc extends Zend_Navigation_Page
      *                                      which clears all params.
      * @return Zend_Navigation_Page_Mvc     fluent interface, returns self
      */
-    public function setParams(array $params = null)
+    public function setParams($params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         $this->clearParams();
 
         if (is_array($params)) {

--- a/packages/zend-oauth/library/Zend/Oauth/Consumer.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Consumer.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -98,10 +101,13 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return Zend_Oauth_Token_Request
      */
     public function getRequestToken(
-        array $customServiceParameters = null,
+        $customServiceParameters = null,
         $httpMethod = null,
-        Zend_Oauth_Http_RequestToken $request = null
+        $request = null
     ) {
+        Types::isNullable('customServiceParameters', $customServiceParameters, 'array');
+        Types::isNullable('request', $request, 'Zend_Oauth_Http_RequestToken');
+
         if ($request === null) {
             $request = new Zend_Oauth_Http_RequestToken($this, $customServiceParameters);
         } elseif($customServiceParameters !== null) {
@@ -130,10 +136,14 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return string
      */
     public function getRedirectUrl(
-        array $customServiceParameters = null,
-        Zend_Oauth_Token_Request $token = null,
-        Zend_Oauth_Http_UserAuthorization $redirect = null
+        $customServiceParameters = null,
+        $token = null,
+        $redirect = null
     ) {
+        Types::isNullable('customServiceParameters', $customServiceParameters, 'array');
+        Types::isNullable('token', $token, 'Zend_Oauth_Token_Request');
+        Types::isNullable('redirect', $redirect, 'Zend_Oauth_Http_UserAuthorization');
+
         if ($redirect === null) {
             $redirect = new Zend_Oauth_Http_UserAuthorization($this, $customServiceParameters);
         } elseif($customServiceParameters !== null) {
@@ -157,10 +167,14 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return void
      */
     public function redirect(
-        array $customServiceParameters = null,
-        Zend_Oauth_Token_Request $token = null,
-        Zend_Oauth_Http_UserAuthorization $request = null
+        $customServiceParameters = null,
+        $token = null,
+        $request = null
     ) {
+        Types::isNullable('customServiceParameters', $customServiceParameters, 'array');
+        Types::isNullable('token', $token, 'Zend_Oauth_Token_Request');
+        Types::isNullable('request', $request, 'Zend_Oauth_Http_UserAuthorization');
+
         if ($token instanceof Zend_Oauth_Http_UserAuthorization) {
             $request = $token;
             $token = null;
@@ -177,7 +191,7 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @param  array $queryData GET data returned in user's redirect from Provider
      * @param  Zend_Oauth_Token_Request Request Token information
      * @param  string $httpMethod
-     * @param  Zend_Oauth_Http_AccessToken $request
+     * @param  Zend_Oauth_Http_AccessToken|null $request
      * @return Zend_Oauth_Token_Access
      * @throws Zend_Oauth_Exception on invalid authorization token, non-matching response authorization token, or unprovided authorization token
      */
@@ -185,8 +199,10 @@ class Zend_Oauth_Consumer extends Zend_Oauth
         $queryData,
         Zend_Oauth_Token_Request $token,
         $httpMethod = null,
-        Zend_Oauth_Http_AccessToken $request = null
+        $request = null
     ) {
+        Types::isNullable('request', $request, 'Zend_Oauth_Http_AccessToken');
+
         $authorizedToken = new Zend_Oauth_Token_AuthorizedRequest($queryData);
         if (!$authorizedToken->isValid()) {
             // require_once 'Zend/Oauth/Exception.php';

--- a/packages/zend-oauth/library/Zend/Oauth/Http.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Http.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -81,9 +84,12 @@ class Zend_Oauth_Http
      */
     public function __construct(
         Zend_Oauth_Consumer $consumer,
-        array $parameters = null,
-        Zend_Oauth_Http_Utility $utility = null
+        $parameters = null,
+        $utility = null
     ) {
+        Types::isNullable('parameters', $parameters, 'array');
+        Types::isNullable('utility', $utility, 'Zend_Oauth_Http_Utility');
+
         $this->_consumer = $consumer;
         $this->_preferredRequestScheme = $this->_consumer->getRequestScheme();
         if ($parameters !== null) {
@@ -216,12 +222,14 @@ class Zend_Oauth_Http
      * Manages the switch from OAuth request scheme to another lower preference
      * scheme during a request cycle.
      *
-     * @param  Zend_Http_Response
+     * @param  Zend_Http_Response|null $response
      * @return void
      * @throws Zend_Oauth_Exception if unable to retrieve valid token response
      */
-    protected function _assessRequestAttempt(Zend_Http_Response $response = null)
+    protected function _assessRequestAttempt($response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Http_Response');
+
         switch ($this->_preferredRequestScheme) {
             case Zend_Oauth::REQUEST_SCHEME_HEADER:
                 $this->_preferredRequestScheme = Zend_Oauth::REQUEST_SCHEME_POSTBODY;

--- a/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -45,8 +48,10 @@ class Zend_Oauth_Http_Utility
     public function assembleParams(
         $url,
         Zend_Oauth_Config_ConfigInterface $config,
-        array $serviceProviderParams = null
+        $serviceProviderParams = null
     ) {
+        Types::isNullable('serviceProviderParams', $serviceProviderParams, 'array');
+
         $params = array(
             'oauth_consumer_key'     => $config->getConsumerKey(),
             'oauth_nonce'            => $this->generateNonce(),

--- a/packages/zend-oauth/library/Zend/Oauth/Token.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -65,9 +68,12 @@ abstract class Zend_Oauth_Token
      * @return void
      */
     public function __construct(
-        Zend_Http_Response $response = null,
-        Zend_Oauth_Http_Utility $utility = null
+        $response = null,
+        $utility = null
     ) {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+        Types::isNullable('utility', $utility, 'Zend_Oauth_Http_Utility');
+
         if ($response !== null) {
             $this->_response = $response;
             $params = $this->_parseParameters($response);

--- a/packages/zend-oauth/library/Zend/Oauth/Token/Access.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/Access.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -49,8 +52,10 @@ class Zend_Oauth_Token_Access extends Zend_Oauth_Token
      * @return string
      */
     public function toHeader(
-        $url, Zend_Oauth_Config_ConfigInterface $config, array $customParams = null, $realm = null
+        $url, Zend_Oauth_Config_ConfigInterface $config, $customParams = null, $realm = null
     ) {
+        Types::isNullable('customParams', $customParams, 'array');
+
         if (!Zend_Uri::check($url)) {
             // require_once 'Zend/Oauth/Exception.php';
             throw new Zend_Oauth_Exception(
@@ -69,8 +74,10 @@ class Zend_Oauth_Token_Access extends Zend_Oauth_Token
      * @param  null|array $params
      * @return string
      */
-    public function toQueryString($url, Zend_Oauth_Config_ConfigInterface $config, array $params = null)
+    public function toQueryString($url, Zend_Oauth_Config_ConfigInterface $config, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+
         if (!Zend_Uri::check($url)) {
             // require_once 'Zend/Oauth/Exception.php';
             throw new Zend_Oauth_Exception(

--- a/packages/zend-oauth/library/Zend/Oauth/Token/AuthorizedRequest.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/AuthorizedRequest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -42,8 +45,11 @@ class Zend_Oauth_Token_AuthorizedRequest extends Zend_Oauth_Token
      * @param  null|Zend_Oauth_Http_Utility $utility
      * @return void
      */
-    public function __construct(array $data = null, Zend_Oauth_Http_Utility $utility = null)
+    public function __construct($data = null, $utility = null)
     {
+        Types::isNullable('data', $data, 'array');
+        Types::isNullable('utility', $utility, 'Zend_Oauth_Http_Utility');
+
         if ($data !== null) {
             $this->_data = $data;
             $params = $this->_parseData();

--- a/packages/zend-oauth/library/Zend/Oauth/Token/Request.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/Request.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -37,9 +40,12 @@ class Zend_Oauth_Token_Request extends Zend_Oauth_Token
      * @param null|Zend_Oauth_Http_Utility $utility
      */
     public function __construct(
-        Zend_Http_Response $response = null,
-        Zend_Oauth_Http_Utility $utility = null
+        $response = null,
+        $utility = null
     ) {
+        Types::isNullable('response', $response, 'Zend_Http_Response');
+        Types::isNullable('utility', $utility, 'Zend_Oauth_Http_Utility');
+
         parent::__construct($response, $utility);
 
         // detect if server supports OAuth 1.0a

--- a/packages/zend-openid/library/Zend/OpenId.php
+++ b/packages/zend-openid/library/Zend/OpenId.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -127,11 +129,11 @@ class Zend_OpenId
         }
 
         $url .= $port;
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { 
+        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
             // IIS with Microsoft Rewrite Module
             $url .= $_SERVER['HTTP_X_ORIGINAL_URL'];
         } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-            // IIS with ISAPI_Rewrite 
+            // IIS with ISAPI_Rewrite
             $url .= $_SERVER['HTTP_X_REWRITE_URL'];
         } elseif (isset($_SERVER['REQUEST_URI'])) {
             $query = strpos($_SERVER['REQUEST_URI'], '?');
@@ -424,12 +426,14 @@ class Zend_OpenId
      *
      * @param string $url URL to redirect to
      * @param array $params additional variable/value pairs to send
-     * @param Zend_Controller_Response_Abstract $response
+     * @param Zend_Controller_Response_Abstract|null $response
      * @param string $method redirection method ('GET' or 'POST')
      */
     static public function redirect($url, $params = null,
-        Zend_Controller_Response_Abstract $response = null, $method = 'GET')
+        $response = null, $method = 'GET')
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $url = Zend_OpenId::absoluteUrl($url);
         $body = "";
         if (null === $response) {

--- a/packages/zend-openid/library/Zend/OpenId/Consumer.php
+++ b/packages/zend-openid/library/Zend/OpenId/Consumer.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -106,14 +108,16 @@ class Zend_OpenId_Consumer
      * Enables or disables future association with server based on
      * Diffie-Hellman key agreement.
      *
-     * @param Zend_OpenId_Consumer_Storage $storage implementation of custom
+     * @param Zend_OpenId_Consumer_Storage|null $storage implementation of custom
      *  storage object
      * @param bool $dumbMode Enables or disables consumer to use association
      *  with server based on Diffie-Hellman key agreement
      */
-    public function __construct(Zend_OpenId_Consumer_Storage $storage = null,
+    public function __construct($storage = null,
                                 $dumbMode = false)
     {
+        Types::isNullable('storage', $storage, 'Zend_OpenId_Consumer_Storage');
+
         if ($storage === null) {
             // require_once "Zend/OpenId/Consumer/Storage/File.php";
             $this->_storage = new Zend_OpenId_Consumer_Storage_File();
@@ -134,13 +138,15 @@ class Zend_OpenId_Consumer
      * @param string $returnTo URL to redirect response from server to
      * @param string $root HTTP URL to identify consumer on server
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response an optional response
+     * @param Zend_Controller_Response_Abstract|null $response an optional response
      *  object to perform HTTP or HTML form redirection
      * @return bool
      */
     public function login($id, $returnTo = null, $root = null, $extensions = null,
-                          Zend_Controller_Response_Abstract $response = null)
+                          $response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         return $this->_checkId(
             false,
             $id,
@@ -161,14 +167,16 @@ class Zend_OpenId_Consumer
      * @param string $returnTo HTTP URL to redirect response from server to
      * @param string $root HTTP URL to identify consumer on server
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response an optional response
+     * @param Zend_Controller_Response_Abstract|null $response an optional response
      *  object to perform HTTP or HTML form redirection
      * @return bool
      */
     public function check($id, $returnTo=null, $root=null, $extensions = null,
-                          Zend_Controller_Response_Abstract $response = null)
+                          $response = null)
 
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         return $this->_checkId(
             true,
             $id,
@@ -300,7 +308,7 @@ class Zend_OpenId_Consumer
             if (isset($params['openid_op_endpoint']) && $url !== $params['openid_op_endpoint']) {
                 $this->_setError("The op_endpoint URI is not the same of URI associated with the assoc_handle");
                 return false;
-            }       
+            }
             $signed = explode(',', $params['openid_signed']);
             // Check the parameters for the signature
             // @see https://openid.net/specs/openid-authentication-2_0.html#positive_assertions
@@ -314,7 +322,7 @@ class Zend_OpenId_Consumer
                     return false;
                 }
             }
-            
+
             $data = '';
             foreach ($signed as $key) {
                 $data .= $key . ':' . $params['openid_' . strtr($key,'.','_')] . "\n";
@@ -763,13 +771,13 @@ class Zend_OpenId_Consumer
                 $r)) {
             $XRDS = $r[3];
             $version = 2.0;
-            $response = $this->_httpRequest($XRDS); 
+            $response = $this->_httpRequest($XRDS);
             if (preg_match(
                     '/<URI>([^\t]*)<\/URI>/i',
                     $response,
                     $x)) {
                 $server = $x[1];
-                // $realId 
+                // $realId
                 $realId = 'http://specs.openid.net/auth/2.0/identifier_select';
             }
             else {
@@ -854,8 +862,10 @@ class Zend_OpenId_Consumer
      * @return bool
      */
     protected function _checkId($immediate, $id, $returnTo=null, $root=null,
-        $extensions=null, Zend_Controller_Response_Abstract $response = null)
+        $extensions=null, $response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $this->_setError('');
 
         if (!Zend_OpenId::normalize($id)) {

--- a/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
+++ b/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -48,13 +50,15 @@ class Zend_OpenId_Extension_Sreg extends Zend_OpenId_Extension
     /**
      * Creates SREG extension object
      *
-     * @param array $props associative array of SREG variables
+     * @param array|null $props associative array of SREG variables
      * @param string $policy_url SREG policy URL
      * @param float $version SREG version
      * @return array
      */
-    public function __construct(array $props=null, $policy_url=null, $version=1.0)
+    public function __construct($props=null, $policy_url=null, $version=1.0)
     {
+        Types::isNullable('props', $props, 'array');
+
         $this->_props = $props;
         $this->_policy_url = $policy_url;
         $this->_version = $version;

--- a/packages/zend-openid/library/Zend/OpenId/Provider.php
+++ b/packages/zend-openid/library/Zend/OpenId/Provider.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -94,10 +96,10 @@ class Zend_OpenId_Provider
      * @param string $trustUrl is an URL that shows a question if end-user
      *  trust to given consumer (by default it is the same URL with additional
      *  GET variable openid.action=trust)
-     * @param Zend_OpenId_Provider_User $user is an object for communication
+     * @param Zend_OpenId_Provider_User|null $user is an object for communication
      *  with User-Agent and store information about logged-in user (it is a
      *  Zend_OpenId_Provider_User_Session object by default)
-     * @param Zend_OpenId_Provider_Storage $storage is an object for keeping
+     * @param Zend_OpenId_Provider_Storage|null $storage is an object for keeping
      *  persistent database (it is a Zend_OpenId_Provider_Storage_File object
      *  by default)
      * @param integer $sessionTtl is a default time to live for association
@@ -106,10 +108,13 @@ class Zend_OpenId_Provider
      */
     public function __construct($loginUrl = null,
                                 $trustUrl = null,
-                                Zend_OpenId_Provider_User $user = null,
-                                Zend_OpenId_Provider_Storage $storage = null,
+                                $user = null,
+                                $storage = null,
                                 $sessionTtl = 3600)
     {
+        Types::isNullable('user', $user, 'Zend_OpenId_Provider_User');
+        Types::isNullable('storage', $storage, 'Zend_OpenId_Provider_Storage');
+
         if ($loginUrl === null) {
             $loginUrl = Zend_OpenId::selfUrl() . '?openid.action=login';
         } else {
@@ -329,13 +334,15 @@ class Zend_OpenId_Provider
      *  or set to null, then $_GET or $_POST superglobal variable is used
      *  according to REQUEST_METHOD.
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response an optional response
+     * @param Zend_Controller_Response_Abstract|null $response an optional response
      *  object to perform HTTP or HTML form redirection
      * @return mixed
      */
     public function handle($params=null, $extensions=null,
-                           Zend_Controller_Response_Abstract $response = null)
+                           $response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         if ($params === null) {
             if ($_SERVER["REQUEST_METHOD"] == "GET") {
                 $params = $_GET;
@@ -508,12 +515,14 @@ class Zend_OpenId_Provider
      * @param array $params GET or POST request variables
      * @param bool $immediate enables or disables interaction with user
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response
+     * @param Zend_Controller_Response_Abstract|null $response
      * @return array
      */
     protected function _checkId($version, $params, $immediate, $extensions=null,
-        Zend_Controller_Response_Abstract $response = null)
+        $response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $ret = array();
 
         if ($version >= 2.0) {
@@ -638,13 +647,15 @@ class Zend_OpenId_Provider
      *
      * @param array $params GET or POST request variables
      * @param mixed $extensions extension object or array of extensions objects
-     * @param Zend_Controller_Response_Abstract $response an optional response
+     * @param Zend_Controller_Response_Abstract|null $response an optional response
      *  object to perform HTTP or HTML form redirection
      * @return bool
      */
     public function respondToConsumer($params, $extensions=null,
-                           Zend_Controller_Response_Abstract $response = null)
+                           $response = null)
     {
+        Types::isNullable('response', $response, 'Zend_Controller_Response_Abstract');
+
         $version = 1.1;
         if (isset($params['openid_ns']) &&
             $params['openid_ns'] == Zend_OpenId::NS_2_0) {

--- a/packages/zend-openid/library/Zend/OpenId/Provider/User/Session.php
+++ b/packages/zend-openid/library/Zend/OpenId/Provider/User/Session.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -46,7 +48,7 @@ class Zend_OpenId_Provider_User_Session extends Zend_OpenId_Provider_User
     /**
      * Reference to an implementation of Zend_Session_Namespace object
      *
-     * @var Zend_Session_Namespace $_session
+     * @var Zend_Session_Namespace|null $_session
      */
     private $_session = null;
 
@@ -54,10 +56,12 @@ class Zend_OpenId_Provider_User_Session extends Zend_OpenId_Provider_User
      * Creates Zend_OpenId_Provider_User_Session object with given session
      * namespace or creates new session namespace named "openid"
      *
-     * @param Zend_Session_Namespace $session
+     * @param Zend_Session_Namespace|null $session
      */
-    public function __construct(Zend_Session_Namespace $session = null)
+    public function __construct($session = null)
     {
+        Types::isNullable('session', $session, 'Zend_Session_Namespace');
+
         if ($session === null) {
             $this->_session = new Zend_Session_Namespace("openid");
         } else {

--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -264,12 +267,14 @@ class Zend_Paginator implements Countable, IteratorAggregate
      *
      * @param  mixed $data
      * @param  string $adapter
-     * @param  array $prefixPaths
+     * @param  array|null $prefixPaths
      * @return Zend_Paginator
      */
     public static function factory($data, $adapter = self::INTERNAL_ADAPTER,
-                                   array $prefixPaths = null)
+                                   $prefixPaths = null)
     {
+        Types::isNullable('prefixPaths', $prefixPaths, 'array');
+
         if ($data instanceof Zend_Paginator_AdapterAggregate) {
             return new self($data->getPaginatorAdapter());
         } else {
@@ -534,7 +539,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
         if (!$this->_cacheEnabled()) {
             return count($this->getAdapter());
         } else {
-            $cacheId   = md5($this->_getCacheInternalId(). '_itemCount');            
+            $cacheId   = md5($this->_getCacheInternalId(). '_itemCount');
             $itemCount = self::$_cache->load($cacheId);
 
             if ($itemCount === false) {
@@ -542,7 +547,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
 
                 self::$_cache->save($itemCount, $cacheId, array($this->_getCacheInternalId()));
             }
-            
+
             return $itemCount;
         }
     }
@@ -933,11 +938,13 @@ class Zend_Paginator implements Countable, IteratorAggregate
     /**
      * Sets the view object.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return Zend_Paginator
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->_view = $view;
 
         return $this;
@@ -990,11 +997,13 @@ class Zend_Paginator implements Countable, IteratorAggregate
     /**
      * Renders the paginator.
      *
-     * @param  Zend_View_Interface $view
+     * @param  Zend_View_Interface|null $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         if (null !== $view) {
             $this->setView($view);
         }
@@ -1060,7 +1069,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
     protected function _getCacheInternalId()
     {
         $adapter = $this->getAdapter();
-        
+
         if (method_exists($adapter, 'getCacheIdentifier')) {
             return md5(serialize(array(
                 $adapter->getCacheIdentifier(), $this->getItemCountPerPage()

--- a/packages/zend-pdf/library/Zend/Pdf.php
+++ b/packages/zend-pdf/library/Zend/Pdf.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -617,7 +620,7 @@ class Zend_Pdf
             }
         }
     }
-  
+
     /**
      * Load form fields
      *
@@ -1008,11 +1011,13 @@ class Zend_Pdf
     /**
      * Set open Action which is actually Zend_Pdf_Destination or Zend_Pdf_Action object
      *
-     * @param Zend_Pdf_Target $openAction
+     * @param Zend_Pdf_Target|null $openAction
      * @returns Zend_Pdf
      */
-    public function setOpenAction(Zend_Pdf_Target $openAction = null)
+    public function setOpenAction($openAction = null)
     {
+        Types::isNullable('openAction', $openAction, 'Zend_Pdf_Target');
+
         $root = $this->_trailer->Root;
         $root->touch();
 

--- a/packages/zend-pdf/library/Zend/Pdf/Action.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Action.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -113,12 +116,14 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @internal
      * @param Zend_Pdf_Element $dictionary (It's actually Dictionary or Dictionary Object or Reference to a Dictionary Object)
-     * @param SplObjectStorage $processedActions  list of already processed action dictionaries, used to avoid cyclic references
+     * @param SplObjectStorage|null $processedActions  list of already processed action dictionaries, used to avoid cyclic references
      * @return Zend_Pdf_Action
      * @throws Zend_Pdf_Exception
      */
-    public static function load(Zend_Pdf_Element $dictionary, SplObjectStorage $processedActions = null)
+    public static function load(Zend_Pdf_Element $dictionary, $processedActions = null)
     {
+        Types::isNullable('processedActions', $processedActions, 'SplObjectStorage');
+
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();
         }
@@ -254,11 +259,13 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @internal
      * @param Zend_Pdf_ElementFactory $factory   Object factory for newly created indirect objects
-     * @param SplObjectStorage $processedActions  list of already processed actions (used to prevent infinity loop caused by cyclic references)
+     * @param SplObjectStorage|null $processedActions  list of already processed actions (used to prevent infinity loop caused by cyclic references)
      * @return Zend_Pdf_Element_Object|Zend_Pdf_Element_Reference   Dictionary indirect object
      */
-    public function dumpAction(Zend_Pdf_ElementFactory_Interface $factory, SplObjectStorage $processedActions = null)
+    public function dumpAction(Zend_Pdf_ElementFactory_Interface $factory, $processedActions = null)
     {
+        Types::isNullable('processedActions', $processedActions, 'SplObjectStorage');
+
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();
         }

--- a/packages/zend-pdf/library/Zend/Pdf/Outline.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline.php
@@ -281,15 +281,15 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      * @param Zend_Pdf_ElementFactory    $factory object factory for newly created indirect objects
      * @param boolean $updateNavigation  Update navigation flag
      * @param Zend_Pdf_Element $parent   Parent outline dictionary reference
-     * @param Zend_Pdf_Element $prev     Previous outline dictionary reference
-     * @param SplObjectStorage $processedOutlines  List of already processed outlines
+     * @param Zend_Pdf_Element|null $prev     Previous outline dictionary reference
+     * @param SplObjectStorage|null $processedOutlines  List of already processed outlines
      * @return Zend_Pdf_Element
      */
     abstract public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                            $updateNavigation,
                                                           Zend_Pdf_Element $parent,
-                                                          Zend_Pdf_Element $prev = null,
-                                                          SplObjectStorage $processedOutlines = null);
+                                                          $prev = null,
+                                                          $processedOutlines = null);
 
 
     ////////////////////////////////////////////////////////////////////////

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -238,17 +241,20 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
      * @param Zend_Pdf_ElementFactory    $factory object factory for newly created indirect objects
      * @param boolean $updateNavigation  Update navigation flag
      * @param Zend_Pdf_Element $parent   Parent outline dictionary reference
-     * @param Zend_Pdf_Element $prev     Previous outline dictionary reference
-     * @param SplObjectStorage $processedOutlines  List of already processed outlines
+     * @param Zend_Pdf_Element|null $prev Previous outline dictionary reference
+     * @param SplObjectStorage|null $processedOutlines List of already processed outlines
      * @return Zend_Pdf_Element
      * @throws Zend_Pdf_Exception
      */
     public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                   $updateNavigation,
                                                  Zend_Pdf_Element $parent,
-                                                 Zend_Pdf_Element $prev = null,
-                                                 SplObjectStorage $processedOutlines = null)
+                                                 $prev = null,
+                                                 $processedOutlines = null)
     {
+        Types::isNullable('prev', $prev, 'Zend_Pdf_Element');
+        Types::isNullable('processedOutlines', $processedOutlines, 'SplObjectStorage');
+
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -308,8 +311,10 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
      * @return Zend_Pdf_Action
      * @throws Zend_Pdf_Exception
      */
-    public function __construct(Zend_Pdf_Element $dictionary, SplObjectStorage $processedDictionaries = null)
+    public function __construct(Zend_Pdf_Element $dictionary, $processedDictionaries = null)
     {
+        Types::isNullable('processedDictionaries', $processedDictionaries, 'SplObjectStorage');
+
         if ($dictionary->getType() != Zend_Pdf_Element::TYPE_DICTIONARY) {
             // require_once 'Zend/Pdf/Exception.php';
             throw new Zend_Pdf_Exception('$dictionary mast be an indirect dictionary object.');
@@ -364,17 +369,20 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
      * @param Zend_Pdf_ElementFactory    $factory object factory for newly created indirect objects
      * @param boolean $updateNavigation  Update navigation flag
      * @param Zend_Pdf_Element $parent   Parent outline dictionary reference
-     * @param Zend_Pdf_Element $prev     Previous outline dictionary reference
-     * @param SplObjectStorage $processedOutlines  List of already processed outlines
+     * @param Zend_Pdf_Element|null $prev     Previous outline dictionary reference
+     * @param SplObjectStorage|null $processedOutlines  List of already processed outlines
      * @return Zend_Pdf_Element
      * @throws Zend_Pdf_Exception
      */
     public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                   $updateNavigation,
                                                  Zend_Pdf_Element $parent,
-                                                 Zend_Pdf_Element $prev = null,
-                                                 SplObjectStorage $processedOutlines = null)
+                                                 $prev = null,
+                                                 $processedOutlines = null)
     {
+        Types::isNullable('prev', $prev, 'Zend_Pdf_Element');
+        Types::isNullable('processedOutlines', $processedOutlines, 'SplObjectStorage');
+
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/GraphicsState.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/GraphicsState.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -47,11 +50,13 @@ class Zend_Pdf_Resource_GraphicsState extends Zend_Pdf_Resource
     /**
      * Object constructor.
      *
-     * @param Zend_Pdf_Element_Object $extGStateObject
+     * @param Zend_Pdf_Element_Object|null $extGStateObject
      * @throws Zend_Pdf_Exception
      */
-    public function __construct(Zend_Pdf_Element_Object $extGStateObject = null)
+    public function __construct($extGStateObject = null)
     {
+        Types::isNullable('extGStateObject', $extGStateObject, 'Zend_Pdf_Element_Object');
+
         if ($extGStateObject == null) {
             // Create new Graphics State object
             // require_once 'Zend/Pdf/ElementFactory.php';

--- a/packages/zend-pdf/library/Zend/Pdf/Trailer/Keeper.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Trailer/Keeper.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -43,7 +46,7 @@ class Zend_Pdf_Trailer_Keeper extends Zend_Pdf_Trailer
     /**
      * Previous trailer
      *
-     * @var Zend_Pdf_Trailer
+     * @var Zend_Pdf_Trailer|null
      */
     private $_prev;
 
@@ -53,12 +56,14 @@ class Zend_Pdf_Trailer_Keeper extends Zend_Pdf_Trailer
      *
      * @param Zend_Pdf_Element_Dictionary $dict
      * @param Zend_Pdf_Element_Reference_Context $context
-     * @param Zend_Pdf_Trailer $prev
+     * @param Zend_Pdf_Trailer|null $prev
      */
     public function __construct(Zend_Pdf_Element_Dictionary $dict,
                                 Zend_Pdf_Element_Reference_Context $context,
-                                Zend_Pdf_Trailer $prev = null)
+                                $prev = null)
     {
+        Types::isNullable('prev', $prev, 'Zend_Pdf_Trailer');
+
         parent::__construct($dict);
 
         $this->_context = $context;

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -64,11 +67,13 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * Constructor
      *
      * @param  array|Zend_Config $config An array having configuration data
-     * @param  Zend_Queue The Zend_Queue object that created this class
+     * @param  Zend_Queue|null The Zend_Queue object that created this class
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         parent::__construct($options);
 
         $options = &$this->_options['driverOptions'];
@@ -227,11 +232,13 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @param  integer    $maxMessages
      * @param  integer    $timeout
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }
@@ -293,11 +300,13 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * Push an element onto the end of the queue
      *
      * @param  string     $message message to send to the queue
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue === null) {
             $queue = $this->_queue;
         }
@@ -340,13 +349,15 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
     /**
      * Returns the length of the queue
      *
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return integer
      * @throws Zend_Queue_Exception (not supported)
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count($queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception('count() is not supported in this adapter');
     }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/AdapterAbstract.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/AdapterAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -69,7 +72,7 @@ abstract class Zend_Queue_Adapter_AdapterAbstract
     /**
      * Contains the Zend_Queue that this object
      *
-     * @var Zend_Queue_Adapter_Abstract
+     * @var Zend_Queue_Adapter_Abstract|null
      */
     protected $_queue = null;
 
@@ -92,12 +95,14 @@ abstract class Zend_Queue_Adapter_AdapterAbstract
      * port           => (string) The port of the database
      *
      * @param  array|Zend_Config $config An array having configuration data
-     * @param  Zend_Queue The Zend_Queue object that created this class
+     * @param  Zend_Queue|null The Zend_Queue object that created this class
      * @return void
      * @throws Zend_Queue_Exception
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+        
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
@@ -35,10 +35,10 @@ interface Zend_Queue_Adapter_AdapterInterface
      * Constructor
      *
      * @param  array|Zend_Config $options
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null);
+    public function __construct($options, $queue = null);
 
     /**
      * Retrieve queue instance
@@ -108,7 +108,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @return integer
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null);
+    public function count($queue = null);
 
     /********************************************************************
      * Messsage management functions
@@ -121,7 +121,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      */
-    public function send($message, Zend_Queue $queue = null);
+    public function send($message, $queue = null);
 
     /**
      * Get messages in the queue
@@ -131,7 +131,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null);
+    public function receive($maxMessages = null, $timeout = null, $queue = null);
 
     /**
      * Delete a message from the queue

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -48,8 +51,10 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         parent::__construct($options, $queue);
     }
 
@@ -132,13 +137,15 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
     /**
      * Return the approximate number of messages in the queue
      *
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return integer
      * @throws Zend_Queue_Exception
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count($queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue === null) {
             $queue = $this->_queue;
         }
@@ -162,12 +169,14 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * Send a message to the queue
      *
      * @param  string     $message Message to send to the active queue
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue === null) {
             $queue = $this->_queue;
         }
@@ -212,11 +221,13 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @param  integer    $maxMessages  Maximum number of messages to return
      * @param  integer    $timeout      Visibility timeout for these messages
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -78,8 +81,10 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+        
         parent::__construct($options, $queue);
 
         if (!isset($this->_options['options'][Zend_Db_Select::FOR_UPDATE])) {
@@ -284,13 +289,15 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
     /**
      * Return the approximate number of messages in the queue
      *
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return integer
      * @throws Zend_Queue_Exception
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null)
+    public function count($queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue === null) {
             $queue = $this->_queue;
         }
@@ -313,12 +320,14 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * Send a message to the queue
      *
      * @param  string     $message Message to send to the active queue
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception - database error
      */
-    public function send($message, Zend_Queue $queue = null)
+    public function send($message, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($this->_messageRow === null) {
             $this->_messageRow = $this->_messageTable->createRow();
         }
@@ -371,12 +380,14 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @param  integer    $maxMessages  Maximum number of messages to return
      * @param  integer    $timeout      Visibility timeout for these messages
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      * @throws Zend_Queue_Exception - database error
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -68,11 +71,13 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * Constructor
      *
      * @param  array|Zend_Config $options
-     * @param  null|Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if (!extension_loaded('memcache')) {
             // require_once 'Zend/Queue/Exception.php';
             throw new Zend_Queue_Exception('Memcache extension does not appear to be loaded');
@@ -227,13 +232,15 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
     /**
      * Return the approximate number of messages in the queue
      *
-     * @param  Zend_Queue $queue
+     * @param  null|Zend_Queue $queue
      * @return integer
      * @throws Zend_Queue_Exception (not supported)
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count($queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception('count() is not supported in this adapter');
     }
@@ -246,12 +253,14 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * Send a message to the queue
      *
      * @param  string     $message Message to send to the active queue
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue === null) {
             $queue = $this->_queue;
         }
@@ -293,12 +302,14 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @param  integer    $maxMessages  Maximum number of messages to return
      * @param  integer    $timeout      Visibility timeout for these messages
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      * @throws Zend_Queue_Exception
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -40,11 +43,13 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      * Constructor
      *
      * @param  array|Zend_Config $options
-     * @param  null|Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         parent::__construct($options, $queue);
     }
 
@@ -103,8 +108,10 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception - not supported.
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count($queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));
     }
@@ -118,8 +125,10 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @throws Zend_Queue_Exception - not supported.
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));
     }
@@ -129,8 +138,10 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @throws Zend_Queue_Exception - not supported.
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));
     }

--- a/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -48,8 +51,10 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         parent::__construct($options, $queue);
 
         if (!extension_loaded("jobqueue_client")) {
@@ -152,8 +157,10 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @return integer
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null)
+    public function count($queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue !== null) {
             // require_once 'Zend/Queue/Exception.php';
             throw new Zend_Queue_Exception('Queue parameter is not supported');
@@ -170,12 +177,14 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * Send a message to the queue
      *
      * @param  array | ZendAPI_job $message Message to send to the active queue
-     * @param  Zend_Queue $queue     Not supported
+     * @param  Zend_Queue|null $queue     Not supported
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue = null)
+    public function send($message, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($queue !== null) {
             // require_once 'Zend/Queue/Exception.php';
             throw new Zend_Queue_Exception('Queue parameter is not supported');
@@ -214,12 +223,14 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      *
      * @param  integer    $maxMessages  Maximum number of messages to return
      * @param  integer    $timeout      Ignored
-     * @param  Zend_Queue $queue        Not supported
+     * @param  Zend_Queue $queue|null   Not supported
      * @throws Zend_Queue_Exception
      * @return ArrayIterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, $queue = null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }

--- a/packages/zend-rest/library/Zend/Rest/Client.php
+++ b/packages/zend-rest/library/Zend/Rest/Client.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -50,7 +53,7 @@ class Zend_Rest_Client extends Zend_Service_Abstract
      * @var Zend_Uri_Http
      */
     protected $_uri = null;
-    
+
     /**
      * Flag indicating the Zend_Http_Client is fresh and needs no reset.
      * Must be set explicitly if you want to keep preset parameters.
@@ -126,18 +129,18 @@ class Zend_Rest_Client extends Zend_Service_Abstract
          * because the Zend_Http_Client instance is shared among all Zend_Service_Abstract subclasses.
          */
         if ($this->_noReset) {
-            // if $_noReset we do not want to reset on this request, 
+            // if $_noReset we do not want to reset on this request,
             // but we do on any subsequent request
             $this->_noReset = false;
         } else {
             self::getHttpClient()->resetParameters();
         }
-        
+
         self::getHttpClient()->setUri($this->_uri);
     }
-    
+
     /**
-     * Tells Zend_Rest_Client not to reset all parameters on it's 
+     * Tells Zend_Rest_Client not to reset all parameters on it's
      * Zend_Http_Client. If you want no reset, this must be called explicitly
      * before every request for which you do not want to reset the parameters.
      * Parameters will accumulate between requests, but as soon as you do not
@@ -154,12 +157,14 @@ class Zend_Rest_Client extends Zend_Service_Abstract
      * Performs an HTTP GET request to the $path.
      *
      * @param string $path
-     * @param array  $query Array of GET parameters
+     * @param array|null  $query Array of GET parameters
      * @throws Zend_Http_Client_Exception
      * @return Zend_Http_Response
      */
-    public function restGet($path, array $query = null)
+    public function restGet($path, $query = null)
     {
+        Types::isNullable('query', $query, 'array');
+
         $this->_prepareRest($path);
         $client = self::getHttpClient();
         $client->setParameterGet($query);

--- a/packages/zend-rest/library/Zend/Rest/Client/Result.php
+++ b/packages/zend-rest/library/Zend/Rest/Client/Result.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -50,7 +53,7 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
     public function __construct($data)
     {
         set_error_handler(array($this, 'handleXmlErrors'));
-        $this->_sxml = Zend_Xml_Security::scan($data); 
+        $this->_sxml = Zend_Xml_Security::scan($data);
         restore_error_handler();
         if($this->_sxml === false) {
             if ($this->_errstr === null) {
@@ -71,11 +74,13 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
      * @param string $errstr
      * @param string $errfile
      * @param string $errline
-     * @param array  $errcontext
+     * @param array|null $errcontext
      * @return true
      */
-    public function handleXmlErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handleXmlErrors($errno, $errstr, $errfile = null, $errline = null, $errcontext = null)
     {
+        Types::isNullable('errcontext', $errcontext, 'array');
+
         $this->_errstr = $errstr;
         return true;
     }
@@ -184,7 +189,7 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
     {
         $status = $this->_sxml->xpath('//status/text()');
         if ( !isset($status[0]) ) return false;
-        
+
         $status = strtolower($status[0]);
 
         if (ctype_alpha($status) && $status == 'success') {

--- a/packages/zend-server/library/Zend/Server/Reflection/Node.php
+++ b/packages/zend-server/library/Zend/Server/Reflection/Node.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -52,11 +55,13 @@ class Zend_Server_Reflection_Node
      * Constructor
      *
      * @param mixed $value
-     * @param Zend_Server_Reflection_Node $parent Optional
+     * @param Zend_Server_Reflection_Node|null $parent Optional
      * @return Zend_Server_Reflection_Node
      */
-    public function __construct($value, Zend_Server_Reflection_Node $parent = null)
+    public function __construct($value, $parent = null)
     {
+        Types::isNullable('parent', $parent, 'Zend_Server_Reflection_Node');
+
         $this->_value = $value;
         if (null !== $parent) {
             $this->setParent($parent, true);

--- a/packages/zend-service-delicious/library/Zend/Service/Delicious.php
+++ b/packages/zend-service-delicious/library/Zend/Service/Delicious.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -282,13 +284,15 @@ class Zend_Service_Delicious
      * If no date or url is given, most recent date will be used
      *
      * @param  string    $tag Optional filtering by tag
-     * @param  Zend_Date $dt  Optional filtering by date
+     * @param  Zend_Date|null $dt  Optional filtering by date
      * @param  string    $url Optional filtering by url
      * @throws Zend_Service_Delicious_Exception
      * @return Zend_Service_Delicious_PostList
      */
-    public function getPosts($tag = null, Zend_Date $dt = null, $url = null)
+    public function getPosts($tag = null, $dt = null, $url = null)
     {
+        Types::isNullable('dt', $dt, 'Zend_Date');
+
         $parms = array();
         if ($tag) {
             $parms['tag'] = $tag;
@@ -508,7 +512,7 @@ class Zend_Service_Delicious
         switch ($type) {
             case 'xml':
                 $dom = new DOMDocument() ;
-    
+
                 if (!$dom = @Zend_Xml_Security::scan($responseBody, $dom)) {
                     /**
                      * @see Zend_Service_Delicious_Exception

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -323,12 +326,14 @@ class Zend_Service_Ebay_Finding extends Zend_Service_Ebay_Abstract
 
     /**
      * @param  string $operation
-     * @param  array  $options
+     * @param  array|null $options
      * @link   http://developer.ebay.com/DevZone/finding/Concepts/MakingACall.html#StandardURLParameters
      * @return DOMDocument
      */
-    protected function _request($operation, array $options = null)
+    protected function _request($operation, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         // generate default options
         // constructor load global-id and application-id values
         $default = array('OPERATION-NAME'       => $operation,

--- a/packages/zend-service-flickr/library/Zend/Service/Flickr.php
+++ b/packages/zend-service-flickr/library/Zend/Service/Flickr.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -140,12 +142,14 @@ class Zend_Service_Flickr
      *  # max_taken_date:  Maximum upload date to search on.  Date should be a MySQL datetime.
      *
      * @param  string $query   username or email
-     * @param  array  $options Additional parameters to refine your query.
+     * @param  array|null $options Additional parameters to refine your query.
      * @return Zend_Service_Flickr_ResultSet
      * @throws Zend_Service_Exception
      */
-    public function userSearch($query, array $options = null)
+    public function userSearch($query, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         static $method = 'flickr.people.getPublicPhotos';
         static $defaultOptions = array('per_page' => 10,
                                        'page'     => 1,

--- a/packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha/Response.php
+++ b/packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha/Response.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -55,10 +58,12 @@ class Zend_Service_ReCaptcha_Response
      *
      * @param string $status
      * @param string $errorCode
-     * @param Zend_Http_Response $httpResponse If this is set the content will override $status and $errorCode
+     * @param Zend_Http_Response|null $httpResponse If this is set the content will override $status and $errorCode
      */
-    public function __construct($status = null, $errorCode = null, Zend_Http_Response $httpResponse = null)
+    public function __construct($status = null, $errorCode = null, $httpResponse = null)
     {
+        Types::isNullable('httpResponse', $httpResponse, 'Zend_Http_Response');
+
         if ($status !== null) {
             $this->setStatus($status);
         }

--- a/packages/zend-service-twitter/library/Zend/Service/Twitter.php
+++ b/packages/zend-service-twitter/library/Zend/Service/Twitter.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -143,8 +146,11 @@ class Zend_Service_Twitter
      * @param  null|Zend_Oauth_Consumer $consumer
      * @param  null|Zend_Http_Client $httpClient
      */
-    public function __construct($options = null, Zend_Oauth_Consumer $consumer = null, Zend_Http_Client $httpClient = null)
+    public function __construct($options = null, $consumer = null, $httpClient = null)
     {
+        Types::isNullable('consumer', $consumer, 'Zend_Oauth_Consumer');
+        Types::isNullable('httpClient', $httpClient, 'Zend_Http_Client');
+
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();
         }

--- a/packages/zend-service-windowsazure/library/Zend/Service/SqlAzure/Management/Client.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/SqlAzure/Management/Client.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -24,17 +27,17 @@
  * @see Zend_Http_Client
  */
  // require_once 'Zend/Http/Client.php';
- 
+
  /**
  * @see Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract
  */
  // require_once 'Zend/Service/WindowsAzure/RetryPolicy/RetryPolicyAbstract.php';
- 
+
  /**
  * @see Zend_Service_SqlAzure_Management_ServerInstance
  */
  // require_once 'Zend/Service/SqlAzure/Management/ServerInstance.php';
- 
+
  /**
  * @see Zend_Service_SqlAzure_Management_FirewallRuleInstance
  */
@@ -56,7 +59,7 @@ class Zend_Service_SqlAzure_Management_Client
 	 * Management service URL
 	 */
 	const URL_MANAGEMENT        = "https://management.database.windows.net:8443";
-	
+
 	/**
 	 * Operations
 	 */
@@ -66,76 +69,78 @@ class Zend_Service_SqlAzure_Management_Client
 
 	/**
 	 * Current API version
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_apiVersion = '1.0';
-	
+
 	/**
 	 * Subscription ID
 	 *
 	 * @var string
 	 */
 	protected $_subscriptionId = '';
-	
+
 	/**
 	 * Management certificate path (.PEM)
 	 *
 	 * @var string
 	 */
 	protected $_certificatePath = '';
-	
+
 	/**
 	 * Management certificate passphrase
 	 *
 	 * @var string
 	 */
 	protected $_certificatePassphrase = '';
-	
+
 	/**
 	 * Zend_Http_Client channel used for communication with REST services
-	 * 
+	 *
 	 * @var Zend_Http_Client
 	 */
-	protected $_httpClientChannel = null;	
+	protected $_httpClientChannel = null;
 
 	/**
 	 * Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract instance
-	 * 
+	 *
 	 * @var Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract
 	 */
 	protected $_retryPolicy = null;
-	
+
 	/**
 	 * Returns the last request ID
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_lastRequestId = null;
-	
+
 	/**
 	 * Creates a new Zend_Service_SqlAzure_Management instance
-	 * 
+	 *
 	 * @param string $subscriptionId Subscription ID
 	 * @param string $certificatePath Management certificate path (.PEM)
 	 * @param string $certificatePassphrase Management certificate passphrase
-     * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+     * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 */
 	public function __construct(
 		$subscriptionId,
 		$certificatePath,
 		$certificatePassphrase,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		$retryPolicy = null
 	) {
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		$this->_subscriptionId = $subscriptionId;
 		$this->_certificatePath = $certificatePath;
 		$this->_certificatePassphrase = $certificatePassphrase;
-		
+
 		$this->_retryPolicy = $retryPolicy;
 		if (is_null($this->_retryPolicy)) {
 		    $this->_retryPolicy = Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract::noRetry();
 		}
-		
+
 		// Setup default Zend_Http_Client channel
 		$options = array(
 		    'adapter'       => 'Zend_Http_Client_Adapter_Socket',
@@ -153,47 +158,47 @@ class Zend_Service_SqlAzure_Management_Client
 		}
 		$this->_httpClientChannel = new Zend_Http_Client(null, $options);
 	}
-	
+
 	/**
 	 * Set the HTTP client channel to use
-	 * 
+	 *
 	 * @param Zend_Http_Client_Adapter_Interface|string $adapterInstance Adapter instance or adapter class name.
 	 */
 	public function setHttpClientChannel($adapterInstance = 'Zend_Http_Client_Adapter_Socket')
 	{
 		$this->_httpClientChannel->setAdapter($adapterInstance);
 	}
-	
+
     /**
      * Retrieve HTTP client channel
-     * 
+     *
      * @return Zend_Http_Client_Adapter_Interface
      */
     public function getHttpClientChannel()
     {
         return $this->_httpClientChannel;
     }
-	
+
 	/**
 	 * Returns the Windows Azure subscription ID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSubscriptionId()
 	{
 		return $this->_subscriptionId;
 	}
-	
+
 	/**
 	 * Returns the last request ID.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getLastRequestId()
 	{
 		return $this->_lastRequestId;
 	}
-	
+
 	/**
 	 * Get base URL for creating requests
 	 *
@@ -203,7 +208,7 @@ class Zend_Service_SqlAzure_Management_Client
 	{
 		return self::URL_MANAGEMENT . '/' . $this->_subscriptionId;
 	}
-	
+
 	/**
 	 * Perform request using Zend_Http_Client channel
 	 *
@@ -225,12 +230,12 @@ class Zend_Service_SqlAzure_Management_Client
 		if (strpos($path, '/') !== 0) {
 			$path = '/' . $path;
 		}
-			
+
 		// Clean headers
 		if (is_null($headers)) {
 		    $headers = array();
 		}
-		
+
 		// Ensure cUrl will also work correctly:
 		//  - disable Content-Type if required
 		//  - disable Expect: 100 Continue
@@ -241,7 +246,7 @@ class Zend_Service_SqlAzure_Management_Client
 
 		// Add version header
 		$headers['x-ms-version'] = $this->_apiVersion;
-		    
+
 		// URL encoding
 		$path           = self::urlencode($path);
 		$queryString    = self::urlencode($queryString);
@@ -250,7 +255,7 @@ class Zend_Service_SqlAzure_Management_Client
 		$requestUrl     = $this->getBaseUrl() . $path . $queryString;
 		$requestHeaders = $headers;
 
-		// Prepare request 
+		// Prepare request
 		$this->_httpClientChannel->resetParameters(true);
 		$this->_httpClientChannel->setUri($requestUrl);
 		$this->_httpClientChannel->setHeaders($requestHeaders);
@@ -261,47 +266,49 @@ class Zend_Service_SqlAzure_Management_Client
 		    array($this->_httpClientChannel, 'request'),
 		    array($httpVerb)
 		);
-		
+
 		// Store request id
 		$this->_lastRequestId = $response->getHeader('x-ms-request-id');
-		
+
 		return $response;
 	}
-	
-	/** 
+
+	/**
 	 * Parse result from Zend_Http_Response
 	 *
-	 * @param Zend_Http_Response $response Response from HTTP call
+	 * @param Zend_Http_Response|null $response Response from HTTP call
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse($response = null)
 	{
+        Types::isNullable('response', $response, 'Zend_Http_Response');
+
 		if (is_null($response)) {
 			// require_once 'Zend/Service/SqlAzure/Exception.php';
 			throw new Zend_Service_SqlAzure_Exception('Response should not be null.');
 		}
-		
+
         $xml = @Zend_Xml_Security::scan($response->getBody());
-        
+
         if ($xml !== false) {
-            // Fetch all namespaces 
-            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true)); 
-            
+            // Fetch all namespaces
+            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true));
+
             // Register all namespace prefixes
-            foreach ($namespaces as $prefix => $ns) { 
+            foreach ($namespaces as $prefix => $ns) {
                 if ($prefix != '') {
                     $xml->registerXPathNamespace($prefix, $ns);
-                } 
-            } 
+                }
+            }
         }
-        
+
         return $xml;
 	}
-	
+
 	/**
 	 * URL encode function
-	 * 
+	 *
 	 * @param  string $value Value to encode
 	 * @return string        Encoded value
 	 */
@@ -309,10 +316,10 @@ class Zend_Service_SqlAzure_Management_Client
 	{
 	    return str_replace(' ', '%20', $value);
 	}
-	
+
     /**
      * Builds a query string from an array of elements
-     * 
+     *
      * @param array     Array of elements
      * @return string   Assembled query string
      */
@@ -320,7 +327,7 @@ class Zend_Service_SqlAzure_Management_Client
     {
     	return count($queryString) > 0 ? '?' . implode('&', $queryString) : '';
     }
-    
+
 	/**
 	 * Get error message from Zend_Http_Response
 	 *
@@ -337,10 +344,10 @@ class Zend_Service_SqlAzure_Management_Client
 			return $alternativeError;
 		}
 	}
-	
+
 	/**
 	 * The Create Server operation adds a new SQL Azure server to a subscription.
-	 * 
+	 *
 	 * @param string $administratorLogin Administrator login.
 	 * @param string $administratorPassword Administrator password.
 	 * @param string $location Location of the server.
@@ -361,15 +368,15 @@ class Zend_Service_SqlAzure_Management_Client
                     // require_once 'Zend/Service/SqlAzure/Management/Exception.php';
                     throw new Zend_Service_SqlAzure_Management_Exception('Please specify a location for the server.');
                 }
-    	
+
                 $response = $this->_performRequest(self::OP_SERVERS, '',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<Server xmlns="http://schemas.microsoft.com/sqlazure/2010/12/"><AdministratorLogin>' . $administratorLogin . '</AdministratorLogin><AdministratorLoginPassword>' . $administratorPassword . '</AdministratorLoginPassword><Location>' . $location . '</Location></Server>');
- 	
+
                 if ($response->isSuccessful()) {
 			$xml = $this->_parseResponse($response);
-			
+
 			return new Zend_Service_SqlAzure_Management_ServerInstance(
 				(string)$xml,
 				$administratorLogin,
@@ -378,23 +385,23 @@ class Zend_Service_SqlAzure_Management_Client
                 } else {
 			// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
 			throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-		}	
+		}
 	}
-	
+
 	/**
 	 * The Get Servers operation enumerates SQL Azure servers that are provisioned for a subscription.
-	 * 
+	 *
 	 * @return array An array of Zend_Service_SqlAzure_Management_ServerInstance.
 	 * @throws Zend_Service_SqlAzure_Management_Exception
 	 */
 	public function listServers()
 	{
             $response = $this->_performRequest(self::OP_SERVERS);
- 	
+
             if ($response->isSuccessful()) {
 		$xml = $this->_parseResponse($response);
 		$xmlServices = null;
-			
+
                 if (!$xml->Server) {
                     return array();
 		}
@@ -403,10 +410,10 @@ class Zend_Service_SqlAzure_Management_Client
     		} else {
     		    $xmlServices = array($xml->Server);
     		}
-    		
+
 		$services = array();
-		if (!is_null($xmlServices)) {				
-				
+		if (!is_null($xmlServices)) {
+
                     for ($i = 0; $i < count($xmlServices); $i++) {
                         $services[] = new Zend_Service_SqlAzure_Management_ServerInstance(
                                 	    (string)$xmlServices[$i]->Name,
@@ -421,10 +428,10 @@ class Zend_Service_SqlAzure_Management_Client
 		throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
             }
 	}
-	
+
 	/**
 	 * The Drop Server operation drops a SQL Azure server from a subscription.
-	 * 
+	 *
 	 * @param string $serverName Server to drop.
 	 * @throws Zend_Service_SqlAzure_Management_Exception
 	 */
@@ -434,18 +441,18 @@ class Zend_Service_SqlAzure_Management_Client
                 // require_once 'Zend/Service/SqlAzure/Management/Exception.php';
                 throw new Zend_Service_SqlAzure_Management_Exception('Server name should be specified.');
             }
-    	
+
             $response = $this->_performRequest(self::OP_SERVERS . '/' . $serverName, '', Zend_Http_Client::DELETE);
 
             if (!$response->isSuccessful()) {
 		// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
 		throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-            }	
+            }
 	}
-	
+
 	/**
 	 * The Set Server Administrator Password operation sets the administrative password of a SQL Azure server for a subscription.
-	 * 
+	 *
 	 * @param string $serverName Server to set password for.
 	 * @param string $administratorPassword Administrator password.
 	 * @throws Zend_Service_SqlAzure_Management_Exception
@@ -460,21 +467,21 @@ class Zend_Service_SqlAzure_Management_Client
                 // require_once 'Zend/Service/SqlAzure/Management/Exception.php';
     		throw new Zend_Service_SqlAzure_Management_Exception('Administrator password should be specified.');
             }
-    	
+
             $response = $this->_performRequest(self::OP_SERVERS . '/' . $serverName, '?op=ResetPassword',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<AdministratorLoginPassword xmlns="http://schemas.microsoft.com/sqlazure/2010/12/">' . $administratorPassword . '</AdministratorLoginPassword>');
-    		
+
             if (!$response->isSuccessful()) {
 		// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
 		throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-            }	
+            }
 	}
-	
+
 	/**
 	 * The Set Server Firewall Rule operation updates an existing firewall rule or adds a new firewall rule for a SQL Azure server that belongs to a subscription.
-	 * 
+	 *
 	 * @param string $serverName Server name.
 	 * @param string $ruleName Firewall rule name.
 	 * @param string $startIpAddress Start IP address.
@@ -500,14 +507,14 @@ class Zend_Service_SqlAzure_Management_Client
                 // require_once 'Zend/Service/SqlAzure/Management/Exception.php';
                 throw new Zend_Service_SqlAzure_Management_Exception('End IP address should be specified.');
             }
-    	
+
             $response = $this->_performRequest(self::OP_SERVERS . '/' . $serverName . '/' . self::OP_FIREWALLRULES . '/' . $ruleName, '',
     		Zend_Http_Client::PUT,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<FirewallRule xmlns="http://schemas.microsoft.com/sqlazure/2010/12/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.microsoft.com/sqlazure/2010/12/ FirewallRule.xsd"><StartIpAddress>' . $startIpAddress . '</StartIpAddress><EndIpAddress>' . $endIpAddress . '</EndIpAddress></FirewallRule>');
 
             if ($response->isSuccessful()) {
-		
+
     		return new Zend_Service_SqlAzure_Management_FirewallRuleInstance(
     			$ruleName,
     			$startIpAddress,
@@ -518,10 +525,10 @@ class Zend_Service_SqlAzure_Management_Client
 		throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
             }
 	}
-	
+
 	/**
 	 * The Get Server Firewall Rules operation retrieves a list of all the firewall rules for a SQL Azure server that belongs to a subscription.
-	 * 
+	 *
 	 * @param string $serverName Server name.
 	 * @return Array of Zend_Service_SqlAzure_Management_FirewallRuleInstance.
 	 * @throws Zend_Service_SqlAzure_Management_Exception
@@ -532,13 +539,13 @@ class Zend_Service_SqlAzure_Management_Client
 		// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
                 throw new Zend_Service_SqlAzure_Management_Exception('Server name should be specified.');
             }
-    	
+
 	    $response = $this->_performRequest(self::OP_SERVERS . '/' . $serverName . '/' . self::OP_FIREWALLRULES);
- 	
+
             if ($response->isSuccessful()) {
 		$xml = $this->_parseResponse($response);
 		$xmlServices = null;
-			
+
     		if (!$xml->FirewallRule) {
                     return array();
 		}
@@ -547,10 +554,10 @@ class Zend_Service_SqlAzure_Management_Client
     		} else {
     		    $xmlServices = array($xml->FirewallRule);
     		}
-    		
+
 		$services = array();
-		if (!is_null($xmlServices)) {				
-                    
+		if (!is_null($xmlServices)) {
+
                     for ($i = 0; $i < count($xmlServices); $i++) {
                         $services[] = new Zend_Service_SqlAzure_Management_FirewallRuleInstance(
 					    (string)$xmlServices[$i]->Name,
@@ -563,12 +570,12 @@ class Zend_Service_SqlAzure_Management_Client
             } else {
 		// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
 		throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-            }		
+            }
 	}
-	
+
 	/**
 	 * The Delete Server Firewall Rule operation deletes a firewall rule from a SQL Azure server that belongs to a subscription.
-	 * 
+	 *
 	 * @param string $serverName Server name.
 	 * @param string $ruleName Rule name.
 	 * @throws Zend_Service_SqlAzure_Management_Exception
@@ -583,7 +590,7 @@ class Zend_Service_SqlAzure_Management_Client
 			// require_once 'Zend/Service/SqlAzure/Management/Exception.php';
     		throw new Zend_Service_SqlAzure_Management_Exception('Rule name should be specified.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_SERVERS . '/' . $serverName . '/' . self::OP_FIREWALLRULES . '/' . $ruleName, '',
     		Zend_Http_Client::DELETE);
 
@@ -592,10 +599,10 @@ class Zend_Service_SqlAzure_Management_Client
 			throw new Zend_Service_SqlAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Creates a firewall rule for Microsoft Services. This is required if access to SQL Azure is required from other services like Windows Azure.
-	 * 
+	 *
 	 * @param string $serverName Server name.
 	 * @param boolean $allowAccess Allow access from other Microsoft Services?
 	 * @throws Zend_Service_SqlAzure_Management_Exception
@@ -608,5 +615,5 @@ class Zend_Service_SqlAzure_Management_Client
 			$this->deleteFirewallRule($serverName, 'MicrosoftServices');
 		}
 	}
-	
+
 }

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -36,26 +39,28 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 {
 	/**
 	 * Blob storage client
-	 * 
+	 *
 	 * @var Zend_Service_WindowsAzure_Storage_Blob
 	 */
 	protected $_blobStorageClient = null;
-	
+
 	/**
 	 * Control container name
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_controlContainer = '';
 
 	/**
 	 * Create a new instance of Zend_Service_WindowsAzure_Diagnostics_Manager
-	 * 
-	 * @param Zend_Service_WindowsAzure_Storage_Blob $blobStorageClient Blob storage client
+	 *
+	 * @param Zend_Service_WindowsAzure_Storage_Blob|null $blobStorageClient Blob storage client
 	 * @param string $controlContainer Control container name
 	 */
-	public function __construct(Zend_Service_WindowsAzure_Storage_Blob $blobStorageClient = null, $controlContainer = 'wad-control-container')
+	public function __construct($blobStorageClient = null, $controlContainer = 'wad-control-container')
 	{
+	    Types::isNullable('blobStorageClient', $blobStorageClient, 'Zend_Service_WindowsAzure_Storage_Blob');
+
 		$this->_blobStorageClient = $blobStorageClient;
 		$this->_controlContainer = $controlContainer;
 
@@ -71,20 +76,20 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 			$this->_blobStorageClient->createContainer($this->_controlContainer);
 		}
 	}
-	
+
 	/**
 	 * Get default configuration values
-	 * 
+	 *
 	 * @return Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance
 	 */
 	public function getDefaultConfiguration()
 	{
 		return new Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance();
 	}
-	
+
 	/**
 	 * Checks if a configuration for a specific role instance exists.
-	 * 
+	 *
 	 * @param string $roleInstance Role instance name, can be found in $_SERVER['RdRoleId'] when hosted on Windows Azure.
 	 * @return boolean
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
@@ -98,10 +103,10 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 
 		return $this->_blobStorageClient->blobExists($this->_controlContainer, $roleInstance);
 	}
-	
+
 	/**
 	 * Checks if a configuration for current role instance exists. Only works on Development Fabric or Windows Azure Fabric.
-	 * 
+	 *
 	 * @return boolean
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
@@ -114,10 +119,10 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 
 		return $this->_blobStorageClient->blobExists($this->_controlContainer, $this->_getCurrentRoleInstanceId());
 	}
-	
+
 	/**
 	 * Get configuration for current role instance. Only works on Development Fabric or Windows Azure Fabric.
-	 * 
+	 *
 	 * @return Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
@@ -129,10 +134,10 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 		}
 		return $this->getConfigurationForRoleInstance($this->_getCurrentRoleInstanceId());
 	}
-	
+
 	/**
 	 * Get the current role instance ID. Only works on Development Fabric or Windows Azure Fabric.
-	 * 
+	 *
 	 * @return string
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
@@ -142,7 +147,7 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 			// require_once 'Zend/Service/WindowsAzure/Diagnostics/Exception.php';
 			throw new Zend_Service_WindowsAzure_Diagnostics_Exception('Server variable \'RdRoleId\' is unknown. Please verify the application is running in Development Fabric or Windows Azure Fabric.');
 		}
-		
+
 		if (strpos($_SERVER['RdRoleId'], 'deployment(') === false) {
 			return $_SERVER['RdRoleId'];
 		} else {
@@ -153,17 +158,17 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 		if (!isset($_SERVER['RoleDeploymentID']) && !isset($_SERVER['RoleInstanceID']) && !isset($_SERVER['RoleName'])) {
 			throw new Exception('Server variables \'RoleDeploymentID\', \'RoleInstanceID\' and \'RoleName\' are unknown. Please verify the application is running in Development Fabric or Windows Azure Fabric.');
 		}
-		
+
 		if (strpos($_SERVER['RdRoleId'], 'deployment(') === false) {
 			return $_SERVER['RdRoleId'];
 		} else {
 			return $_SERVER['RoleDeploymentID'] . '/' . $_SERVER['RoleInstanceID'] . '/' . $_SERVER['RoleName'];
 		}
 	}
-	
+
 	/**
 	 * Set configuration for current role instance. Only works on Development Fabric or Windows Azure Fabric.
-	 * 
+	 *
 	 * @param Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration Configuration to apply
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
@@ -173,13 +178,13 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 			// require_once 'Zend/Service/WindowsAzure/Diagnostics/Exception.php';
 			throw new Zend_Service_WindowsAzure_Diagnostics_Exception('Server variable \'RdRoleId\' is unknown. Please verify the application is running in Development Fabric or Windows Azure Fabric.');
 		}
-		
+
 		$this->setConfigurationForRoleInstance($this->_getCurrentRoleInstanceId(), $configuration);
 	}
-	
+
 	/**
 	 * Get configuration for a specific role instance
-	 * 
+	 *
 	 * @param string $roleInstance Role instance name, can be found in $_SERVER['RdRoleId'] when hosted on Windows Azure.
 	 * @return Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
@@ -191,8 +196,8 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 			throw new Zend_Service_WindowsAzure_Diagnostics_Exception('Role instance should be specified. Try reading $_SERVER[\'RdRoleId\'] for this information if the application is hosted on Windows Azure Fabric or Development Fabric.');
 		}
 
-		
-		
+
+
 		if ($this->_blobStorageClient->blobExists($this->_controlContainer, $roleInstance)) {
 			$configurationInstance = new Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance();
 			$configurationInstance->loadXml( $this->_blobStorageClient->getBlobData($this->_controlContainer, $roleInstance) );
@@ -201,10 +206,10 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 
 		return new Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance();
 	}
-	
+
 	/**
 	 * Set configuration for a specific role instance
-	 * 
+	 *
 	 * @param string $roleInstance Role instance name, can be found in $_SERVER['RdRoleId'] when hosted on Windows Azure.
 	 * @param Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration Configuration to apply
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -91,7 +94,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	 * Management service URL
 	 */
 	const URL_MANAGEMENT        = "https://management.core.windows.net";
-	
+
 	/**
 	 * Operations
 	 */
@@ -105,76 +108,78 @@ class Zend_Service_WindowsAzure_Management_Client
 
 	/**
 	 * Current API version
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_apiVersion = '2011-02-25';
-	
+
 	/**
 	 * Subscription ID
 	 *
 	 * @var string
 	 */
 	protected $_subscriptionId = '';
-	
+
 	/**
 	 * Management certificate path (.PEM)
 	 *
 	 * @var string
 	 */
 	protected $_certificatePath = '';
-	
+
 	/**
 	 * Management certificate passphrase
 	 *
 	 * @var string
 	 */
 	protected $_certificatePassphrase = '';
-	
+
 	/**
 	 * Zend_Http_Client channel used for communication with REST services
-	 * 
+	 *
 	 * @var Zend_Http_Client
 	 */
-	protected $_httpClientChannel = null;	
+	protected $_httpClientChannel = null;
 
 	/**
 	 * Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract instance
-	 * 
+	 *
 	 * @var Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract
 	 */
 	protected $_retryPolicy = null;
-	
+
 	/**
 	 * Returns the last request ID
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_lastRequestId = null;
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Management instance
-	 * 
+	 *
 	 * @param string $subscriptionId Subscription ID
 	 * @param string $certificatePath Management certificate path (.PEM)
 	 * @param string $certificatePassphrase Management certificate passphrase
-     * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+     * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 */
 	public function __construct(
 		$subscriptionId,
 		$certificatePath,
 		$certificatePassphrase,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		$retryPolicy = null
 	) {
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		$this->_subscriptionId = $subscriptionId;
 		$this->_certificatePath = $certificatePath;
 		$this->_certificatePassphrase = $certificatePassphrase;
-		
+
 		$this->_retryPolicy = $retryPolicy;
 		if (is_null($this->_retryPolicy)) {
 		    $this->_retryPolicy = Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract::noRetry();
 		}
-		
+
 		// Setup default Zend_Http_Client channel
 		$options = array(
 		    'adapter'       => 'Zend_Http_Client_Adapter_Socket',
@@ -192,47 +197,47 @@ class Zend_Service_WindowsAzure_Management_Client
 		}
 		$this->_httpClientChannel = new Zend_Http_Client(null, $options);
 	}
-	
+
 	/**
 	 * Set the HTTP client channel to use
-	 * 
+	 *
 	 * @param Zend_Http_Client_Adapter_Interface|string $adapterInstance Adapter instance or adapter class name.
 	 */
 	public function setHttpClientChannel($adapterInstance = 'Zend_Http_Client_Adapter_Socket')
 	{
 		$this->_httpClientChannel->setAdapter($adapterInstance);
 	}
-	
+
     /**
      * Retrieve HTTP client channel
-     * 
+     *
      * @return Zend_Http_Client_Adapter_Interface
      */
     public function getHttpClientChannel()
     {
         return $this->_httpClientChannel;
     }
-	
+
 	/**
 	 * Returns the Windows Azure subscription ID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSubscriptionId()
 	{
 		return $this->_subscriptionId;
 	}
-	
+
 	/**
 	 * Returns the last request ID.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getLastRequestId()
 	{
 		return $this->_lastRequestId;
 	}
-	
+
 	/**
 	 * Get base URL for creating requests
 	 *
@@ -242,7 +247,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	{
 		return self::URL_MANAGEMENT . '/' . $this->_subscriptionId;
 	}
-	
+
 	/**
 	 * Perform request using Zend_Http_Client channel
 	 *
@@ -264,12 +269,12 @@ class Zend_Service_WindowsAzure_Management_Client
 		if (strpos($path, '/') !== 0) {
 			$path = '/' . $path;
 		}
-			
+
 		// Clean headers
 		if (is_null($headers)) {
 		    $headers = array();
 		}
-		
+
 		// Ensure cUrl will also work correctly:
 		//  - disable Content-Type if required
 		//  - disable Expect: 100 Continue
@@ -280,7 +285,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
 		// Add version header
 		$headers['x-ms-version'] = $this->_apiVersion;
-		    
+
 		// URL encoding
 		$path           = self::urlencode($path);
 		$queryString    = self::urlencode($queryString);
@@ -289,7 +294,7 @@ class Zend_Service_WindowsAzure_Management_Client
 		$requestUrl     = $this->getBaseUrl() . $path . $queryString;
 		$requestHeaders = $headers;
 
-		// Prepare request 
+		// Prepare request
 		$this->_httpClientChannel->resetParameters(true);
 		$this->_httpClientChannel->setUri($requestUrl);
 		$this->_httpClientChannel->setHeaders($requestHeaders);
@@ -300,47 +305,49 @@ class Zend_Service_WindowsAzure_Management_Client
 		    array($this->_httpClientChannel, 'request'),
 		    array($httpVerb)
 		);
-		
+
 		// Store request id
 		$this->_lastRequestId = $response->getHeader('x-ms-request-id');
-		
+
 		return $response;
 	}
-	
-	/** 
+
+	/**
 	 * Parse result from Zend_Http_Response
 	 *
-	 * @param Zend_Http_Response $response Response from HTTP call
+	 * @param Zend_Http_Response|null $response Response from HTTP call
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse($response = null)
 	{
+        Types::isNullable('response', $response, 'Zend_Http_Response');
+
 		if (is_null($response)) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Response should not be null.');
 		}
-		
+
         $xml = Zend_Xml_Security::scan($response->getBody());
-        
+
         if ($xml !== false) {
-            // Fetch all namespaces 
-            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true)); 
-            
+            // Fetch all namespaces
+            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true));
+
             // Register all namespace prefixes
-            foreach ($namespaces as $prefix => $ns) { 
+            foreach ($namespaces as $prefix => $ns) {
                 if ($prefix != '') {
                     $xml->registerXPathNamespace($prefix, $ns);
-                } 
-            } 
+                }
+            }
         }
-        
+
         return $xml;
 	}
-	
+
 	/**
 	 * URL encode function
-	 * 
+	 *
 	 * @param  string $value Value to encode
 	 * @return string        Encoded value
 	 */
@@ -348,10 +355,10 @@ class Zend_Service_WindowsAzure_Management_Client
 	{
 	    return str_replace(' ', '%20', $value);
 	}
-	
+
     /**
      * Builds a query string from an array of elements
-     * 
+     *
      * @param array     Array of elements
      * @return string   Assembled query string
      */
@@ -359,7 +366,7 @@ class Zend_Service_WindowsAzure_Management_Client
     {
     	return count($queryString) > 0 ? '?' . implode('&', $queryString) : '';
     }
-    
+
 	/**
 	 * Get error message from Zend_Http_Response
 	 *
@@ -376,7 +383,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			return $alternativeError;
 		}
 	}
-    
+
     /**
      * The Get Operation Status operation returns the status of the specified operation.
      * After calling an asynchronous operation, you can call Get Operation Status to
@@ -391,7 +398,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	if ($requestId == '') {
     		$requestId = $this->getLastRequestId();
     	}
-    	
+
     	$response = $this->_performRequest(self::OP_OPERATIONS . '/' . $requestId);
 
     	if ($response->isSuccessful()) {
@@ -411,17 +418,17 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
 
-    
+
+
     /**
      * The List Subscription Operations operation returns a list of create, update,
      * and delete operations that were performed on a subscription during the specified timeframe.
      * Documentation on the parameters can be found at http://msdn.microsoft.com/en-us/library/gg715318.aspx.
      *
      * @param string $startTime The start of the timeframe to begin listing subscription operations in UTC format. This parameter and the $endTime parameter indicate the timeframe to retrieve subscription operations. This parameter cannot indicate a start date of more than 90 days in the past.
-     * @param string $endTime The end of the timeframe to begin listing subscription operations in UTC format. This parameter and the $startTime parameter indicate the timeframe to retrieve subscription operations. 
-     * @param string $objectIdFilter Returns subscription operations only for the specified object type and object ID. 
+     * @param string $endTime The end of the timeframe to begin listing subscription operations in UTC format. This parameter and the $startTime parameter indicate the timeframe to retrieve subscription operations.
+     * @param string $objectIdFilter Returns subscription operations only for the specified object type and object ID.
      * @param string $operationResultFilter Returns subscription operations only for the specified result status, either Succeeded, Failed, or InProgress.
      * @param string $continuationToken Internal usage.
      * @return array Array of Zend_Service_WindowsAzure_Management_SubscriptionOperationInstance
@@ -444,7 +451,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	    		throw new Zend_Service_WindowsAzure_Management_Exception('OperationResultFilter should be succeeded|failed|inprogress.');
 	    	}
     	}
-    	
+
     	$parameters = array();
     	$parameters[] = 'StartTime=' . $startTime;
     	$parameters[] = 'EndTime=' . $endTime;
@@ -457,18 +464,18 @@ class Zend_Service_WindowsAzure_Management_Client
     	if ($continuationToken != '' && !is_null($continuationToken)) {
     		$parameters[] = 'ContinuationToken=' . $continuationToken;
     	}
-    	
+
     	$response = $this->_performRequest(self::OP_OPERATIONS, '?' . implode('&', $parameters));
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			$namespaces = $result->getDocNamespaces(); 
+			$namespaces = $result->getDocNamespaces();
     		$result->registerXPathNamespace('__empty_ns', $namespaces['']);
- 
+
 			$xmlOperations = $result->xpath('//__empty_ns:SubscriptionOperation');
-			
+
 		    // Create return value
-		    $returnValue = array();		    
+		    $returnValue = array();
 		    foreach ($xmlOperations as $xmlOperation) {
 		    	// Create operation instance
 		    	$operation = new Zend_Service_WindowsAzure_Management_SubscriptionOperationInstance(
@@ -479,24 +486,24 @@ class Zend_Service_WindowsAzure_Management_Client
 		    		(array)$xmlOperation->OperationCaller,
 		    		(array)$xmlOperation->OperationStatus
 		    	);
-		    	
+
 		    	// Parse parameters
-		    	$xmlOperation->registerXPathNamespace('__empty_ns', $namespaces['']); 
+		    	$xmlOperation->registerXPathNamespace('__empty_ns', $namespaces['']);
 		    	$xmlParameters = $xmlOperation->xpath('.//__empty_ns:OperationParameter');
 		    	foreach ($xmlParameters as $xmlParameter) {
 		    		$xmlParameterDetails = $xmlParameter->children('http://schemas.datacontract.org/2004/07/Microsoft.Samples.WindowsAzure.ServiceManagement');
 		    		$operation->addOperationParameter((string)$xmlParameterDetails->Name, (string)$xmlParameterDetails->Value);
 		    	}
-		    	
+
     		    // Add to result
     		    $returnValue[] = $operation;
 		    }
-		    
+
 			// More data?
 		    if (!is_null($result->ContinuationToken) && $result->ContinuationToken != '') {
 		    	$returnValue = array_merge($returnValue, $this->listSubscriptionOperations($startTime, $endTime, $objectIdFilter, $operationResultFilter, (string)$result->ContinuationToken));
 		    }
-		    
+
 		    // Return
 		    return $returnValue;
 		} else {
@@ -504,10 +511,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * Wait for an operation to complete
-     * 
+     *
      * @param string $requestId The request ID. If omitted, the last request ID will be used.
      * @param int $sleepInterval Sleep interval in milliseconds.
      * @return Zend_Service_WindowsAzure_Management_OperationStatusInstance
@@ -527,27 +534,29 @@ class Zend_Service_WindowsAzure_Management_Client
 		  $status = $this->getOperationStatus($requestId);
 		  usleep($sleepInterval);
 		}
-		
+
 		return $status;
     }
-    
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage_Blob instance for the current account
 	 *
 	 * @param string $serviceName the service name to create a storage client for.
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Blob
 	 */
-	public function createBlobClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createBlobClientForService($serviceName, $retryPolicy = null)
 	{
+        Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		if ($serviceName == '' || is_null($serviceName)) {
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$storageKeys = $this->getStorageAccountKeys($serviceName);
-    	
-		
-		
+
+
+
 		return new Zend_Service_WindowsAzure_Storage_Blob(
 			Zend_Service_WindowsAzure_Storage::URL_CLOUD_BLOB,
 			$serviceName,
@@ -556,23 +565,25 @@ class Zend_Service_WindowsAzure_Management_Client
 			$retryPolicy
 		);
 	}
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage_Table instance for the current account
 	 *
 	 * @param string $serviceName the service name to create a storage client for.
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Table
 	 */
-	public function createTableClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createTableClientForService($serviceName, $retryPolicy = null)
 	{
+        Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		if ($serviceName == '' || is_null($serviceName)) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$storageKeys = $this->getStorageAccountKeys($serviceName);
-		
+
 		return new Zend_Service_WindowsAzure_Storage_Table(
 			Zend_Service_WindowsAzure_Storage::URL_CLOUD_TABLE,
 			$serviceName,
@@ -581,25 +592,27 @@ class Zend_Service_WindowsAzure_Management_Client
 			$retryPolicy
 		);
 	}
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage_Queue instance for the current account
 	 *
 	 * @param string $serviceName the service name to create a storage client for.
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Queue
 	 */
-	public function createQueueClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createQueueClientForService($serviceName, $retryPolicy = null)
 	{
+        Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		if ($serviceName == '' || is_null($serviceName)) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$storageKeys = $this->getStorageAccountKeys($serviceName);
-    	
+
 		// require_once 'Zend/Service/WindowsAzure/Storage/Queue.php';
-		
+
 		return new Zend_Service_WindowsAzure_Storage_Queue(
 			Zend_Service_WindowsAzure_Storage::URL_CLOUD_QUEUE,
 			$serviceName,
@@ -608,7 +621,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			$retryPolicy
 		);
 	}
-    
+
     /**
      * The List Storage Accounts operation lists the storage accounts available under
      * the current subscription.
@@ -621,7 +634,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->StorageService) {
 				return array();
 			}
@@ -630,9 +643,9 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->StorageService);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {				
+			if (!is_null($xmlServices)) {
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_StorageServiceInstance(
 					    (string)$xmlServices[$i]->Url,
@@ -645,10 +658,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Get Storage Account Properties operation returns the system properties for the
-     * specified storage account. These properties include: the address, description, and 
+     * specified storage account. These properties include: the address, description, and
      * label of the storage account; and the name of the affinity group to which the service
      * belongs, or its geo-location if it is not part of an affinity group.
      *
@@ -661,7 +674,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	if ($serviceName == '' || is_null($serviceName)) {
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$response = $this->_performRequest(self::OP_STORAGE_ACCOUNTS . '/' . $serviceName);
 
     	if ($response->isSuccessful()) {
@@ -669,7 +682,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
 			if (!is_null($xmlService)) {
 				// require_once 'Zend/Service/WindowsAzure/Management/StorageServiceInstance.php';
-				
+
 				return new Zend_Service_WindowsAzure_Management_StorageServiceInstance(
 					(string)$xmlService->Url,
 					(string)$xmlService->ServiceName,
@@ -685,7 +698,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Get Storage Keys operation returns the primary
      * and secondary access keys for the specified storage account.
@@ -700,7 +713,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$response = $this->_performRequest(self::OP_STORAGE_ACCOUNTS . '/' . $serviceName . '/keys');
 
     	if ($response->isSuccessful()) {
@@ -718,7 +731,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Regenerate Keys operation regenerates the primary
      * or secondary access key for the specified storage account.
@@ -739,7 +752,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Key identifier should be primary|secondary.');
     	}
-    	
+
     	$response = $this->_performRequest(
     		self::OP_STORAGE_ACCOUNTS . '/' . $serviceName . '/keys', '?action=regenerate',
     		Zend_Http_Client::POST,
@@ -764,7 +777,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List Hosted Services operation lists the hosted services available
      * under the current subscription.
@@ -778,7 +791,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->HostedService) {
 				return array();
 			}
@@ -787,10 +800,10 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->HostedService);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {	
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_HostedServiceInstance(
 					    (string)$xmlServices[$i]->Url,
@@ -804,14 +817,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Create Hosted Service operation creates a new hosted service in Windows Azure.
-     * 
+     *
      * @param string $serviceName A name for the hosted service that is unique to the subscription.
      * @param string $label A label for the hosted service. The label may be up to 100 characters in length.
      * @param string $description A description for the hosted service. The description may be up to 1024 characters in length.
-     * @param string $location Required if AffinityGroup is not specified. The location where the hosted service will be created. 
+     * @param string $location Required if AffinityGroup is not specified. The location where the hosted service will be created.
      * @param string $affinityGroup Required if Location is not specified. The name of an existing affinity group associated with this subscription.
      */
     public function createHostedService($serviceName, $label, $description = '', $location = null, $affinityGroup = null)
@@ -836,25 +849,25 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Please specify a location -or- an affinity group for the service.');
     	}
-    	
+
     	$locationOrAffinityGroup = is_null($location)
     		? '<AffinityGroup>' . $affinityGroup . '</AffinityGroup>'
     		: '<Location>' . $location . '</Location>';
-    	
+
         $response = $this->_performRequest(self::OP_HOSTED_SERVICES, '',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<CreateHostedService xmlns="http://schemas.microsoft.com/windowsazure"><ServiceName>' . $serviceName . '</ServiceName><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description>' . $locationOrAffinityGroup . '</CreateHostedService>');
- 	
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Update Hosted Service operation updates the label and/or the description for a hosted service in Windows Azure.
-     * 
+     *
      * @param string $serviceName A name for the hosted service that is unique to the subscription.
      * @param string $label A label for the hosted service. The label may be up to 100 characters in length.
      * @param string $description A description for the hosted service. The description may be up to 1024 characters in length.
@@ -873,21 +886,21 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Label is too long. The maximum length is 100 characters.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_HOSTED_SERVICES . '/' . $serviceName, '',
     		Zend_Http_Client::PUT,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<UpdateHostedService xmlns="http://schemas.microsoft.com/windowsazure"><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description></UpdateHostedService>');
- 	
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Delete Hosted Service operation deletes the specified hosted service in Windows Azure.
-     * 
+     *
      * @param string $serviceName A name for the hosted service that is unique to the subscription.
      */
     public function deleteHostedService($serviceName)
@@ -896,15 +909,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_HOSTED_SERVICES . '/' . $serviceName, '', Zend_Http_Client::DELETE);
- 	
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Get Hosted Service Properties operation retrieves system properties
      * for the specified hosted service. These properties include the service
@@ -922,14 +935,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$response = $this->_performRequest(self::OP_HOSTED_SERVICES . '/' . $serviceName, '?embed-detail=true');
 
     	if ($response->isSuccessful()) {
 			$xmlService = $this->_parseResponse($response);
 
 			if (!is_null($xmlService)) {
-				
+
 				$returnValue = new Zend_Service_WindowsAzure_Management_HostedServiceInstance(
 					(string)$xmlService->Url,
 					(string)$xmlService->ServiceName,
@@ -938,20 +951,20 @@ class Zend_Service_WindowsAzure_Management_Client
 					(string)$xmlService->HostedServiceProperties->Location,
 					(string)$xmlService->HostedServiceProperties->Label
 				);
-				
+
 				// Deployments
 		    	if (count($xmlService->Deployments->Deployment) > 1) {
     		    	$xmlServices = $xmlService->Deployments->Deployment;
     			} else {
     		    	$xmlServices = array($xmlService->Deployments->Deployment);
     			}
-    			
+
     			$deployments = array();
     			foreach ($xmlServices as $xmlDeployment) {
 					$deployments[] = $this->_convertXmlElementToDeploymentInstance($xmlDeployment);
     			}
 				$returnValue->Deployments = $deployments;
-				
+
 				return $returnValue;
 			}
 			return null;
@@ -964,7 +977,7 @@ class Zend_Service_WindowsAzure_Management_Client
     /**
      * The Create Deployment operation uploads a new service package
      * and creates a new deployment on staging or production.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
 	 * @param string $name              The name for the deployment. The deployment ID as listed on the Windows Azure management portal must be unique among other deployments for the hosted service.
@@ -1006,30 +1019,30 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Configuration should be specified.');
     	}
-    	
+
     	if (@file_exists($configuration)) {
     		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
-    	
+
     	// Clean up the configuration
     	$conformingConfiguration = $this->_cleanConfiguration($configuration);
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
         $response = $this->_performRequest($operationUrl, '',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<CreateDeployment xmlns="http://schemas.microsoft.com/windowsazure"><Name>' . $name . '</Name><PackageUrl>' . $packageUrl . '</PackageUrl><Label>' . base64_encode($label) . '</Label><Configuration>' . base64_encode($conformingConfiguration) . '</Configuration><StartDeployment>' . ($startDeployment ? 'true' : 'false') . '</StartDeployment><TreatWarningsAsError>' . ($treatWarningsAsErrors ? 'true' : 'false') . '</TreatWarningsAsError></CreateDeployment>');
- 	
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-		}    	
+		}
     }
-    
+
     /**
      * The Get Deployment operation returns configuration information, status,
      * and system properties for the specified deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @return Zend_Service_WindowsAzure_Management_DeploymentInstance
@@ -1046,15 +1059,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment slot should be production|staging.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
     	return $this->_getDeployment($operationUrl);
     }
-    
+
     /**
      * The Get Deployment operation returns configuration information, status,
      * and system properties for the specified deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
      * @return Zend_Service_WindowsAzure_Management_DeploymentInstance
@@ -1070,15 +1083,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment ID should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
     	return $this->_getDeployment($operationUrl);
     }
-    
+
     /**
      * The Get Deployment operation returns configuration information, status,
      * and system properties for the specified deployment.
-     * 
+     *
      * @param string $operationUrl		The operation url
      * @return Zend_Service_WindowsAzure_Management_DeploymentInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1089,21 +1102,21 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$xmlService = $this->_parseResponse($response);
-			
+
 			return $this->_convertXmlElementToDeploymentInstance($xmlService);
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Swap Deployment operation initiates a virtual IP swap between
      * the staging and production deployment environments for a service.
      * If the service is currently running in the staging environment,
      * it will be swapped to the production environment. If it is running
      * in the production environment, it will be swapped to staging.
-     * 
+     *
      * @param string $serviceName The service name.
      * @param string $productionDeploymentName The name of the production deployment.
      * @param string $sourceDeploymentName The name of the source deployment.
@@ -1123,22 +1136,22 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Source Deployment ID should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName;
         $response = $this->_performRequest($operationUrl, '',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<Swap xmlns="http://schemas.microsoft.com/windowsazure"><Production>' . $productionDeploymentName . '</Production><SourceDeployment>' . $sourceDeploymentName . '</SourceDeployment></Swap>');
-    		
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
-		}    	
+		}
     }
-    
+
     /**
      * The Delete Deployment operation deletes the specified deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1154,14 +1167,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment slot should be production|staging.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
     	return $this->_deleteDeployment($operationUrl);
     }
-    
+
     /**
      * The Delete Deployment operation deletes the specified deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1176,30 +1189,30 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment ID should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
     	return $this->_deleteDeployment($operationUrl);
     }
-    
+
     /**
      * The Delete Deployment operation deletes the specified deployment.
-     * 
+     *
      * @param string $operationUrl		The operation url
      * @throws Zend_Service_WindowsAzure_Management_Exception
      */
     protected function _deleteDeployment($operationUrl)
     {
         $response = $this->_performRequest($operationUrl, '', Zend_Http_Client::DELETE);
-			 
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Update Deployment Status operation initiates a change in deployment status.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string $status            The deployment status (running|suspended)
@@ -1221,14 +1234,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Status should be running|suspended.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
     	return $this->_updateDeploymentStatus($operationUrl, $status);
     }
-    
+
     /**
      * The Update Deployment Status operation initiates a change in deployment status.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
      * @param string $status            The deployment status (running|suspended)
@@ -1249,14 +1262,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Status should be running|suspended.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
     	return $this->_updateDeploymentStatus($operationUrl, $status);
     }
-    
+
     /**
      * The Update Deployment Status operation initiates a change in deployment status.
-     * 
+     *
      * @param string $operationUrl		The operation url
      * @param string $status            The deployment status (running|suspended)
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1267,16 +1280,16 @@ class Zend_Service_WindowsAzure_Management_Client
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<UpdateDeploymentStatus xmlns="http://schemas.microsoft.com/windowsazure"><Status>' . ucfirst($status) . '</Status></UpdateDeploymentStatus>');
-    		
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * Converts an XmlElement into a Zend_Service_WindowsAzure_Management_DeploymentInstance
-     * 
+     *
      * @param object $xmlService The XML Element
      * @return Zend_Service_WindowsAzure_Management_DeploymentInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1284,7 +1297,7 @@ class Zend_Service_WindowsAzure_Management_Client
     protected function _convertXmlElementToDeploymentInstance($xmlService)
     {
 		if (!is_null($xmlService)) {
-			
+
 			$returnValue = new Zend_Service_WindowsAzure_Management_DeploymentInstance(
 				(string)$xmlService->Name,
 				(string)$xmlService->DeploymentSlot,
@@ -1299,16 +1312,16 @@ class Zend_Service_WindowsAzure_Management_Client
 				(string)$xmlService->CurrentUpgradeDomain,
 				(string)$xmlService->UpgradeDomainCount
 			);
-				
+
 			// Append role instances
 			if ($xmlService->RoleInstanceList && $xmlService->RoleInstanceList->RoleInstance) {
 				$xmlRoleInstances = $xmlService->RoleInstanceList->RoleInstance;
 				if (count($xmlService->RoleInstanceList->RoleInstance) == 1) {
 		    	    $xmlRoleInstances = array($xmlService->RoleInstanceList->RoleInstance);
 		    	}
-		    		
+
 				$roleInstances = array();
-				if (!is_null($xmlRoleInstances)) {				
+				if (!is_null($xmlRoleInstances)) {
 					for ($i = 0; $i < count($xmlRoleInstances); $i++) {
 						$roleInstances[] = array(
 						    'rolename' => (string)$xmlRoleInstances[$i]->RoleName,
@@ -1317,37 +1330,37 @@ class Zend_Service_WindowsAzure_Management_Client
 						);
 					}
 				}
-				
+
 				$returnValue->RoleInstanceList = $roleInstances;
 			}
-			
+
 			// Append roles
 			if ($xmlService->RoleList && $xmlService->RoleList->Role) {
 				$xmlRoles = $xmlService->RoleList->Role;
 				if (count($xmlService->RoleList->Role) == 1) {
 		    	    $xmlRoles = array($xmlService->RoleList->Role);
 		    	}
-	    		
+
 				$roles = array();
-				if (!is_null($xmlRoles)) {				
+				if (!is_null($xmlRoles)) {
 					for ($i = 0; $i < count($xmlRoles); $i++) {
 						$roles[] = array(
 						    'rolename' => (string)$xmlRoles[$i]->RoleName,
-						    'osversion' => (!is_null($xmlRoles[$i]->OsVersion) ? (string)$xmlRoles[$i]->OsVersion : (string)$xmlRoles[$i]->OperatingSystemVersion)					
+						    'osversion' => (!is_null($xmlRoles[$i]->OsVersion) ? (string)$xmlRoles[$i]->OsVersion : (string)$xmlRoles[$i]->OperatingSystemVersion)
 						);
 					}
 				}
 				$returnValue->RoleList = $roles;
 			}
-				
+
 			return $returnValue;
 		}
 		return null;
     }
-    
+
     /**
      * Updates a deployment's role instance count.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string|array $roleName	The role name
@@ -1368,19 +1381,19 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role name name should be specified.');
     	}
-    	
+
 		// Get configuration
 		$deployment = $this->getDeploymentBySlot($serviceName, $deploymentSlot);
 		$configuration = $deployment->Configuration;
 		$configuration = $this->_updateInstanceCountInConfiguration($roleName, $instanceCount, $configuration);
-		
+
 		// Update configuration
-		$this->configureDeploymentBySlot($serviceName, $deploymentSlot, $configuration);		
+		$this->configureDeploymentBySlot($serviceName, $deploymentSlot, $configuration);
 	}
-	
+
     /**
      * Updates a deployment's role instance count.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string|array $roleName	The role name
@@ -1401,19 +1414,19 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role name name should be specified.');
     	}
-    	
+
 		// Get configuration
 		$deployment = $this->getDeploymentByDeploymentId($serviceName, $deploymentId);
 		$configuration = $deployment->Configuration;
 		$configuration = $this->_updateInstanceCountInConfiguration($roleName, $instanceCount, $configuration);
-		
+
 		// Update configuration
 		$this->configureDeploymentByDeploymentId($serviceName, $deploymentId, $configuration);
     }
-	
+
     /**
      * Updates instance count in configuration XML.
-     * 
+     *
      * @param string|array $roleName			The role name
      * @param string|array $instanceCount		The instance count
      * @param string $configuration             XML configuration represented as a string
@@ -1431,32 +1444,32 @@ class Zend_Service_WindowsAzure_Management_Client
 		$configuration = preg_replace('/(<\?xml[^?]+?)utf-16/i', '$1utf-8', $configuration);
 		//$configuration = '<?xml version="1.0">' . substr($configuration, strpos($configuration, '>') + 2);
 
-		$xml = Zend_Xml_Security::scan($configuration); 
-		
+		$xml = Zend_Xml_Security::scan($configuration);
+
 		// http://www.php.net/manual/en/simplexmlelement.xpath.php#97818
 		$namespaces = $xml->getDocNamespaces();
-	    $xml->registerXPathNamespace('__empty_ns', $namespaces['']); 
-	
+	    $xml->registerXPathNamespace('__empty_ns', $namespaces['']);
+
 		for ($i = 0; $i < count($roleName); $i++) {
 			$elements = $xml->xpath('//__empty_ns:Role[@name="' . $roleName[$i] . '"]/__empty_ns:Instances');
-	
+
 			if (count($elements) == 1) {
 				$element = $elements[0];
 				$element['count'] = $instanceCount[$i];
-			} 
+			}
 		}
-		
+
 		$configuration = $xml->asXML();
 		//$configuration = preg_replace('/(<\?xml[^?]+?)utf-8/i', '$1utf-16', $configuration);
 
 		return $configuration;
 	}
-    
+
     /**
      * The Change Deployment Configuration request may be specified as follows.
      * Note that you can change a deployment's configuration either by specifying the deployment
-     * environment (staging or production), or by specifying the deployment's unique name. 
-     * 
+     * environment (staging or production), or by specifying the deployment's unique name.
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string $configuration     XML configuration represented as a string
@@ -1477,20 +1490,20 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Configuration name should be specified.');
     	}
-    	
+
         if (@file_exists($configuration)) {
     		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
     	return $this->_configureDeployment($operationUrl, $configuration);
     }
-    
+
     /**
      * The Change Deployment Configuration request may be specified as follows.
      * Note that you can change a deployment's configuration either by specifying the deployment
-     * environment (staging or production), or by specifying the deployment's unique name. 
-     * 
+     * environment (staging or production), or by specifying the deployment's unique name.
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
      * @param string $configuration     XML configuration represented as a string
@@ -1510,20 +1523,20 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Configuration name should be specified.');
     	}
-    	
+
         if (@file_exists($configuration)) {
     		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
     	return $this->_configureDeployment($operationUrl, $configuration);
     }
-    
+
     /**
      * The Change Deployment Configuration request may be specified as follows.
      * Note that you can change a deployment's configuration either by specifying the deployment
-     * environment (staging or production), or by specifying the deployment's unique name. 
-     * 
+     * environment (staging or production), or by specifying the deployment's unique name.
+     *
      * @param string $operationUrl		The operation url
      * @param string $configuration     XML configuration represented as a string
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1537,16 +1550,16 @@ class Zend_Service_WindowsAzure_Management_Client
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
     		'<ChangeConfiguration xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Configuration>' . base64_encode($conformingConfiguration) . '</Configuration></ChangeConfiguration>');
-			 
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Upgrade Deployment operation initiates an upgrade.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
 	 * @param string $label             A URL that refers to the location of the service package in the Blob service. The service package must be located in a storage account beneath the same subscription.
@@ -1588,18 +1601,18 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Mode should be auto|manual.');
     	}
-    	
+
     	if (@file_exists($configuration)) {
     		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
-    	
+
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
-    	return $this->_upgradeDeployment($operationUrl, $label, $packageUrl, $configuration, $mode, $roleToUpgrade);  	
+    	return $this->_upgradeDeployment($operationUrl, $label, $packageUrl, $configuration, $mode, $roleToUpgrade);
     }
-    
+
     /**
      * The Upgrade Deployment operation initiates an upgrade.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
 	 * @param string $label             A URL that refers to the location of the service package in the Blob service. The service package must be located in a storage account beneath the same subscription.
@@ -1640,19 +1653,19 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Mode should be auto|manual.');
     	}
-    	
+
     	if (@file_exists($configuration)) {
     		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
-    	
+
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
-    	return $this->_upgradeDeployment($operationUrl, $label, $packageUrl, $configuration, $mode, $roleToUpgrade);  	
+    	return $this->_upgradeDeployment($operationUrl, $label, $packageUrl, $configuration, $mode, $roleToUpgrade);
     }
-    
-    
+
+
     /**
      * The Upgrade Deployment operation initiates an upgrade.
-     * 
+     *
      * @param string $operationUrl		The operation url
 	 * @param string $label             A URL that refers to the location of the service package in the Blob service. The service package must be located in a storage account beneath the same subscription.
 	 * @param string $packageUrl        The service configuration file for the deployment.
@@ -1665,21 +1678,21 @@ class Zend_Service_WindowsAzure_Management_Client
     {
     	// Clean up the configuration
     	$conformingConfiguration = $this->_cleanConfiguration($configuration);
-    	
+
         $response = $this->_performRequest($operationUrl . '/', '?comp=upgrade',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
-    		'<UpgradeDeployment xmlns="http://schemas.microsoft.com/windowsazure"><Mode>' . ucfirst($mode) . '</Mode><PackageUrl>' . $packageUrl . '</PackageUrl><Configuration>' . base64_encode($conformingConfiguration) . '</Configuration><Label>' . base64_encode($label) . '</Label>' . (!is_null($roleToUpgrade) ? '<RoleToUpgrade>' . $roleToUpgrade . '</RoleToUpgrade>' : '') . '</UpgradeDeployment>');		
-    		
+    		'<UpgradeDeployment xmlns="http://schemas.microsoft.com/windowsazure"><Mode>' . ucfirst($mode) . '</Mode><PackageUrl>' . $packageUrl . '</PackageUrl><Configuration>' . base64_encode($conformingConfiguration) . '</Configuration><Label>' . base64_encode($label) . '</Label>' . (!is_null($roleToUpgrade) ? '<RoleToUpgrade>' . $roleToUpgrade . '</RoleToUpgrade>' : '') . '</UpgradeDeployment>');
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Walk Upgrade Domain operation specifies the next upgrade domain to be walked during an in-place upgrade.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
 	 * @param int $upgradeDomain     An integer value that identifies the upgrade domain to walk. Upgrade domains are identified with a zero-based index: the first upgrade domain has an ID of 0, the second has an ID of 1, and so on.
@@ -1696,14 +1709,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment slot should be production|staging.');
     	}
-    	
+
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
-    	return $this->_walkUpgradeDomain($operationUrl, $upgradeDomain);  	
+    	return $this->_walkUpgradeDomain($operationUrl, $upgradeDomain);
     }
-    
+
     /**
      * The Walk Upgrade Domain operation specifies the next upgrade domain to be walked during an in-place upgrade.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
 	 * @param int $upgradeDomain     An integer value that identifies the upgrade domain to walk. Upgrade domains are identified with a zero-based index: the first upgrade domain has an ID of 0, the second has an ID of 1, and so on.
@@ -1719,15 +1732,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Deployment ID should be specified.');
     	}
-    	
+
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
-    	return $this->_walkUpgradeDomain($operationUrl, $upgradeDomain);  	
+    	return $this->_walkUpgradeDomain($operationUrl, $upgradeDomain);
     }
-    
-    
+
+
     /**
      * The Walk Upgrade Domain operation specifies the next upgrade domain to be walked during an in-place upgrade.
-     * 
+     *
      * @param string $operationUrl   The operation url
 	 * @param int $upgradeDomain     An integer value that identifies the upgrade domain to walk. Upgrade domains are identified with a zero-based index: the first upgrade domain has an ID of 0, the second has an ID of 1, and so on.
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1737,18 +1750,18 @@ class Zend_Service_WindowsAzure_Management_Client
         $response = $this->_performRequest($operationUrl . '/', '?comp=walkupgradedomain',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
-    		'<WalkUpgradeDomain xmlns="http://schemas.microsoft.com/windowsazure"><UpgradeDomain>' . $upgradeDomain . '</UpgradeDomain></WalkUpgradeDomain>');		
+    		'<WalkUpgradeDomain xmlns="http://schemas.microsoft.com/windowsazure"><UpgradeDomain>' . $upgradeDomain . '</UpgradeDomain></WalkUpgradeDomain>');
 
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Reboot Role Instance operation requests a reboot of a role instance
      * that is running in a deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string $roleInstanceName  The role instance name
@@ -1769,15 +1782,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role instance name should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot . '/roleinstances/' . $roleInstanceName;
     	return $this->_rebootOrReimageRoleInstance($operationUrl, 'reboot');
     }
-    
+
     /**
      * The Reboot Role Instance operation requests a reboot of a role instance
      * that is running in a deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	The deployment ID as listed on the Windows Azure management portal
      * @param string $roleInstanceName  The role instance name
@@ -1797,7 +1810,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role instance name should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId . '/roleinstances/' . $roleInstanceName;
     	return $this->_rebootOrReimageRoleInstance($operationUrl, 'reboot');
     }
@@ -1805,7 +1818,7 @@ class Zend_Service_WindowsAzure_Management_Client
     /**
      * The Reimage Role Instance operation requests a reimage of a role instance
      * that is running in a deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentSlot	The deployment slot (production or staging)
      * @param string $roleInstanceName  The role instance name
@@ -1826,15 +1839,15 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role instance name should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot . '/roleinstances/' . $roleInstanceName;
     	return $this->_rebootOrReimageRoleInstance($operationUrl, 'reimage');
     }
-    
+
     /**
      * The Reimage Role Instance operation requests a reimage of a role instance
      * that is running in a deployment.
-     * 
+     *
      * @param string $serviceName		The service name
      * @param string $deploymentId	    The deployment ID as listed on the Windows Azure management portal
      * @param string $roleInstanceName  The role instance name
@@ -1854,14 +1867,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Role instance name should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId . '/roleinstances/' . $roleInstanceName;
     	return $this->_rebootOrReimageRoleInstance($operationUrl, 'reimage');
     }
-    
+
     /**
      * Reboots or reimages a role instance.
-     * 
+     *
      * @param string $operationUrl		The operation url
      * @param string $operation The operation (reboot|reimage)
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1869,17 +1882,17 @@ class Zend_Service_WindowsAzure_Management_Client
     protected function _rebootOrReimageRoleInstance($operationUrl, $operation = 'reboot')
     {
         $response = $this->_performRequest($operationUrl, '?comp=' . $operation, Zend_Http_Client::POST);
-    		
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List Certificates operation lists all certificates associated with
      * the specified hosted service.
-     * 
+     *
      * @param string $serviceName		The service name
      * @return array Array of Zend_Service_WindowsAzure_Management_CertificateInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -1890,7 +1903,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/certificates';
         $response = $this->_performRequest($operationUrl);
 
@@ -1907,8 +1920,8 @@ class Zend_Service_WindowsAzure_Management_Client
     		}
 
 			$services = array();
-			if (!is_null($xmlServices)) {				
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_CertificateInstance(
 					    (string)$xmlServices[$i]->CertificateUrl,
@@ -1924,10 +1937,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Get Certificate operation returns the public data for the specified certificate.
-     * 
+     *
      * @param string $serviceName|$certificateUrl	The service name -or- the certificate URL
      * @param string $algorithm         			Algorithm
      * @param string $thumbprint        			Thumbprint
@@ -1944,17 +1957,17 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Algorithm and thumbprint should be specified.');
     	}
-    	
+
     	$operationUrl = str_replace($this->getBaseUrl(), '', $serviceName);
     	if (strpos($serviceName, 'https') === false) {
     		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/certificates/' . $algorithm . '-' . strtoupper($thumbprint);
     	}
-    	
+
         $response = $this->_performRequest($operationUrl);
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
 			return new Zend_Service_WindowsAzure_Management_CertificateInstance(
 				$this->getBaseUrl() . $operationUrl,
 				$algorithm,
@@ -1966,10 +1979,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Add Certificate operation adds a certificate to the subscription.
-     * 
+     *
      * @param string $serviceName         The service name
      * @param string $certificateData     Certificate data
      * @param string $certificatePassword The certificate password
@@ -1994,11 +2007,11 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Certificate format should be "pfx".');
     	}
-    	
+
     	if (@file_exists($certificateData)) {
     		$certificateData = file_get_contents($certificateData);
     	}
-    	
+
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/certificates';
         $response = $this->_performRequest($operationUrl, '',
     		Zend_Http_Client::POST,
@@ -2010,10 +2023,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Delete Certificate operation deletes a certificate from the subscription's certificate store.
-     * 
+     *
      * @param string $serviceName|$certificateUrl	The service name -or- the certificate URL
      * @param string $algorithm         			Algorithm
      * @param string $thumbprint        			Thumbprint
@@ -2029,12 +2042,12 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Algorithm and thumbprint should be specified.');
     	}
-    	
+
     	$operationUrl = str_replace($this->getBaseUrl(), '', $serviceName);
     	if (strpos($serviceName, 'https') === false) {
     		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/certificates/' . $algorithm . '-' . strtoupper($thumbprint);
     	}
-    	
+
         $response = $this->_performRequest($operationUrl, '', Zend_Http_Client::DELETE);
 
     	if (!$response->isSuccessful()) {
@@ -2042,11 +2055,11 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List Affinity Groups operation lists the affinity groups associated with
      * the specified subscription.
-     * 
+     *
      * @return array Array of Zend_Service_WindowsAzure_Management_AffinityGroupInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
      */
@@ -2056,7 +2069,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->AffinityGroup) {
 				return array();
 			}
@@ -2065,10 +2078,10 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->AffinityGroup);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {				
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_AffinityGroupInstance(
 					    (string)$xmlServices[$i]->Name,
@@ -2084,14 +2097,14 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Create Affinity Group operation creates a new affinity group for the specified subscription.
-     * 
+     *
      * @param string $name A name for the affinity group that is unique to the subscription.
      * @param string $label A label for the affinity group. The label may be up to 100 characters in length.
      * @param string $description A description for the affinity group. The description may be up to 1024 characters in length.
-     * @param string $location The location where the affinity group will be created. To list available locations, use the List Locations operation. 
+     * @param string $location The location where the affinity group will be created. To list available locations, use the List Locations operation.
      */
     public function createAffinityGroup($name, $label, $description = '', $location = '')
     {
@@ -2115,24 +2128,24 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Location should be specified.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_AFFINITYGROUPS, '',
     		Zend_Http_Client::POST,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
-    		'<CreateAffinityGroup xmlns="http://schemas.microsoft.com/windowsazure"><Name>' . $name . '</Name><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description><Location>' . $location . '</Location></CreateAffinityGroup>');	
-    		
+    		'<CreateAffinityGroup xmlns="http://schemas.microsoft.com/windowsazure"><Name>' . $name . '</Name><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description><Location>' . $location . '</Location></CreateAffinityGroup>');
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Update Affinity Group operation updates the label and/or the description for an affinity group for the specified subscription.
-     * 
+     *
      * @param string $name The name for the affinity group that should be updated.
      * @param string $label A label for the affinity group. The label may be up to 100 characters in length.
-     * @param string $description A description for the affinity group. The description may be up to 1024 characters in length. 
+     * @param string $description A description for the affinity group. The description may be up to 1024 characters in length.
      */
     public function updateAffinityGroup($name, $label, $description = '')
     {
@@ -2152,21 +2165,21 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Description is too long. The maximum length is 1024 characters.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_AFFINITYGROUPS . '/' . $name, '',
     		Zend_Http_Client::PUT,
     		array('Content-Type' => 'application/xml; charset=utf-8'),
-    		'<UpdateAffinityGroup xmlns="http://schemas.microsoft.com/windowsazure"><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description></UpdateAffinityGroup>');	
-    		
+    		'<UpdateAffinityGroup xmlns="http://schemas.microsoft.com/windowsazure"><Label>' . base64_encode($label) . '</Label><Description>' . $description . '</Description></UpdateAffinityGroup>');
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Delete Affinity Group operation deletes an affinity group in the specified subscription.
-     * 
+     *
      * @param string $name The name for the affinity group that should be deleted.
      */
     public function deleteAffinityGroup($name)
@@ -2175,20 +2188,20 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Affinity group name should be specified.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_AFFINITYGROUPS . '/' . $name, '',
     		Zend_Http_Client::DELETE);
-    		
+
     	if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The Get Affinity Group Properties operation returns the
      * system properties associated with the specified affinity group.
-     * 
+     *
      * @param string $affinityGroupName The affinity group name.
      * @return Zend_Service_WindowsAzure_Management_AffinityGroupInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
@@ -2199,12 +2212,12 @@ class Zend_Service_WindowsAzure_Management_Client
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
     		throw new Zend_Service_WindowsAzure_Management_Exception('Affinity group name should be specified.');
     	}
-    	
+
         $response = $this->_performRequest(self::OP_AFFINITYGROUPS . '/' . $affinityGroupName);
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
 			$affinityGroup = new Zend_Service_WindowsAzure_Management_AffinityGroupInstance(
 				$affinityGroupName,
 				(string)$result->Label,
@@ -2218,9 +2231,9 @@ class Zend_Service_WindowsAzure_Management_Client
 		    } else {
 		    	$xmlService = array($result->HostedServices->HostedService);
 		    }
-		    		
+
 			$services = array();
-			if (!is_null($xmlService)) {				
+			if (!is_null($xmlService)) {
 				for ($i = 0; $i < count($xmlService); $i++) {
 					$services[] = array(
 						'url' => (string)$xmlService[$i]->Url,
@@ -2229,16 +2242,16 @@ class Zend_Service_WindowsAzure_Management_Client
 				}
 			}
 			$affinityGroup->HostedServices = $services;
-			
+
 			// Storage services
 			if (count($result->StorageServices->StorageService) > 1) {
 		    	$xmlService = $result->StorageServices->StorageService;
 		    } else {
 		    	$xmlService = array($result->StorageServices->StorageService);
 		    }
-		    		
+
 			$services = array();
-			if (!is_null($xmlService)) {				
+			if (!is_null($xmlService)) {
 				for ($i = 0; $i < count($xmlService); $i++) {
 					$services[] = array(
 						'url' => (string)$xmlService[$i]->Url,
@@ -2246,19 +2259,19 @@ class Zend_Service_WindowsAzure_Management_Client
 					);
 				}
 			}
-			$affinityGroup->StorageServices = $services;	
-			
+			$affinityGroup->StorageServices = $services;
+
 			return $affinityGroup;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List Locations operation lists all of the data center locations
      * that are valid for your subscription.
-     * 
+     *
      * @return array Array of Zend_Service_WindowsAzure_Management_LocationInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
      */
@@ -2268,7 +2281,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->Location) {
 				return array();
 			}
@@ -2277,10 +2290,10 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->Location);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {				
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_LocationInstance(
 					    (string)$xmlServices[$i]->Name
@@ -2293,7 +2306,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List Operating Systems operation lists the versions of the guest operating system
      * that are currently available in Windows Azure. The 2010-10-28 version of List Operating
@@ -2302,7 +2315,7 @@ class Zend_Service_WindowsAzure_Management_Client
      * operating system that is substantially compatible with Windows Server 2008 SP2,
      * and the Windows Azure guest operating system that is substantially compatible with
      * Windows Server 2008 R2.
-     * 
+     *
      * @return array Array of Zend_Service_WindowsAzure_Management_OperatingSystemInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
      */
@@ -2312,7 +2325,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->OperatingSystem) {
 				return array();
 			}
@@ -2321,10 +2334,10 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->OperatingSystem);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {				
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_OperatingSystemInstance(
 					    (string)$xmlServices[$i]->Version,
@@ -2342,7 +2355,7 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * The List OS Families operation lists the guest operating system families
      * available in Windows Azure, and also lists the operating system versions
@@ -2351,7 +2364,7 @@ class Zend_Service_WindowsAzure_Management_Client
      * substantially compatible with Windows Server 2008 SP2, and the Windows
      * Azure guest operating system that is substantially compatible with
      * Windows Server 2008 R2.
-     * 
+     *
      * @return array Array of Zend_Service_WindowsAzure_Management_OperatingSystemFamilyInstance
      * @throws Zend_Service_WindowsAzure_Management_Exception
      */
@@ -2361,7 +2374,7 @@ class Zend_Service_WindowsAzure_Management_Client
 
     	if ($response->isSuccessful()) {
 			$result = $this->_parseResponse($response);
-			
+
     		if (!$result->OperatingSystemFamily) {
 				return array();
 			}
@@ -2370,24 +2383,24 @@ class Zend_Service_WindowsAzure_Management_Client
     		} else {
     		    $xmlServices = array($result->OperatingSystemFamily);
     		}
-    		
+
 			$services = array();
-			if (!is_null($xmlServices)) {				
-				
+			if (!is_null($xmlServices)) {
+
 				for ($i = 0; $i < count($xmlServices); $i++) {
 					$services[] = new Zend_Service_WindowsAzure_Management_OperatingSystemFamilyInstance(
 					    (string)$xmlServices[$i]->Name,
 					    (string)$xmlServices[$i]->Label
 					);
-								
+
 					if (count($xmlServices[$i]->OperatingSystems->OperatingSystem) > 1) {
 		    		    $xmlOperatingSystems = $xmlServices[$i]->OperatingSystems->OperatingSystem;
 		    		} else {
 		    		    $xmlOperatingSystems = array($xmlServices[$i]->OperatingSystems->OperatingSystem);
 		    		}
-		    		
+
 					$operatingSystems = array();
-					if (!is_null($xmlOperatingSystems)) {				
+					if (!is_null($xmlOperatingSystems)) {
 						// require_once 'Zend/Service/WindowsAzure/Management/OperatingSystemInstance.php';
 						for ($i = 0; $i < count($xmlOperatingSystems); $i++) {
 							$operatingSystems[] = new Zend_Service_WindowsAzure_Management_OperatingSystemInstance(
@@ -2409,10 +2422,10 @@ class Zend_Service_WindowsAzure_Management_Client
 			throw new Zend_Service_WindowsAzure_Management_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
     }
-    
+
     /**
      * Clean configuration
-     * 
+     *
      * @param string $configuration Configuration to clean.
      * @return string
      */
@@ -2420,7 +2433,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	$configuration = str_replace('?<?', '<?', $configuration);
 		$configuration = str_replace("\r", "", $configuration);
 		$configuration = str_replace("\n", "", $configuration);
-		
+
 		return $configuration;
     }
 }

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -53,14 +56,14 @@ class Zend_Service_WindowsAzure_Storage
 	const URL_DEV_BLOB      = "127.0.0.1:10000";
 	const URL_DEV_QUEUE     = "127.0.0.1:10001";
 	const URL_DEV_TABLE     = "127.0.0.1:10002";
-	
+
 	/**
 	 * Live storage URLS
 	 */
 	const URL_CLOUD_BLOB    = "blob.core.windows.net";
 	const URL_CLOUD_QUEUE   = "queue.core.windows.net";
 	const URL_CLOUD_TABLE   = "table.core.windows.net";
-	
+
 	/**
 	 * Resource types
 	 */
@@ -70,98 +73,98 @@ class Zend_Service_WindowsAzure_Storage
 	const RESOURCE_TABLE       = "t";
 	const RESOURCE_ENTITY      = "e";
 	const RESOURCE_QUEUE       = "q";
-	
+
 	/**
 	 * HTTP header prefixes
 	 */
 	const PREFIX_PROPERTIES      = "x-ms-prop-";
 	const PREFIX_METADATA        = "x-ms-meta-";
 	const PREFIX_STORAGE_HEADER  = "x-ms-";
-	
+
 	/**
 	 * Current API version
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_apiVersion = '2009-09-19';
-	
+
 	/**
 	 * Storage host name
 	 *
 	 * @var string
 	 */
 	protected $_host = '';
-	
+
 	/**
 	 * Account name for Windows Azure
 	 *
 	 * @var string
 	 */
 	protected $_accountName = '';
-	
+
 	/**
 	 * Account key for Windows Azure
 	 *
 	 * @var string
 	 */
 	protected $_accountKey = '';
-	
+
 	/**
 	 * Use path-style URI's
 	 *
 	 * @var boolean
 	 */
 	protected $_usePathStyleUri = false;
-	
+
 	/**
 	 * Zend_Service_WindowsAzure_Credentials_CredentialsAbstract instance
 	 *
 	 * @var Zend_Service_WindowsAzure_Credentials_CredentialsAbstract
 	 */
 	protected $_credentials = null;
-	
+
 	/**
 	 * Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract instance
-	 * 
+	 *
 	 * @var Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract
 	 */
 	protected $_retryPolicy = null;
-	
+
 	/**
 	 * Zend_Http_Client channel used for communication with REST services
-	 * 
+	 *
 	 * @var Zend_Http_Client
 	 */
 	protected $_httpClientChannel = null;
-	
+
 	/**
 	 * Use proxy?
-	 * 
+	 *
 	 * @var boolean
 	 */
 	protected $_useProxy = false;
-	
+
 	/**
 	 * Proxy url
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_proxyUrl = '';
-	
+
 	/**
 	 * Proxy port
-	 * 
+	 *
 	 * @var int
 	 */
 	protected $_proxyPort = 80;
-	
+
 	/**
 	 * Proxy credentials
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $_proxyCredentials = '';
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage instance
 	 *
@@ -169,20 +172,22 @@ class Zend_Service_WindowsAzure_Storage
 	 * @param string $accountName Account name for Windows Azure
 	 * @param string $accountKey Account key for Windows Azure
 	 * @param boolean $usePathStyleUri Use path-style URI's
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy|null Retry policy to use when making requests
 	 */
 	public function __construct(
 		$host = self::URL_DEV_BLOB,
 		$accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT,
 		$accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY,
 		$usePathStyleUri = false,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		$retryPolicy = null
 	) {
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		$this->_host = $host;
 		$this->_accountName = $accountName;
 		$this->_accountKey = $accountKey;
 		$this->_usePathStyleUri = $usePathStyleUri;
-		
+
 		// Using local storage?
 		if (!$this->_usePathStyleUri
 			&& ($this->_host == self::URL_DEV_BLOB
@@ -192,17 +197,17 @@ class Zend_Service_WindowsAzure_Storage
 			// Local storage
 			$this->_usePathStyleUri = true;
 		}
-		
+
 		if (is_null($this->_credentials)) {
 		    $this->_credentials = new Zend_Service_WindowsAzure_Credentials_SharedKey(
 		    	$this->_accountName, $this->_accountKey, $this->_usePathStyleUri);
 		}
-		
+
 		$this->_retryPolicy = $retryPolicy;
 		if (is_null($this->_retryPolicy)) {
 		    $this->_retryPolicy = Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract::noRetry();
 		}
-		
+
 		// Setup default Zend_Http_Client channel
 		$options = array(
 			'adapter' => 'Zend_Http_Client_Adapter_Proxy'
@@ -216,43 +221,45 @@ class Zend_Service_WindowsAzure_Storage
 		}
 		$this->_httpClientChannel = new Zend_Http_Client(null, $options);
 	}
-	
+
 	/**
 	 * Set the HTTP client channel to use
-	 * 
+	 *
 	 * @param Zend_Http_Client_Adapter_Interface|string $adapterInstance Adapter instance or adapter class name.
 	 */
 	public function setHttpClientChannel($adapterInstance = 'Zend_Http_Client_Adapter_Proxy')
 	{
 		$this->_httpClientChannel->setAdapter($adapterInstance);
 	}
-	
+
     /**
      * Retrieve HTTP client channel
-     * 
+     *
      * @return Zend_Http_Client_Adapter_Interface
      */
     public function getHttpClientChannel()
     {
         return $this->_httpClientChannel;
     }
-	
+
 	/**
 	 * Set retry policy to use when making requests
 	 *
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 */
-	public function setRetryPolicy(Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function setRetryPolicy($retryPolicy = null)
 	{
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		$this->_retryPolicy = $retryPolicy;
 		if (is_null($this->_retryPolicy)) {
 		    $this->_retryPolicy = Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract::noRetry();
 		}
 	}
-	
+
 	/**
 	 * Set proxy
-	 * 
+	 *
 	 * @param boolean $useProxy         Use proxy?
 	 * @param string  $proxyUrl         Proxy URL
 	 * @param int     $proxyPort        Proxy port
@@ -264,10 +271,10 @@ class Zend_Service_WindowsAzure_Storage
 	    $this->_proxyUrl         = $proxyUrl;
 	    $this->_proxyPort        = $proxyPort;
 	    $this->_proxyCredentials = $proxyCredentials;
-	    
+
 	    if ($this->_useProxy) {
 	    	$credentials = explode(':', $this->_proxyCredentials);
-	    	
+
 	    	$this->_httpClientChannel->setConfig(array(
 				'proxy_host' => $this->_proxyUrl,
 	    		'proxy_port' => $this->_proxyPort,
@@ -283,17 +290,17 @@ class Zend_Service_WindowsAzure_Storage
 	    	));
 	    }
 	}
-	
+
 	/**
 	 * Returns the Windows Azure account name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountName()
 	{
 		return $this->_accountName;
 	}
-	
+
 	/**
 	 * Get base URL for creating requests
 	 *
@@ -307,10 +314,10 @@ class Zend_Service_WindowsAzure_Storage
 			return 'http://' . $this->_accountName . '.' . $this->_host;
 		}
 	}
-	
+
 	/**
 	 * Set Zend_Service_WindowsAzure_Credentials_CredentialsAbstract instance
-	 * 
+	 *
 	 * @param Zend_Service_WindowsAzure_Credentials_CredentialsAbstract $credentials Zend_Service_WindowsAzure_Credentials_CredentialsAbstract instance to use for request signing.
 	 */
 	public function setCredentials(Zend_Service_WindowsAzure_Credentials_CredentialsAbstract $credentials)
@@ -320,17 +327,17 @@ class Zend_Service_WindowsAzure_Storage
 	    $this->_credentials->setAccountkey($this->_accountKey);
 	    $this->_credentials->setUsePathStyleUri($this->_usePathStyleUri);
 	}
-	
+
 	/**
 	 * Get Zend_Service_WindowsAzure_Credentials_CredentialsAbstract instance
-	 * 
+	 *
 	 * @return Zend_Service_WindowsAzure_Credentials_CredentialsAbstract
 	 */
 	public function getCredentials()
 	{
 	    return $this->_credentials;
 	}
-	
+
 	/**
 	 * Perform request using Zend_Http_Client channel
 	 *
@@ -358,12 +365,12 @@ class Zend_Service_WindowsAzure_Storage
 		if (strpos($path, '/') !== 0) {
 			$path = '/' . $path;
 		}
-			
+
 		// Clean headers
 		if (is_null($headers)) {
 		    $headers = array();
 		}
-		
+
 		// Ensure cUrl will also work correctly:
 		//  - disable Content-Type if required
 		//  - disable Expect: 100 Continue
@@ -374,7 +381,7 @@ class Zend_Service_WindowsAzure_Storage
 
 		// Add version header
 		$headers['x-ms-version'] = $this->_apiVersion;
-		    
+
 		// URL encoding
 		$path           = self::urlencode($path);
 		$queryString    = self::urlencode($queryString);
@@ -385,55 +392,57 @@ class Zend_Service_WindowsAzure_Storage
 		$requestHeaders = $this->_credentials
 						  ->signRequestHeaders($httpVerb, $path, $queryString, $headers, $forTableStorage, $resourceType, $requiredPermission, $rawData);
 
-		// Prepare request 
+		// Prepare request
 		$this->_httpClientChannel->resetParameters(true);
 		$this->_httpClientChannel->setUri($requestUrl);
 		$this->_httpClientChannel->setHeaders($requestHeaders);
 		$this->_httpClientChannel->setRawData($rawData);
-				
+
 		// Execute request
 		$response = $this->_retryPolicy->execute(
 		    array($this->_httpClientChannel, 'request'),
 		    array($httpVerb)
 		);
-		
+
 		return $response;
 	}
-	
-	/** 
+
+	/**
 	 * Parse result from Zend_Http_Response
 	 *
-	 * @param Zend_Http_Response $response Response from HTTP call
+	 * @param Zend_Http_Response|null $response Response from HTTP call
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse($response = null)
 	{
+	    Types::isNullable('response', $response, 'Zend_Http_Response');
+
 		if (is_null($response)) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Response should not be null.');
 		}
-		
+
         $xml = Zend_Xml_Security::scan($response->getBody());
-        
+
         if ($xml !== false) {
-            // Fetch all namespaces 
-            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true)); 
-            
+            // Fetch all namespaces
+            $namespaces = array_merge($xml->getNamespaces(true), $xml->getDocNamespaces(true));
+
             // Register all namespace prefixes
-            foreach ($namespaces as $prefix => $ns) { 
+            foreach ($namespaces as $prefix => $ns) {
                 if ($prefix != '') {
                     $xml->registerXPathNamespace($prefix, $ns);
-                } 
-            } 
+                }
+            }
         }
-        
+
         return $xml;
 	}
-	
+
 	/**
 	 * Generate metadata headers
-	 * 
+	 *
 	 * @param array $metadata
 	 * @return HTTP headers containing metadata
 	 */
@@ -443,7 +452,7 @@ class Zend_Service_WindowsAzure_Storage
 		if (!is_array($metadata)) {
 			return array();
 		}
-		
+
 		// Return headers
 		$headers = array();
 		foreach ($metadata as $key => $value) {
@@ -451,20 +460,20 @@ class Zend_Service_WindowsAzure_Storage
                             // require_once 'Zend/Service/WindowsAzure/Exception.php';
                             throw new Zend_Service_WindowsAzure_Exception('Metadata cannot contain newline characters.');
 			}
-			
+
 			if (!self::isValidMetadataName($key)) {
                             // require_once 'Zend/Service/WindowsAzure/Exception.php';
                             throw new Zend_Service_WindowsAzure_Exception('Metadata name does not adhere to metadata naming conventions. See http://msdn.microsoft.com/en-us/library/aa664670(VS.71).aspx for more information.');
 			}
-			
+
 		    $headers["x-ms-meta-" . strtolower($key)] = $value;
 		}
 		return $headers;
 	}
-	
+
 	/**
 	 * Parse metadata headers
-	 * 
+	 *
 	 * @param array $headers HTTP headers containing metadata
 	 * @return array
 	 */
@@ -474,7 +483,7 @@ class Zend_Service_WindowsAzure_Storage
 		if (!is_array($headers)) {
 			return array();
 		}
-		
+
 		// Return metadata
 		$metadata = array();
 		foreach ($headers as $key => $value) {
@@ -484,10 +493,10 @@ class Zend_Service_WindowsAzure_Storage
 		}
 		return $metadata;
 	}
-	
+
 	/**
 	 * Parse metadata XML
-	 * 
+	 *
 	 * @param SimpleXMLElement $parentElement Element containing the Metadata element.
 	 * @return array
 	 */
@@ -500,30 +509,30 @@ class Zend_Service_WindowsAzure_Storage
 
 		return array();
 	}
-	
+
 	/**
 	 * Generate ISO 8601 compliant date string in UTC time zone
-	 * 
+	 *
 	 * @param int $timestamp
 	 * @return string
 	 */
-	public function isoDate($timestamp = null) 
-	{        
+	public function isoDate($timestamp = null)
+	{
 	    $tz = @date_default_timezone_get();
 	    @date_default_timezone_set('UTC');
-	    
+
 	    if (is_null($timestamp)) {
 	        $timestamp = time();
 	    }
-	        
+
 	    $returnValue = str_replace('+00:00', '.0000000Z', @date('c', $timestamp));
 	    @date_default_timezone_set($tz);
 	    return $returnValue;
 	}
-	
+
 	/**
 	 * URL encode function
-	 * 
+	 *
 	 * @param  string $value Value to encode
 	 * @return string        Encoded value
 	 */
@@ -531,7 +540,7 @@ class Zend_Service_WindowsAzure_Storage
 	{
 	    return str_replace(' ', '%20', $value);
 	}
-	
+
 	/**
 	 * Is valid metadata name?
 	 *
@@ -543,22 +552,22 @@ class Zend_Service_WindowsAzure_Storage
         if (preg_match("/^[a-zA-Z0-9_@][a-zA-Z0-9_]*$/", $metadataName) === 0) {
             return false;
         }
-    
+
         if ($metadataName == '') {
             return false;
         }
 
         return true;
     }
-    
+
     /**
      * Builds a query string from an array of elements
-     * 
+     *
      * @param array     Array of elements
      * @return string   Assembled query string
      */
     public static function createQueryStringFromArray($queryString)
     {
     	return count($queryString) > 0 ? '?' . implode('&', $queryString) : '';
-    }	
+    }
 }

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -29,54 +32,56 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
 class Zend_Service_WindowsAzure_Storage_Batch
-{	
+{
     /**
      * Storage client the batch is defined on
-     * 
+     *
      * @var Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
      */
     protected $_storageClient = null;
-    
+
     /**
      * For table storage?
-     * 
+     *
      * @var boolean
      */
     protected $_forTableStorage = false;
-    
+
     /**
      * Base URL
-     * 
+     *
      * @var string
      */
     protected $_baseUrl;
-    
+
     /**
      * Pending operations
-     * 
+     *
      * @var unknown_type
      */
     protected $_operations = array();
-    
+
     /**
      * Does the batch contain a single select?
-     * 
+     *
      * @var boolean
      */
     protected $_isSingleSelect = false;
-    
+
     /**
      * Creates a new Zend_Service_WindowsAzure_Storage_Batch
-     * 
-     * @param Zend_Service_WindowsAzure_Storage_BatchStorageAbstract $storageClient Storage client the batch is defined on
+     *
+     * @param Zend_Service_WindowsAzure_Storage_BatchStorageAbstract|null $storageClient Storage client the batch is defined on
      */
-    public function __construct(Zend_Service_WindowsAzure_Storage_BatchStorageAbstract $storageClient = null, $baseUrl = '')
+    public function __construct($storageClient = null, $baseUrl = '')
     {
+        Types::isNullable('storageClient', $storageClient, 'Zend_Service_WindowsAzure_Storage_BatchStorageAbstract');
+
         $this->_storageClient = $storageClient;
         $this->_baseUrl       = $baseUrl;
         $this->_beginBatch();
     }
-    
+
 	/**
 	 * Get base URL for creating requests
 	 *
@@ -86,17 +91,17 @@ class Zend_Service_WindowsAzure_Storage_Batch
 	{
 		return $this->_baseUrl;
 	}
-    
+
     /**
      * Starts a new batch operation set
-     * 
+     *
      * @throws Zend_Service_WindowsAzure_Exception
      */
     protected function _beginBatch()
     {
         $this->_storageClient->setCurrentBatch($this);
     }
-    
+
     /**
      * Cleanup current batch
      */
@@ -124,7 +129,7 @@ class Zend_Service_WindowsAzure_Storage_Batch
 	    if ($forTableStorage) {
 	        $this->_forTableStorage = true;
 	    }
-	    
+
 	    // Set _isSingleSelect
 	    if ($httpVerb == Zend_Http_Client::GET) {
 	        if (count($this->_operations) > 0) {
@@ -133,29 +138,29 @@ class Zend_Service_WindowsAzure_Storage_Batch
 	        }
 	        $this->_isSingleSelect = true;
 	    }
-	    
+
 	    // Clean path
 		if (strpos($path, '/') !== 0) {
 			$path = '/' . $path;
 		}
-			
+
 		// Clean headers
 		if (is_null($headers)) {
 		    $headers = array();
 		}
-		    
+
 		// URL encoding
 		$path           = Zend_Service_WindowsAzure_Storage::urlencode($path);
 		$queryString    = Zend_Service_WindowsAzure_Storage::urlencode($queryString);
 
 		// Generate URL
 		$requestUrl     = $this->getBaseUrl() . $path . $queryString;
-		
+
 		// Generate $rawData
 		if (is_null($rawData)) {
 		    $rawData = '';
 		}
-		    
+
 		// Add headers
 		if ($httpVerb != Zend_Http_Client::GET) {
     		$headers['Content-ID'] = count($this->_operations) + 1;
@@ -164,7 +169,7 @@ class Zend_Service_WindowsAzure_Storage_Batch
     		}
     		$headers['Content-Length'] = strlen($rawData);
 		}
-		    
+
 		// Generate $operation
 		$operation = '';
 		$operation .= $httpVerb . ' ' . $requestUrl . ' HTTP/1.1' . "\n";
@@ -173,42 +178,42 @@ class Zend_Service_WindowsAzure_Storage_Batch
 		    $operation .= $key . ': ' . $value . "\n";
 		}
 		$operation .= "\n";
-		
+
 		// Add data
 		$operation .= $rawData;
 
 		// Store operation
-		$this->_operations[] = $operation;	        
+		$this->_operations[] = $operation;
 	}
-    
+
     /**
      * Commit current batch
-     * 
+     *
      * @return Zend_Http_Response
      * @throws Zend_Service_WindowsAzure_Exception
      */
     public function commit()
-    {    	
+    {
         // Perform batch
         $response = $this->_storageClient->performBatch($this->_operations, $this->_forTableStorage, $this->_isSingleSelect);
-        
+
         // Dispose
         $this->_clean();
-        
+
         // Parse response
         $errors = null;
         preg_match_all('/<message (.*)>(.*)<\/message>/', $response->getBody(), $errors);
-        
+
         // Error?
         if (count($errors[2]) > 0) {
             // require_once 'Zend/Service/WindowsAzure/Exception.php';
             throw new Zend_Service_WindowsAzure_Exception('An error has occured while committing a batch: ' . $errors[2][0]);
         }
-        
+
         // Return
         return $response;
     }
-    
+
     /**
      * Rollback current batch
      */
@@ -217,20 +222,20 @@ class Zend_Service_WindowsAzure_Storage_Batch
         // Dispose
         $this->_clean();
     }
-    
+
     /**
      * Get operation count
-     * 
+     *
      * @return integer
      */
     public function getOperationCount()
     {
         return count($this->_operations);
     }
-    
+
     /**
      * Is single select?
-     * 
+     *
      * @return boolean
      */
     public function isSingleSelect()

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -34,52 +37,54 @@
  */
 abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
     extends Zend_Service_WindowsAzure_Storage
-{	
+{
     /**
      * Current batch
-     * 
+     *
      * @var Zend_Service_WindowsAzure_Storage_Batch
      */
     protected $_currentBatch = null;
-    
+
     /**
      * Set current batch
-     * 
-     * @param Zend_Service_WindowsAzure_Storage_Batch $batch Current batch
+     *
+     * @param Zend_Service_WindowsAzure_Storage_Batch|null $batch Current batch
      * @throws Zend_Service_WindowsAzure_Exception
      */
-    public function setCurrentBatch(Zend_Service_WindowsAzure_Storage_Batch $batch = null)
+    public function setCurrentBatch( $batch = null)
     {
+        Types::isNullable('batch', $batch, 'Zend_Service_WindowsAzure_Storage_Batch');
+
         if (!is_null($batch) && $this->isInBatch()) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
             throw new Zend_Service_WindowsAzure_Exception('Only one batch can be active at a time.');
         }
         $this->_currentBatch = $batch;
     }
-    
+
     /**
      * Get current batch
-     * 
+     *
      * @return Zend_Service_WindowsAzure_Storage_Batch
      */
     public function getCurrentBatch()
     {
         return $this->_currentBatch;
     }
-    
+
     /**
      * Is there a current batch?
-     * 
+     *
      * @return boolean
      */
     public function isInBatch()
     {
         return !is_null($this->_currentBatch);
     }
-    
+
     /**
      * Starts a new batch operation set
-     * 
+     *
      * @return Zend_Service_WindowsAzure_Storage_Batch
      * @throws Zend_Service_WindowsAzure_Exception
      */
@@ -88,7 +93,7 @@ abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
 		// require_once 'Zend/Service/WindowsAzure/Storage/Batch.php';
         return new Zend_Service_WindowsAzure_Storage_Batch($this, $this->getBaseUrl());
     }
-	
+
 	/**
 	 * Perform batch using Zend_Http_Client channel, combining all batch operations into one request
 	 *
@@ -104,42 +109,42 @@ abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
 	    // Generate boundaries
 	    $batchBoundary = 'batch_' . md5(time() . microtime());
 	    $changesetBoundary = 'changeset_' . md5(time() . microtime());
-	    
+
 	    // Set headers
 	    $headers = array();
-	    
+
 		// Add version header
 		$headers['x-ms-version'] = $this->_apiVersion;
-		
+
 		// Add dataservice headers
 		$headers['DataServiceVersion'] = '1.0;NetFx';
 		$headers['MaxDataServiceVersion'] = '1.0;NetFx';
-		
+
 		// Add content-type header
 		$headers['Content-Type'] = 'multipart/mixed; boundary=' . $batchBoundary;
 
 		// Set path and query string
 		$path           = '/$batch';
 		$queryString    = '';
-		
+
 		// Set verb
 		$httpVerb = Zend_Http_Client::POST;
-		
+
 		// Generate raw data
     	$rawData = '';
-    		
+
 		// Single select?
 		if ($isSingleSelect) {
 		    $operation = $operations[0];
 		    $rawData .= '--' . $batchBoundary . "\n";
             $rawData .= 'Content-Type: application/http' . "\n";
             $rawData .= 'Content-Transfer-Encoding: binary' . "\n\n";
-            $rawData .= $operation; 
+            $rawData .= $operation;
             $rawData .= '--' . $batchBoundary . '--';
 		} else {
     		$rawData .= '--' . $batchBoundary . "\n";
     		$rawData .= 'Content-Type: multipart/mixed; boundary=' . $changesetBoundary . "\n\n";
-    		
+
         		// Add operations
         		foreach ($operations as $operation)
         		{
@@ -149,7 +154,7 @@ abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
                 	$rawData .= $operation;
         		}
         		$rawData .= '--' . $changesetBoundary . '--' . "\n";
-    		    		    
+
     		$rawData .= '--' . $batchBoundary . '--';
 		}
 
@@ -162,7 +167,7 @@ abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
 		$this->_httpClientChannel->setUri($requestUrl);
 		$this->_httpClientChannel->setHeaders($requestHeaders);
 		$this->_httpClientChannel->setRawData($rawData);
-		
+
 		// Execute request
 		$response = $this->_retryPolicy->execute(
 		    array($this->_httpClientChannel, 'request'),

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -74,7 +77,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 	 * @deprecated Use ACL_PUBLIC_CONTAINER or ACL_PUBLIC_BLOB instead.
 	 */
 	const ACL_PUBLIC = 'container';
-	
+
 	/**
 	 * ACL - Blob Public access (read all blobs)
 	 */
@@ -136,10 +139,12 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 	 * @param string $accountName Account name for Windows Azure
 	 * @param string $accountKey Account key for Windows Azure
 	 * @param boolean $usePathStyleUri Use path-style URI's
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_BLOB, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_BLOB, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, $retryPolicy = null)
 	{
+        Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
 
 		// API version
@@ -198,7 +203,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Container name does not adhere to container naming conventions. See http://msdn.microsoft.com/en-us/library/dd135715.aspx for more information.');
 		}
-			
+
 		// List containers
 		$containers = $this->listContainers($containerName, 1);
 		foreach ($containers as $container) {
@@ -232,7 +237,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Meta data should be an array of key and value pairs.');
 		}
-			
+
 		// Create metadata headers
 		$headers = array();
 		$headers = array_merge($headers, $this->_generateMetadataHeaders($metadata));
@@ -240,7 +245,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		// Perform request
 		$response = $this->_performRequest($containerName, '?restype=container', Zend_Http_Client::PUT, $headers, false, null, Zend_Service_WindowsAzure_Storage::RESOURCE_CONTAINER, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_WRITE);
 		if ($response->isSuccessful()) {
-			
+
 			return new Zend_Service_WindowsAzure_Storage_BlobContainer(
 			$containerName,
 			$response->getHeader('Etag'),
@@ -252,7 +257,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Create container if it does not exist
 	 *
@@ -510,7 +515,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Container name does not adhere to container naming conventions. See http://msdn.microsoft.com/en-us/library/dd135715.aspx for more information.');
 		}
-			
+
 		// Additional headers?
 		$headers = array();
 		foreach ($additionalHeaders as $key => $value) {
@@ -553,7 +558,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			$queryString[] = 'include=' . $include;
 		}
 		$queryString = self::createQueryStringFromArray($queryString);
-		 
+
 		// Perform request
 		$response = $this->_performRequest('', $queryString, Zend_Http_Client::GET, array(), false, null, Zend_Service_WindowsAzure_Storage::RESOURCE_CONTAINER, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_LIST);
 		if ($response->isSuccessful()) {
@@ -563,7 +568,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			$containers = array();
 			if (!is_null($xmlContainers)) {
 				for ($i = 0; $i < count($xmlContainers); $i++) {
-					
+
 					$containers[] = new Zend_Service_WindowsAzure_Storage_BlobContainer(
 					(string)$xmlContainers[$i]->Name,
 					(string)$xmlContainers[$i]->Etag,
@@ -581,7 +586,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			if (!is_null($maxResults) && count($containers) > $maxResults) {
 				$containers = array_slice($containers, 0, $maxResults);
 			}
-			 
+
 			return $containers;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -627,7 +632,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Blobs stored in the root container can not have a name containing a forward slash (/).');
 		}
-			
+
 		// Check file size
 		if (filesize($localFileName) >= self::MAX_BLOB_SIZE) {
 			return $this->putLargeBlob($containerName, $blobName, $localFileName, $metadata, $leaseId, $additionalHeaders);
@@ -689,7 +694,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		// Perform request
 		$response = $this->_performRequest($resourceName, '', Zend_Http_Client::PUT, $headers, false, $data, Zend_Service_WindowsAzure_Storage::RESOURCE_BLOB, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_WRITE);
 		if ($response->isSuccessful()) {
-			
+
 			return new Zend_Service_WindowsAzure_Storage_BlobInstance(
 			$containerName,
 			$blobName,
@@ -748,12 +753,12 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Blobs stored in the root container can not have a name containing a forward slash (/).');
 		}
-			
+
 		// Check file size
 		if (filesize($localFileName) < self::MAX_BLOB_SIZE) {
 			return $this->putBlob($containerName, $blobName, $localFileName, $metadata, $leaseId, $additionalHeaders);
 		}
-			
+
 		// Determine number of parts
 		$numberOfParts = ceil( filesize($localFileName) / self::MAX_BLOB_TRANSFER_SIZE );
 
@@ -769,18 +774,18 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Could not open local file.');
 		}
-			
+
 		// Upload parts
 		for ($i = 0; $i < $numberOfParts; $i++) {
 			// Seek position in file
 			fseek($fp, $i * self::MAX_BLOB_TRANSFER_SIZE);
-				
+
 			// Read contents
 			$fileContents = fread($fp, self::MAX_BLOB_TRANSFER_SIZE);
-				
+
 			// Put block
 			$this->putBlock($containerName, $blobName, $blockIdentifiers[$i], $fileContents, $leaseId);
-				
+
 			// Dispose file contents
 			$fileContents = null;
 			unset($fileContents);
@@ -795,7 +800,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		// Return information of the blob
 		return $this->getBlobInstance($containerName, $blobName, null, $leaseId);
 	}
-		
+
 	/**
 	 * Put large blob block
 	 *
@@ -834,7 +839,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		if (!is_null($leaseId)) {
 			$headers['x-ms-lease-id'] = $leaseId;
 		}
-			
+
 		// Resource name
 		$resourceName = self::createResourceName($containerName , $blobName);
 
@@ -971,7 +976,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 
 		// Resource name
 		$resourceName = self::createResourceName($containerName , $blobName);
-			
+
 		// Perform request
 		$response = $this->_performRequest($resourceName, $queryString, Zend_Http_Client::GET, $headers, false, null, Zend_Service_WindowsAzure_Storage::RESOURCE_BLOB, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_READ);
 		if ($response->isSuccessful()) {
@@ -1062,7 +1067,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		// Perform request
 		$response = $this->_performRequest($resourceName, '', Zend_Http_Client::PUT, $headers, false, '', Zend_Service_WindowsAzure_Storage::RESOURCE_BLOB, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_WRITE);
 		if ($response->isSuccessful()) {
-			
+
 			return new Zend_Service_WindowsAzure_Storage_BlobInstance(
 			$containerName,
 			$blobName,
@@ -1220,24 +1225,24 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			} else {
 				$xmlRanges = array($result->PageRange);
 			}
-			
-			
+
+
 			$ranges = array();
-			
+
 			for ($i = 0; $i < count($xmlRanges); $i++) {
 				$ranges[] = new Zend_Service_WindowsAzure_Storage_PageRegionInstance(
 				(int)$xmlRanges[$i]->Start,
 				(int)$xmlRanges[$i]->End
 				);
 			}
-			 
+
 			return $ranges;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-		
+
 	/**
 	 * Copy blob
 	 *
@@ -1312,7 +1317,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		// Perform request
 		$response = $this->_performRequest($destinationResourceName, '', Zend_Http_Client::PUT, $headers, false, null, Zend_Service_WindowsAzure_Storage::RESOURCE_BLOB, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_WRITE);
 		if ($response->isSuccessful()) {
-			
+
 			return new Zend_Service_WindowsAzure_Storage_BlobInstance(
 			$destinationContainerName,
 			$destinationBlobName,
@@ -1458,7 +1463,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			$queryString[] = 'snapshot=' . $snapshotId;
 		}
 		$queryString = self::createQueryStringFromArray($queryString);
-		 
+
 		// Additional headers?
 		$headers = array();
 		if (!is_null($leaseId)) {
@@ -1476,7 +1481,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		if ($response->isSuccessful()) {
 			// Parse metadata
 			$metadata = $this->_parseMetadataHeaders($response->getHeaders());
-			
+
 			// Return blob
 			return new Zend_Service_WindowsAzure_Storage_BlobInstance(
 				$containerName,
@@ -1709,7 +1714,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			$queryString[] = 'snapshot=' . $snapshotId;
 		}
 		$queryString = self::createQueryStringFromArray($queryString);
-			
+
 		// Additional headers?
 		$headers = array();
 		if (!is_null($leaseId)) {
@@ -1819,9 +1824,9 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 
 		// Perform request
 		$response = $this->_performRequest($resourceName, '?comp=lease', Zend_Http_Client::PUT, $headers, false, null, Zend_Service_WindowsAzure_Storage::RESOURCE_BLOB, Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::PERMISSION_WRITE);
-		
-		
-		
+
+
+
 		if ($response->isSuccessful()) {
 			return new Zend_Service_WindowsAzure_Storage_LeaseInstance(
 			$containerName,
@@ -1857,7 +1862,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Container name does not adhere to container naming conventions. See http://msdn.microsoft.com/en-us/library/dd135715.aspx for more information.');
 		}
-			
+
 		// Build query string
 		$queryString = array('restype=container', 'comp=list');
 		if (!is_null($prefix)) {
@@ -1882,14 +1887,14 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		if ($response->isSuccessful()) {
 			// Return value
 			$blobs = array();
-	
+
 			// Blobs
 			$xmlBlobs = $this->_parseResponse($response)->Blobs->Blob;
 			if (!is_null($xmlBlobs)) {
-				
+
 				for ($i = 0; $i < count($xmlBlobs); $i++) {
 					$properties = (array)$xmlBlobs[$i]->Properties;
-						
+
 					$blobs[] = new Zend_Service_WindowsAzure_Storage_BlobInstance(
 					$containerName,
 					(string)$xmlBlobs[$i]->Name,
@@ -1909,12 +1914,12 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 					);
 				}
 			}
-				
+
 			// Blob prefixes (folders)
 			$xmlBlobs = $this->_parseResponse($response)->Blobs->BlobPrefix;
-				
+
 			if (!is_null($xmlBlobs)) {
-				
+
 				for ($i = 0; $i < count($xmlBlobs); $i++) {
 					$blobs[] = new Zend_Service_WindowsAzure_Storage_BlobInstance(
 					$containerName,
@@ -1935,7 +1940,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 					);
 				}
 			}
-				
+
 			// More blobs?
 			$xmlMarker = (string)$this->_parseResponse($response)->NextMarker;
 			$currentResultCount = $currentResultCount + count($blobs);
@@ -1947,7 +1952,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 			if (!is_null($maxResults) && count($blobs) > $maxResults) {
 				$blobs = array_slice($blobs, 0, $maxResults);
 			}
-				
+
 			return $blobs;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -48,12 +51,12 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	 * Maximal message size (in bytes)
 	 */
 	const MAX_MESSAGE_SIZE = 8388608;
-	
+
 	/**
 	 * Maximal message ttl (in seconds)
 	 */
 	const MAX_MESSAGE_TTL = 604800;
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage_Queue instance
 	 *
@@ -61,19 +64,21 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	 * @param string $accountName Account name for Windows Azure
 	 * @param string $accountKey Account key for Windows Azure
 	 * @param boolean $usePathStyleUri Use path-style URI's
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy|null Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_QUEUE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_QUEUE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, $retryPolicy = null)
 	{
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
-		
+
 		// API version
 		$this->_apiVersion = '2009-09-19';
 	}
-	
+
 	/**
 	 * Check if a queue exists
-	 * 
+	 *
 	 * @param string $queueName Queue name
 	 * @return boolean
 	 */
@@ -87,7 +92,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Queue name does not adhere to queue naming conventions. See http://msdn.microsoft.com/en-us/library/dd179349.aspx for more information.');
 		}
-			
+
 		// List queues
         $queues = $this->listQueues($queueName, 1);
         foreach ($queues as $queue) {
@@ -95,10 +100,10 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
                 return true;
             }
         }
-        
+
         return false;
 	}
-	
+
 	/**
 	 * Create queue
 	 *
@@ -117,15 +122,15 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Queue name does not adhere to queue naming conventions. See http://msdn.microsoft.com/en-us/library/dd179349.aspx for more information.');
 		}
-			
+
 		// Create metadata headers
 		$headers = array();
-		$headers = array_merge($headers, $this->_generateMetadataHeaders($metadata)); 
-		
+		$headers = array_merge($headers, $this->_generateMetadataHeaders($metadata));
+
 		// Perform request
-		$response = $this->_performRequest($queueName, '', Zend_Http_Client::PUT, $headers);	
+		$response = $this->_performRequest($queueName, '', Zend_Http_Client::PUT, $headers);
 		if ($response->isSuccessful()) {
-			
+
 		    return new Zend_Service_WindowsAzure_Storage_QueueInstance(
 		        $queueName,
 		        $metadata
@@ -135,7 +140,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Create queue if it does not exist
 	 *
@@ -149,10 +154,10 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			$this->createQueue($queueName, $metadata);
 		}
 	}
-	
+
 	/**
 	 * Get queue
-	 * 
+	 *
 	 * @param string $queueName  Queue name
 	 * @return Zend_Service_WindowsAzure_Storage_QueueInstance
 	 * @throws Zend_Service_WindowsAzure_Exception
@@ -167,13 +172,13 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Queue name does not adhere to queue naming conventions. See http://msdn.microsoft.com/en-us/library/dd179349.aspx for more information.');
 		}
-		    
+
 		// Perform request
-		$response = $this->_performRequest($queueName, '?comp=metadata', Zend_Http_Client::GET);	
+		$response = $this->_performRequest($queueName, '?comp=metadata', Zend_Http_Client::GET);
 		if ($response->isSuccessful()) {
 		    // Parse metadata
 		    $metadata = $this->_parseMetadataHeaders($response->getHeaders());
-			
+
 		    // Return queue
 		    $queue = new Zend_Service_WindowsAzure_Storage_QueueInstance(
 		        $queueName,
@@ -186,10 +191,10 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 		    throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Get queue metadata
-	 * 
+	 *
 	 * @param string $queueName  Queue name
 	 * @return array Key/value pairs of meta data
 	 * @throws Zend_Service_WindowsAzure_Exception
@@ -204,13 +209,13 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Queue name does not adhere to queue naming conventions. See http://msdn.microsoft.com/en-us/library/dd179349.aspx for more information.');
 		}
-			
+
 	    return $this->getQueue($queueName)->Metadata;
 	}
-	
+
 	/**
 	 * Set queue metadata
-	 * 
+	 *
 	 * Calling the Set Queue Metadata operation overwrites all existing metadata that is associated with the queue. It's not possible to modify an individual name/value pair.
 	 *
 	 * @param string $queueName  Queue name
@@ -230,11 +235,11 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 		if (count($metadata) == 0) {
 		    return;
 		}
-		    
+
 		// Create metadata headers
 		$headers = array();
-		$headers = array_merge($headers, $this->_generateMetadataHeaders($metadata)); 
-		
+		$headers = array_merge($headers, $this->_generateMetadataHeaders($metadata));
+
 		// Perform request
 		$response = $this->_performRequest($queueName, '?comp=metadata', Zend_Http_Client::PUT, $headers);
 
@@ -243,7 +248,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Delete queue
 	 *
@@ -260,7 +265,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Queue name does not adhere to queue naming conventions. See http://msdn.microsoft.com/en-us/library/dd179349.aspx for more information.');
 		}
-			
+
 		// Perform request
 		$response = $this->_performRequest($queueName, '', Zend_Http_Client::DELETE);
 		if (!$response->isSuccessful()) {
@@ -268,7 +273,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * List queues
 	 *
@@ -297,16 +302,16 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	        $queryString[] = 'include=' . $include;
 	    }
 	    $queryString = self::createQueryStringFromArray($queryString);
-	        
+
 		// Perform request
-		$response = $this->_performRequest('', $queryString, Zend_Http_Client::GET);	
+		$response = $this->_performRequest('', $queryString, Zend_Http_Client::GET);
 		if ($response->isSuccessful()) {
 			$xmlQueues = $this->_parseResponse($response)->Queues->Queue;
 			$xmlMarker = (string)$this->_parseResponse($response)->NextMarker;
 
 			$queues = array();
 			if (!is_null($xmlQueues)) {
-				
+
 				for ($i = 0; $i < count($xmlQueues); $i++) {
 					$queues[] = new Zend_Service_WindowsAzure_Storage_QueueInstance(
 						(string)$xmlQueues[$i]->Name,
@@ -323,14 +328,14 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			if (!is_null($maxResults) && count($queues) > $maxResults) {
 			    $queues = array_slice($queues, 0, $maxResults);
 			}
-			    
+
 			return $queues;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Put message into queue
 	 *
@@ -361,20 +366,20 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Message TTL is invalid. Maximal TTL is 7 days (' . self::MAX_MESSAGE_SIZE . ' seconds) and should be greater than zero.');
 		}
-		    
+
 	    // Build query string
 		$queryString = array();
         if (!is_null($ttl)) {
 	        $queryString[] = 'messagettl=' . $ttl;
         }
 	    $queryString = self::createQueryStringFromArray($queryString);
-	        
+
 	    // Build body
 	    $rawData = '';
 	    $rawData .= '<QueueMessage>';
 	    $rawData .= '    <MessageText>' . base64_encode($message) . '</MessageText>';
 	    $rawData .= '</QueueMessage>';
-	        
+
 		// Perform request
 		$response = $this->_performRequest($queueName . '/messages', $queryString, Zend_Http_Client::POST, array(), false, $rawData);
 
@@ -383,7 +388,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			throw new Zend_Service_WindowsAzure_Exception('Error putting message into queue.');
 		}
 	}
-	
+
 	/**
 	 * Get queue messages
 	 *
@@ -412,7 +417,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Visibility timeout is invalid. Maximum value is 2 hours (7200 seconds) and should be greater than zero.');
 		}
-		    
+
 	    // Build query string
 		$queryString = array();
     	if ($peek) {
@@ -423,11 +428,11 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
     	}
     	if (!$peek && !is_null($visibilityTimeout)) {
 	        $queryString[] = 'visibilitytimeout=' . $visibilityTimeout;
-    	}   
+    	}
 	    $queryString = self::createQueryStringFromArray($queryString);
-	        
+
 		// Perform request
-		$response = $this->_performRequest($queueName . '/messages', $queryString, Zend_Http_Client::GET);	
+		$response = $this->_performRequest($queueName . '/messages', $queryString, Zend_Http_Client::GET);
 		if ($response->isSuccessful()) {
 		    // Parse results
 			$result = $this->_parseResponse($response);
@@ -441,7 +446,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
     		} else {
     		    $xmlMessages = array($result->QueueMessage);
     		}
-			
+
 			$messages = array();
 			for ($i = 0; $i < count($xmlMessages); $i++) {
 				$messages[] = new Zend_Service_WindowsAzure_Storage_QueueMessage(
@@ -454,14 +459,14 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 					base64_decode((string)$xmlMessages[$i]->MessageText)
 			    );
 			}
-			    
+
 			return $messages;
 		} else {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Peek queue messages
 	 *
@@ -474,7 +479,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	{
 	    return $this->getMessages($queueName, $numOfMessages, null, true);
 	}
-	
+
 	/**
 	 * Checks to see if a given queue has messages
 	 *
@@ -486,7 +491,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	{
 		return count($this->peekMessages($queueName)) > 0;
 	}
-	
+
 	/**
 	 * Clear queue messages
 	 *
@@ -505,13 +510,13 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 		}
 
 		// Perform request
-		$response = $this->_performRequest($queueName . '/messages', '', Zend_Http_Client::DELETE);	
+		$response = $this->_performRequest($queueName . '/messages', '', Zend_Http_Client::DELETE);
 		if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Error clearing messages from queue.');
 		}
 	}
-	
+
 	/**
 	 * Delete queue message
 	 *
@@ -535,13 +540,13 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 		}
 
 		// Perform request
-		$response = $this->_performRequest($queueName . '/messages/' . $message->MessageId, '?popreceipt=' . urlencode($message->PopReceipt), Zend_Http_Client::DELETE);	
+		$response = $this->_performRequest($queueName . '/messages/' . $message->MessageId, '?popreceipt=' . urlencode($message->PopReceipt), Zend_Http_Client::DELETE);
 		if (!$response->isSuccessful()) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Is valid queue name?
 	 *
@@ -553,29 +558,29 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
         if (preg_match("/^[a-z0-9][a-z0-9-]*$/", $queueName) === 0) {
             return false;
         }
-    
+
         if (strpos($queueName, '--') !== false) {
             return false;
         }
-    
+
         if (strtolower($queueName) != $queueName) {
             return false;
         }
-    
+
         if (strlen($queueName) < 3 || strlen($queueName) > 63) {
             return false;
         }
-            
+
         if (substr($queueName, -1) == '-') {
             return false;
         }
-    
+
         return true;
     }
-    
+
 	/**
 	 * Get error message from Zend_Http_Response
-	 * 
+	 *
 	 * @param Zend_Http_Response $response Repsonse
 	 * @param string $alternativeError Alternative error message
 	 * @return string

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Table.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Table.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -41,7 +44,7 @@
 // require_once 'Zend/Service/WindowsAzure/Storage/DynamicTableEntity.php';
 
 /**
- * @see Zend_Service_WindowsAzure_Credentials_SharedKeyLite 
+ * @see Zend_Service_WindowsAzure_Credentials_SharedKeyLite
  */
 // require_once 'Zend/Service/WindowsAzure/Credentials/SharedKeyLite.php';
 
@@ -58,22 +61,22 @@ class Zend_Service_WindowsAzure_Storage_Table
 	/**
 	 * Throw Zend_Service_WindowsAzure_Exception when a property is not specified in Windows Azure?
 	 * Defaults to true, making behaviour similar to Windows Azure StorageClient in .NET.
-	 * 
+	 *
 	 * @var boolean
 	 */
 	protected $_throwExceptionOnMissingData = true;
-	
+
 	/**
 	 * Throw Zend_Service_WindowsAzure_Exception when a property is not specified in Windows Azure?
 	 * Defaults to true, making behaviour similar to Windows Azure StorageClient in .NET.
-	 * 
+	 *
 	 * @param boolean $value
 	 */
 	public function setThrowExceptionOnMissingData($value = true)
 	{
 		$this->_throwExceptionOnMissingData = $value;
 	}
-	
+
 	/**
 	 * Throw Zend_Service_WindowsAzure_Exception when a property is not specified in Windows Azure?
 	 */
@@ -81,7 +84,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	{
 		return $this->_throwExceptionOnMissingData;
 	}
-	
+
 	/**
 	 * Creates a new Zend_Service_WindowsAzure_Storage_Table instance
 	 *
@@ -89,22 +92,24 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param string $accountName Account name for Windows Azure
 	 * @param string $accountKey Account key for Windows Azure
 	 * @param boolean $usePathStyleUri Use path-style URI's
-	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
+	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract|null $retryPolicy Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_TABLE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_TABLE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, $retryPolicy = null)
 	{
+	    Types::isNullable('retryPolicy', $retryPolicy, 'Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract');
+
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
 
 	    // Always use SharedKeyLite authentication
 	    $this->_credentials = new Zend_Service_WindowsAzure_Credentials_SharedKeyLite($accountName, $accountKey, $this->_usePathStyleUri);
-	    
+
 	    // API version
 		$this->_apiVersion = '2009-09-19';
 	}
-	
+
 	/**
 	 * Check if a table exists
-	 * 
+	 *
 	 * @param string $tableName Table name
 	 * @return boolean
 	 */
@@ -114,7 +119,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Table name is not specified.');
 		}
-			
+
 		// List tables
         $tables = $this->listTables(); // 2009-09-19 does not support $this->listTables($tableName); all of a sudden...
         foreach ($tables as $table) {
@@ -122,10 +127,10 @@ class Zend_Service_WindowsAzure_Storage_Table
                 return true;
             }
         }
-        
+
         return false;
 	}
-	
+
 	/**
 	 * List tables
 	 *
@@ -141,17 +146,17 @@ class Zend_Service_WindowsAzure_Storage_Table
 	        $queryString[] = 'NextTableName=' . $nextTableName;
 	    }
 	    $queryString = self::createQueryStringFromArray($queryString);
-	    
+
 		// Perform request
 		$response = $this->_performRequest('Tables', $queryString, Zend_Http_Client::GET, null, true);
-		if ($response->isSuccessful()) {	    
+		if ($response->isSuccessful()) {
 		    // Parse result
-		    $result = $this->_parseResponse($response);	
-		    
+		    $result = $this->_parseResponse($response);
+
 		    if (!$result || !$result->entry) {
 		        return array();
 		    }
-	        
+
 		    $entries = null;
 		    if (count($result->entry) > 1) {
 		        $entries = $result->entry;
@@ -160,11 +165,11 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    }
 
 		    // Create return value
-		    $returnValue = array();		    
+		    $returnValue = array();
 		    foreach ($entries as $entry) {
 		        $tableName = $entry->xpath('.//m:properties/d:TableName');
 		        $tableName = (string)$tableName[0];
-		        
+
 		        $returnValue[] = new Zend_Service_WindowsAzure_Storage_TableInstance(
 		            (string)$entry->id,
 		            $tableName,
@@ -172,7 +177,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 		            (string)$entry->updated
 		        );
 		    }
-		    
+
 			// More tables?
 		    if (!is_null($response->getHeader('x-ms-continuation-NextTableName'))) {
 				// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -184,7 +189,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Create table
 	 *
@@ -197,7 +202,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 		if ($tableName === '') {
 			throw new Zend_Service_WindowsAzure_Exception('Table name is not specified.');
 		}
-			
+
 		// Generate request body
 		$requestBody = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>
                         <entry
@@ -216,30 +221,30 @@ class Zend_Service_WindowsAzure_Storage_Table
                             </m:properties>
                           </content>
                         </entry>';
-		
+
         $requestBody = $this->_fillTemplate($requestBody, array(
             'BaseUrl' => $this->getBaseUrl(),
             'TableName' => htmlspecialchars($tableName),
         	'Updated' => $this->isoDate(),
             'AccountName' => $this->_accountName
         ));
-        
+
         // Add header information
         $headers = array();
         $headers['Content-Type'] = 'application/atom+xml';
         $headers['DataServiceVersion'] = '1.0;NetFx';
-        $headers['MaxDataServiceVersion'] = '1.0;NetFx';        
+        $headers['MaxDataServiceVersion'] = '1.0;NetFx';
 
 		// Perform request
 		$response = $this->_performRequest('Tables', '', Zend_Http_Client::POST, $headers, true, $requestBody);
 		if ($response->isSuccessful()) {
 		    // Parse response
 		    $entry = $this->_parseResponse($response);
-		    
+
 		    $tableName = $entry->xpath('.//m:properties/d:TableName');
 		    $tableName = (string)$tableName[0];
-		        
-			
+
+
 		    return new Zend_Service_WindowsAzure_Storage_TableInstance(
 		        (string)$entry->id,
 		        $tableName,
@@ -251,7 +256,7 @@ class Zend_Service_WindowsAzure_Storage_Table
                     throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Create table if it does not exist
 	 *
@@ -264,7 +269,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			$this->createTable($tableName);
 		}
 	}
-	
+
 	/**
 	 * Delete table
 	 *
@@ -289,17 +294,19 @@ class Zend_Service_WindowsAzure_Storage_Table
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Insert entity into table
-	 * 
+	 *
 	 * @param string                              $tableName   Table name
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity      Entity to insert
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity      Entity to insert
 	 * @return Zend_Service_WindowsAzure_Storage_TableEntity
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function insertEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
+	public function insertEntity($tableName = '', $entity = null)
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Table name is not specified.');
@@ -308,7 +315,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Entity is not specified.');
 		}
-		                     
+
 		// Generate request body
 		$requestBody = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>
                         <entry xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom">
@@ -324,7 +331,7 @@ class Zend_Service_WindowsAzure_Storage_Table
                             </m:properties>
                           </content>
                         </entry>';
-		
+
         $requestBody = $this->_fillTemplate($requestBody, array(
         	'Updated'    => $this->isoDate(),
             'Properties' => $this->_generateAzureRepresentation($entity)
@@ -345,13 +352,13 @@ class Zend_Service_WindowsAzure_Storage_Table
 		if ($response->isSuccessful()) {
 		    // Parse result
 		    $result = $this->_parseResponse($response);
-		    
+
 		    $timestamp = $result->xpath('//m:properties/d:Timestamp');
 		    $timestamp = $this->_convertToDateTime( (string)$timestamp[0] );
 
 		    $etag      = $result->attributes('http://schemas.microsoft.com/ado/2007/08/dataservices/metadata');
 		    $etag      = (string)$etag['etag'];
-		    
+
 		    // Update properties
 		    $entity->setTimestamp($timestamp);
 		    $entity->setEtag($etag);
@@ -362,17 +369,19 @@ class Zend_Service_WindowsAzure_Storage_Table
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Delete entity from table
-	 * 
+	 *
 	 * @param string                              $tableName   Table name
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity      Entity to delete
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity      Entity to delete
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function deleteEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	public function deleteEntity($tableName = '', $entity = null, $verifyEtag = false)
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Table name is not specified.');
@@ -381,7 +390,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Entity is not specified.');
 		}
-		                     
+
         // Add header information
         $headers = array();
         if (!$this->isInBatch()) {
@@ -408,14 +417,14 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Retrieve entity from table, by id
-	 * 
+	 *
 	 * @param string $tableName    Table name
 	 * @param string $partitionKey Partition key
 	 * @param string $rowKey       Row key
-	 * @param string $entityClass  Entity class name* 
+	 * @param string $entityClass  Entity class name*
 	 * @return Zend_Service_WindowsAzure_Storage_TableEntity
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
@@ -438,7 +447,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			throw new Zend_Service_WindowsAzure_Exception('Entity class is not specified.');
 		}
 
-			
+
 		// Check for combined size of partition key and row key
 		// http://msdn.microsoft.com/en-us/library/dd179421.aspx
 		if (strlen($partitionKey . $rowKey) >= 256) {
@@ -447,10 +456,10 @@ class Zend_Service_WindowsAzure_Storage_Table
 				// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		        throw new Zend_Service_WindowsAzure_Exception('Entity cannot be retrieved. A transaction is required to retrieve the entity, but another transaction is already active.');
 		    }
-		        
+
 		    $this->startBatch();
 		}
-		
+
 		// Fetch entities from Azure
         $result = $this->retrieveEntities(
             $this->select()
@@ -460,29 +469,29 @@ class Zend_Service_WindowsAzure_Storage_Table
             '',
             $entityClass
         );
-        
+
         // Return
         if (count($result) == 1) {
             return $result[0];
         }
-        
+
         return null;
 	}
-	
+
 	/**
 	 * Create a new Zend_Service_WindowsAzure_Storage_TableEntityQuery
-	 * 
+	 *
 	 * @return Zend_Service_WindowsAzure_Storage_TableEntityQuery
 	 */
 	public function select()
 	{
-            
+
 	    return new Zend_Service_WindowsAzure_Storage_TableEntityQuery();
 	}
-	
+
 	/**
 	 * Retrieve entities from table
-	 * 
+	 *
 	 * @param string $tableName|Zend_Service_WindowsAzure_Storage_TableEntityQuery    Table name -or- Zend_Service_WindowsAzure_Storage_TableEntityQuery instance
 	 * @param string $filter                                                Filter condition (not applied when $tableName is a Zend_Service_WindowsAzure_Storage_TableEntityQuery instance)
 	 * @param string $entityClass                                           Entity class name
@@ -507,27 +516,27 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    $entityClass = $filter;
 		    $filter = '';
 		}
-			
+
 		// Query string
 		$queryString = '';
 
 		// Determine query
 		if (is_string($tableName)) {
 		    // Option 1: $tableName is a string
-		    
+
 		    // Append parentheses
 		    if (strpos($tableName, '()') === false) {
 		    	$tableName .= '()';
 		    }
-		    
+
     	    // Build query
     	    $query = array();
-    	    
+
     		// Filter?
     		if ($filter !== '') {
     		    $query[] = '$filter=' . Zend_Service_WindowsAzure_Storage_TableEntityQuery::encodeQuery($filter);
     		}
-    		    
+
     	    // Build queryString
     	    if (count($query) > 0)  {
     	        $queryString = '?' . implode('&', $query);
@@ -544,7 +553,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 		    throw new Zend_Service_WindowsAzure_Exception('Invalid argument: $tableName');
 		}
-		
+
 		// Add continuation querystring parameters?
 		if (!is_null($nextPartitionKey) && !is_null($nextRowKey)) {
 		    if ($queryString !== '') {
@@ -552,7 +561,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    } else {
 		    	$queryString .= '?';
 		    }
-		        
+
 		    $queryString .= 'NextPartitionKey=' . rawurlencode($nextPartitionKey) . '&NextRowKey=' . rawurlencode($nextRowKey);
 		}
 
@@ -561,7 +570,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	    if ($this->isInBatch() && $this->getCurrentBatch()->getOperationCount() == 0) {
 		    $this->getCurrentBatch()->enlistOperation($tableName, $queryString, Zend_Http_Client::GET, array(), true, null);
 		    $response = $this->getCurrentBatch()->commit();
-		    
+
 		    // Get inner response (multipart)
 		    $innerResponse = $response->getBody();
 		    $innerResponse = substr($innerResponse, strpos($innerResponse, 'HTTP/1.1 200 OK'));
@@ -596,19 +605,19 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    }
 
 		    // Create return value
-		    $returnValue = array();		    
+		    $returnValue = array();
 		    foreach ($entries as $entry) {
     		    // Parse properties
     		    $properties = $entry->xpath('.//m:properties');
     		    $properties = $properties[0]->children('http://schemas.microsoft.com/ado/2007/08/dataservices');
-    		    
+
     		    // Create entity
     		    $entity = new $entityClass('', '');
     		    $entity->setAzureValues((array)$properties, $this->_throwExceptionOnMissingData);
-    		    
+
     		    // If we have a Zend_Service_WindowsAzure_Storage_DynamicTableEntity, make sure all property types are set
     		    if ($entity instanceof Zend_Service_WindowsAzure_Storage_DynamicTableEntity) {
-    		        foreach ($properties as $key => $value) {  
+    		        foreach ($properties as $key => $value) {
     		            $attributes = $value->attributes('http://schemas.microsoft.com/ado/2007/08/dataservices/metadata');
     		            $type = (string)$attributes['type'];
     		            if ($type !== '') {
@@ -616,12 +625,12 @@ class Zend_Service_WindowsAzure_Storage_Table
     		            }
     		        }
     		    }
-    
+
     		    // Update etag
     		    $etag      = $entry->attributes('http://schemas.microsoft.com/ado/2007/08/dataservices/metadata');
     		    $etag      = (string)$etag['etag'];
     		    $entity->setEtag($etag);
-    		    
+
     		    // Add to result
     		    $returnValue[] = $entity;
 		    }
@@ -632,7 +641,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 		            $returnValue = array_merge($returnValue, $this->retrieveEntities($tableName, $filter, $entityClass, $response->getHeader('x-ms-continuation-NextPartitionKey'), $response->getHeader('x-ms-continuation-NextRowKey')));
 		        }
 		    }
-		    
+
 		    // Return
 		    return $returnValue;
 		} else {
@@ -640,37 +649,41 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Update entity by replacing it
-	 * 
+	 *
 	 * @param string                              $tableName   Table name
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity      Entity to update
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity      Entity to update
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function updateEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	public function updateEntity($tableName = '', $entity = null, $verifyEtag = false)
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 	    return $this->_changeEntity(Zend_Http_Client::PUT, $tableName, $entity, $verifyEtag);
 	}
-	
+
 	/**
 	 * Update entity by adding or updating properties
-	 * 
+	 *
 	 * @param string                              $tableName   Table name
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity      Entity to update
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity      Entity to update
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @param array                               $properties  Properties to merge. All properties will be used when omitted.
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function mergeEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false, $properties = array())
+	public function mergeEntity($tableName = '', $entity = null, $verifyEtag = false, $properties = array())
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 		$mergeEntity = null;
 		if (is_array($properties) && count($properties) > 0) {
-			
+
 			// Build a new object
 			$mergeEntity = new Zend_Service_WindowsAzure_Storage_DynamicTableEntity($entity->getPartitionKey(), $entity->getRowKey());
-			
+
 			// Keep only values mentioned in $properties
 			$azureValues = $entity->getAzureValues();
 			foreach ($azureValues as $key => $value) {
@@ -681,16 +694,16 @@ class Zend_Service_WindowsAzure_Storage_Table
 		} else {
 			$mergeEntity = $entity;
 		}
-		
-		// Ensure entity timestamp matches updated timestamp 
+
+		// Ensure entity timestamp matches updated timestamp
         $entity->setTimestamp(new DateTime());
-        
+
 	    return $this->_changeEntity(Zend_Http_Client::MERGE, $tableName, $mergeEntity, $verifyEtag);
 	}
-	
+
 	/**
 	 * Get error message from Zend_Http_Response
-	 * 
+	 *
 	 * @param Zend_Http_Response $response Repsonse
 	 * @param string $alternativeError Alternative error message
 	 * @return string
@@ -704,27 +717,29 @@ class Zend_Service_WindowsAzure_Storage_Table
 		    return $alternativeError;
 		}
 	}
-	
+
 	/**
 	 * Update entity / merge entity
-	 * 
+	 *
 	 * @param string                              $httpVerb    HTTP verb to use (PUT = update, MERGE = merge)
 	 * @param string                              $tableName   Table name
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity      Entity to update
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity      Entity to update
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _changeEntity($httpVerb = Zend_Http_Client::PUT, $tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	protected function _changeEntity($httpVerb = Zend_Http_Client::PUT, $tableName = '', $entity = null, $verifyEtag = false)
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Table name is not specified.');
 		}
-		if (is_null($entity)) {	
+		if (is_null($entity)) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
 			throw new Zend_Service_WindowsAzure_Exception('Entity is not specified.');
 		}
-		                     
+
         // Add header information
         $headers = array();
         $headers['Content-Type']   = 'application/atom+xml';
@@ -750,10 +765,10 @@ class Zend_Service_WindowsAzure_Storage_Table
                             </m:properties>
                           </content>
                         </entry>';
-		
+
 		// Attempt to get timestamp from entity
         $timestamp = $entity->getTimestamp();
-        
+
         $requestBody = $this->_fillTemplate($requestBody, array(
         	'Updated'    => $this->_convertToEdmDateTime($timestamp),
             'Properties' => $this->_generateAzureRepresentation($entity)
@@ -767,7 +782,7 @@ class Zend_Service_WindowsAzure_Storage_Table
         } else {
             $headers['If-Match']       = $entity->getEtag();
         }
-        
+
 		// Perform request
 		$response = null;
 	    if ($this->isInBatch()) {
@@ -787,20 +802,20 @@ class Zend_Service_WindowsAzure_Storage_Table
 			throw new Zend_Service_WindowsAzure_Exception($this->_getErrorMessage($response, 'Resource could not be accessed.'));
 		}
 	}
-	
+
 	/**
 	 * Generate RFC 1123 compliant date string
-	 * 
+	 *
 	 * @return string
 	 */
 	protected function _rfcDate()
 	{
 	    return gmdate('D, d M Y H:i:s', time()) . ' GMT'; // RFC 1123
 	}
-	
+
 	/**
 	 * Fill text template with variables from key/value array
-	 * 
+	 *
 	 * @param string $templateText Template text
 	 * @param array $variables Array containing key/value pairs
 	 * @return string
@@ -812,15 +827,17 @@ class Zend_Service_WindowsAzure_Storage_Table
 	    }
 	    return $templateText;
 	}
-	
+
 	/**
 	 * Generate Azure representation from entity (creates atompub markup from properties)
-	 * 
-	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity
+	 *
+	 * @param Zend_Service_WindowsAzure_Storage_TableEntity|null $entity
 	 * @return string
 	 */
-	protected function _generateAzureRepresentation(Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
+	protected function _generateAzureRepresentation($entity = null)
 	{
+	    Types::isNullable('entity', $entity, 'Zend_Service_WindowsAzure_Storage_TableEntity');
+
 		// Generate Azure representation from entity
 		$azureRepresentation = array();
 		$azureValues         = $entity->getAzureValues();
@@ -831,10 +848,10 @@ class Zend_Service_WindowsAzure_Storage_Table
 		        $value[] = ' m:type="' . $azureValue->Type . '"';
 		    }
 		    if (is_null($azureValue->Value)) {
-		        $value[] = ' m:null="true"'; 
+		        $value[] = ' m:null="true"';
 		    }
 		    $value[] = '>';
-		    
+
 		    if (!is_null($azureValue->Value)) {
 		        if (strtolower($azureValue->Type) == 'edm.boolean') {
 		            $value[] = ($azureValue->Value == true ? '1' : '0');
@@ -844,14 +861,14 @@ class Zend_Service_WindowsAzure_Storage_Table
 		            $value[] = htmlspecialchars($azureValue->Value);
 		        }
 		    }
-		    
+
 		    $value[] = '</d:' . $azureValue->Name . '>';
 		    $azureRepresentation[] = implode('', $value);
 		}
 
 		return implode('', $azureRepresentation);
 	}
-	
+
 		/**
 	 * Perform request using Zend_Http_Client channel
 	 *
@@ -890,20 +907,20 @@ class Zend_Service_WindowsAzure_Storage_Table
 			$resourceType,
 			$requiredPermission
 		);
-	}  
-	  
+	}
+
     /**
      * Converts a string to a DateTime object. Returns false on failure.
-     * 
+     *
      * @param string $value The string value to parse
      * @return DateTime|boolean
      */
-    protected function _convertToDateTime($value = '') 
+    protected function _convertToDateTime($value = '')
     {
     	if ($value instanceof DateTime) {
     		return $value;
     	}
-    	
+
     	try {
     		if (substr($value, -1) == 'Z') {
     			$value = substr($value, 0, strlen($value) - 1);
@@ -914,15 +931,15 @@ class Zend_Service_WindowsAzure_Storage_Table
     		return false;
     	}
     }
-    
+
     /**
      * Converts a DateTime object into an Edm.DaeTime value in UTC timezone,
      * represented as a string.
-     * 
+     *
      * @param DateTime $value
      * @return string
      */
-    protected function _convertToEdmDateTime(DateTime $value) 
+    protected function _convertToEdmDateTime(DateTime $value)
     {
     	$cloned = clone $value;
     	$cloned->setTimezone(new DateTimeZone('UTC'));

--- a/packages/zend-soap/library/Zend/Soap/Server.php
+++ b/packages/zend-soap/library/Zend/Soap/Server.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -94,11 +97,11 @@ class Zend_Soap_Server implements Zend_Server_Interface
 
     /**
      * WS-I compliant
-     * 
-     * @var boolean 
+     *
+     * @var boolean
      */
     protected $_wsiCompliant;
-    
+
     /**
      * Registered fault exceptions
      * @var array
@@ -166,11 +169,13 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * options are specified, they are passed on to {@link setOptions()}.
      *
      * @param string $wsdl
-     * @param array $options
+     * @param array|null $options
      * @return void
      */
-    public function __construct($wsdl = null, array $options = null)
+    public function __construct($wsdl = null, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         if (!extension_loaded('soap')) {
             // require_once 'Zend/Soap/Server/Exception.php';
             throw new Zend_Soap_Server_Exception('SOAP extension is not loaded.');
@@ -279,14 +284,14 @@ class Zend_Soap_Server implements Zend_Server_Interface
         if (null !== $this->_wsiCompliant) {
             $options['wsi_compliant'] = $this->_wsiCompliant;
         }
-        
+
         return $options;
     }
     /**
      * Set WS-I compliant
-     * 
+     *
      * @param  boolean $value
-     * @return Zend_Soap_Server 
+     * @return Zend_Soap_Server
      */
     public function setWsiCompliant($value)
     {
@@ -297,10 +302,10 @@ class Zend_Soap_Server implements Zend_Server_Interface
     }
     /**
      * Gt WS-I compliant
-     * 
+     *
      * @return boolean
      */
-    public function getWsiCompliant() 
+    public function getWsiCompliant()
     {
         return $this->_wsiCompliant;
     }
@@ -640,7 +645,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
             $this->_object = new Zend_Soap_Server_Proxy($object);
         } else {
             $this->_object = $object;
-        }    
+        }
 
         return $this;
     }
@@ -823,7 +828,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
             if ($this->_wsiCompliant) {
                 // require_once 'Zend/Soap/Server/Proxy.php';
                 array_unshift($args, 'Zend_Soap_Server_Proxy');
-            } 
+            }
             call_user_func_array(array($server, 'setClass'), $args);
         }
 
@@ -876,7 +881,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
         } catch (Zend_Soap_Server_Exception $e) {
             $setRequestException = $e;
         }
-        
+
         $soap = $this->_getSoap();
 
         $fault = false;
@@ -1011,12 +1016,14 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * @param string $errstr
      * @param string $errfile
      * @param int $errline
-     * @param array $errcontext
+     * @param array|null $errcontext
      * @return void
      * @throws SoapFault
      */
-    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, $errcontext = null)
     {
+        Types::isNullable('errcontext', $errcontext, 'array');
+
         throw $this->fault($errstr, "Receiver");
     }
 }

--- a/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -89,13 +92,15 @@ class Zend_Tag_Cloud_Decorator_HtmlTag extends Zend_Tag_Cloud_Decorator_Tag
     /**
      * Set a list of classes to use instead of fontsizes
      *
-     * @param  array $classList
+     * @param  array|null $classList
      * @throws Zend_Tag_Cloud_Decorator_Exception When the classlist is empty
      * @throws Zend_Tag_Cloud_Decorator_Exception When the classlist contains an invalid classname
      * @return Zend_Tag_Cloud_Decorator_HtmlTag
      */
-    public function setClassList(array $classList = null)
+    public function setClassList($classList = null)
     {
+        Types::isNullable('classList', $classList, 'array');
+
         if (is_array($classList)) {
             if (count($classList) === 0) {
                 // require_once 'Zend/Tag/Cloud/Decorator/Exception.php';

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery37.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -136,7 +139,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery37 extends PHPUnit_Framework_Constrai
      * @param  null|string  Assertion type
      * @param  string       (optional) String to match (needle), may be required depending on assertion type
      * @return bool
-     * 
+     *
      * NOTE:
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function evaluate($other, $assertType = null)
@@ -219,11 +222,13 @@ class Zend_Test_PHPUnit_Constraint_DomQuery37 extends PHPUnit_Framework_Constrai
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, 'PHPUnit_Framework_ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_CONTENT_CONTAINS:

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery41.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -136,7 +139,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery41 extends PHPUnit_Framework_Constrai
      * @param  null|string  Assertion type
      * @param  string       (optional) String to match (needle), may be required depending on assertion type
      * @return bool
-     * 
+     *
      * NOTE:
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function evaluate($other, $assertType = null)
@@ -219,13 +222,15 @@ class Zend_Test_PHPUnit_Constraint_DomQuery41 extends PHPUnit_Framework_Constrai
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, '\SebastianBergmann\Comparator\ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_CONTENT_CONTAINS:

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -61,7 +64,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect37 extends PHPUnit_Framework_Constrai
      * @var string
      */
     protected $_match             = null;
-    
+
     /**
      * What is actual redirect
      */
@@ -173,11 +176,13 @@ class Zend_Test_PHPUnit_Constraint_Redirect37 extends PHPUnit_Framework_Constrai
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, 'PHPUnit_Framework_ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_REDIRECT_TO:

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -61,7 +64,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit_Framework_Constrai
      * @var string
      */
     protected $_match             = null;
-    
+
     /**
      * What is actual redirect
      */
@@ -173,13 +176,15 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit_Framework_Constrai
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, '\SebastianBergmann\Comparator\ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_REDIRECT_TO:

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -62,7 +65,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader37 extends PHPUnit_Framework_Co
      * @var int Response code
      */
     protected $_code              = 200;
-    
+
     /**
      * @var int Actual response code
      */
@@ -199,11 +202,13 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader37 extends PHPUnit_Framework_Co
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, 'PHPUnit_Framework_ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_RESPONSE_CODE:

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -62,7 +65,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit_Framework_Co
      * @var int Response code
      */
     protected $_code              = 200;
-    
+
     /**
      * @var int Actual response code
      */
@@ -199,13 +202,15 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit_Framework_Co
      * Drastic changes up to PHPUnit 3.5.15 this was:
      *     public function fail($other, $description, $not = false)
      * In PHPUnit 3.6.0 they changed the interface into this:
-     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     *     protected function fail($other, $description, $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
+        Types::isNullable('cannot_be_used', $cannot_be_used, '\SebastianBergmann\Comparator\ComparisonFailure');
+
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {
             case self::ASSERT_RESPONSE_CODE:

--- a/packages/zend-text/library/Zend/Text/Table/Row.php
+++ b/packages/zend-text/library/Zend/Text/Table/Row.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -47,11 +50,13 @@ class Zend_Text_Table_Row
      * Create a new column and append it to the row
      *
      * @param  string $content
-     * @param  array  $options
+     * @param  array|null $options
      * @return Zend_Text_Table_Row
      */
-    public function createColumn($content, array $options = null)
+    public function createColumn($content, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $align    = null;
         $colSpan  = null;
         $encoding = null;

--- a/packages/zend-tool/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -56,10 +59,12 @@ class Zend_Tool_Framework_Client_Console_HelpSystem
      * respondWithErrorMessage()
      *
      * @param string $errorMessage
-     * @param Exception $exception
+     * @param Exception|null $exception
      */
-    public function respondWithErrorMessage($errorMessage, Exception $exception = null)
+    public function respondWithErrorMessage($errorMessage, $exception = null)
     {
+        Types::isNullable('exception', $exception, 'Exception');
+
         // break apart the message into wrapped chunks
         $errorMessages = explode(PHP_EOL, wordwrap($errorMessage, 70, PHP_EOL, false));
 

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile/FileParser/Xml.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile/FileParser/Xml.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -183,10 +186,11 @@ class Zend_Tool_Project_Profile_FileParser_Xml implements Zend_Tool_Project_Prof
      * as needed to *unserialize* the profile from an xmlIterator
      *
      * @param SimpleXMLIterator $xmlIterator
-     * @param Zend_Tool_Project_Profile_Resource $resource
+     * @param Zend_Tool_Project_Profile_Resource|null $resource
      */
-    protected function _unserializeRecurser(SimpleXMLIterator $xmlIterator, Zend_Tool_Project_Profile_Resource $resource = null)
+    protected function _unserializeRecurser(SimpleXMLIterator $xmlIterator, $resource = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Tool_Project_Profile_Resource');
 
         foreach ($xmlIterator as $resourceName => $resourceData) {
 

--- a/packages/zend-tool/library/Zend/Tool/Project/Provider/Module.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Provider/Module.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -51,8 +54,9 @@ class Zend_Tool_Project_Provider_Module
     implements Zend_Tool_Framework_Provider_Pretendable
 {
 
-    public static function createResources(Zend_Tool_Project_Profile $profile, $moduleName, Zend_Tool_Project_Profile_Resource $targetModuleResource = null)
+    public static function createResources(Zend_Tool_Project_Profile $profile, $moduleName, $targetModuleResource = null)
     {
+        Types::isNullable('targetModuleResource', $targetModuleResource, 'Zend_Tool_Project_Profile_Resource');
 
         // find the appliction directory, it will serve as our module skeleton
         if ($targetModuleResource == null) {
@@ -139,7 +143,7 @@ class Zend_Tool_Project_Provider_Module
         // determine if testing is enabled in the project
         // require_once 'Zend/Tool/Project/Provider/Test.php';
         //$testingEnabled = Zend_Tool_Project_Provider_Test::isTestingEnabled($this->_loadedProfile);
-        
+
         $resources = self::createResources($this->_loadedProfile, $name);
 
         $response = $this->_registry->getResponse();

--- a/packages/zend-validate/library/Zend/Validate/EmailAddress.php
+++ b/packages/zend-validate/library/Zend/Validate/EmailAddress.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -239,12 +242,14 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
     }
 
     /**
-     * @param Zend_Validate_Hostname $hostnameValidator OPTIONAL
+     * @param Zend_Validate_Hostname|null $hostnameValidator OPTIONAL
      * @param int                    $allow             OPTIONAL
      * @return $this
      */
-    public function setHostnameValidator(Zend_Validate_Hostname $hostnameValidator = null, $allow = Zend_Validate_Hostname::ALLOW_DNS)
+    public function setHostnameValidator($hostnameValidator = null, $allow = Zend_Validate_Hostname::ALLOW_DNS)
     {
+        Types::isNullable('hostnameValidator', $hostnameValidator, 'Zend_Validate_Hostname');
+
         if (!$hostnameValidator) {
             $hostnameValidator = new Zend_Validate_Hostname($allow);
         }

--- a/packages/zend-validate/library/Zend/Validate/Hostname.php
+++ b/packages/zend-validate/library/Zend/Validate/Hostname.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -2042,11 +2045,13 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
     }
 
     /**
-     * @param Zend_Validate_Ip $ipValidator OPTIONAL
+     * @param Zend_Validate_Ip|null $ipValidator OPTIONAL
      * @return Zend_Validate_Hostname
      */
-    public function setIpValidator(Zend_Validate_Ip $ipValidator = null)
+    public function setIpValidator($ipValidator = null)
     {
+        Types::isNullable('ipValidator', $ipValidator, 'Zend_Validate_Ip');
+
         if ($ipValidator === null) {
             $ipValidator = new Zend_Validate_Ip();
         }

--- a/packages/zend-view/library/Zend/View/Exception.php
+++ b/packages/zend-view/library/Zend/View/Exception.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -38,8 +41,10 @@ class Zend_View_Exception extends Zend_Exception
 {
     protected $view = null;
 
-    public function setView(Zend_View_Interface $view = null)
+    public function setView($view = null)
     {
+        Types::isNullable('view', $view, 'Zend_View_Interface');
+
         $this->view = $view;
         return $this;
     }

--- a/packages/zend-view/library/Zend/View/Helper/FormCheckbox.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormCheckbox.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -59,8 +62,10 @@ class Zend_View_Helper_FormCheckbox extends Zend_View_Helper_FormElement
      * @param array $attribs Attributes for the element tag.
      * @return string The element XHTML.
      */
-    public function formCheckbox($name, $value = null, $attribs = null, array $checkedOptions = null)
+    public function formCheckbox($name, $value = null, $attribs = null, $checkedOptions = null)
     {
+        Types::isNullable('checkedOptions', $checkedOptions, 'array');
+
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, id, value, attribs, options, listsep, disable
 
@@ -113,8 +118,10 @@ class Zend_View_Helper_FormCheckbox extends Zend_View_Helper_FormElement
      * @param  array|null $checkedOptions
      * @return array
      */
-    public static function determineCheckboxInfo($value, $checked, array $checkedOptions = null)
+    public static function determineCheckboxInfo($value, $checked, $checkedOptions = null)
     {
+        Types::isNullable('$checkedOptions', $checkedOptions, 'array');
+
         // Checked/unchecked values
         $checkedValue   = null;
         $uncheckedValue = null;

--- a/packages/zend-view/library/Zend/View/Helper/FormErrors.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormErrors.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -54,11 +57,13 @@ class Zend_View_Helper_FormErrors extends Zend_View_Helper_FormElement
      * Render form errors
      *
      * @param  string|array $errors Error(s) to render
-     * @param  array $options
+     * @param  array|null $options
      * @return string
      */
-    public function formErrors($errors, array $options = null)
+    public function formErrors($errors, $options = null)
     {
+        Types::isNullable('options', $options, 'array');
+
         $escape = true;
         if (isset($options['escape'])) {
             $escape = (bool) $options['escape'];

--- a/packages/zend-view/library/Zend/View/Helper/FormHidden.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormHidden.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -47,11 +50,13 @@ class Zend_View_Helper_FormHidden extends Zend_View_Helper_FormElement
      * array, all other parameters are ignored, and the array elements
      * are extracted in place of added parameters.
      * @param mixed $value The element value.
-     * @param array $attribs Attributes for the element tag.
+     * @param array|null $attribs Attributes for the element tag.
      * @return string The element XHTML.
      */
-    public function formHidden($name, $value = null, array $attribs = null)
+    public function formHidden($name, $value = null, $attribs = null)
     {
+        Types::isNullable('attribs', $attribs, 'array');
+
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, value, attribs, options, listsep, disable
         if (isset($id)) {

--- a/packages/zend-view/library/Zend/View/Helper/FormLabel.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormLabel.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -39,11 +42,13 @@ class Zend_View_Helper_FormLabel extends Zend_View_Helper_FormElement
      *
      * @param  string $name The form element name for which the label is being generated
      * @param  string $value The label text
-     * @param  array $attribs Form element attributes (used to determine if disabled)
+     * @param  array|null $attribs Form element attributes (used to determine if disabled)
      * @return string The element XHTML.
      */
-    public function formLabel($name, $value = null, array $attribs = null)
+    public function formLabel($name, $value = null, $attribs = null)
     {
+        Types::isNullable('attribs', $attribs, 'array');
+
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, value, attribs, options, listsep, disable, escape
 

--- a/packages/zend-view/library/Zend/View/Helper/HeadLink.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadLink.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -88,8 +91,10 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
      *
      * @return Zend_View_Helper_HeadLink
      */
-    public function headLink(array $attributes = null, $placement = Zend_View_Helper_Placeholder_Container_Abstract::APPEND)
+    public function headLink($attributes = null, $placement = Zend_View_Helper_Placeholder_Container_Abstract::APPEND)
     {
+        Types::isNullable('attributes', $attributes, 'array');
+
         if (null !== $attributes) {
             $item = $this->createData($attributes);
             switch ($placement) {

--- a/packages/zend-view/library/Zend/View/Helper/Navigation.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -86,13 +89,15 @@ class Zend_View_Helper_Navigation
     /**
      * Helper entry point
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on
      * @return Zend_View_Helper_Navigation           fluent interface, returns
      *                                               self
      */
-    public function navigation(Zend_Navigation_Container $container = null)
+    public function navigation($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -164,11 +169,11 @@ class Zend_View_Helper_Navigation
             // Add navigation helper path at the beginning
             $paths = $this->view->getHelperPaths();
             $this->view->setHelperPath(null);
-            
+
             $this->view->addHelperPath(
                     str_replace('_', '/', self::NS),
                     self::NS);
-            
+
             foreach ($paths as $ns => $path) {
                 $this->view->addHelperPath($path, $ns);
             }
@@ -332,7 +337,7 @@ class Zend_View_Helper_Navigation
     /**
      * Renders helper
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
@@ -342,8 +347,10 @@ class Zend_View_Helper_Navigation
      *                                               the interface specified in
      *                                               {@link findHelper()}
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         $helper = $this->findHelper($this->getDefaultProxy());
         return $helper->render($container);
     }

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -69,13 +72,15 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
-     * @param  Zend_Navigation_Container $container     [optional] container to
+     * @param  Zend_Navigation_Container|null $container     [optional] container to
      *                                                  operate on
      * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
      *                                                  returns self
      */
-    public function breadcrumbs(Zend_Navigation_Container $container = null)
+    public function breadcrumbs($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -174,14 +179,16 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      * Renders breadcrumbs by chaining 'a' elements with the separator
      * registered in the helper
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function renderStraight(Zend_Navigation_Container $container = null)
+    public function renderStraight($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }
@@ -230,7 +237,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      * The container will simply be passed on as a model to the view script,
      * so in the script it will be available in <code>$this->container</code>.
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               pass to view script.
      *                                               Default is to use the
      *                                               container registered in the
@@ -247,9 +254,11 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *                                               be found.
      * @return string                                helper output
      */
-    public function renderPartial(Zend_Navigation_Container $container = null,
+    public function renderPartial($container = null,
                                   $partial = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }
@@ -314,14 +323,16 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *
      * Implements {@link Zend_View_Helper_Navigation_Helper::render()}.
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if ($partial = $this->getPartial()) {
             return $this->renderPartial($container, $partial);
         } else {

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Helper.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Helper.php
@@ -34,7 +34,7 @@ interface Zend_View_Helper_Navigation_Helper
     /**
      * Sets navigation container the helper should operate on by default
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on. Default is
      *                                               null, which indicates that
      *                                               the container should be
@@ -42,7 +42,7 @@ interface Zend_View_Helper_Navigation_Helper
      * @return Zend_View_Helper_Navigation_Helper    fluent interface, returns
      *                                               self
      */
-    public function setContainer(Zend_Navigation_Container $container = null);
+    public function setContainer($container = null);
 
     /**
      * Returns the navigation container the helper operates on by default
@@ -74,11 +74,11 @@ interface Zend_View_Helper_Navigation_Helper
     /**
      * Sets ACL to use when iterating pages
      *
-     * @param  Zend_Acl $acl                       [optional] ACL instance
+     * @param  Zend_Acl|null $acl                       [optional] ACL instance
      * @return Zend_View_Helper_Navigation_Helper  fluent interface, returns
      *                                             self
      */
-    public function setAcl(Zend_Acl $acl = null);
+    public function setAcl($acl = null);
 
     /**
      * Returns ACL or null if it isn't set using {@link setAcl()} or
@@ -199,7 +199,7 @@ interface Zend_View_Helper_Navigation_Helper
     /**
      * Renders helper
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is null,
      *                                               which indicates that the
      *                                               helper should render the
@@ -208,5 +208,5 @@ interface Zend_View_Helper_Navigation_Helper
      * @return string                                helper output
      * @throws Zend_View_Exception                   if unable to render
      */
-    public function render(Zend_Navigation_Container $container = null);
+    public function render($container = null);
 }

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/HelperAbstract.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/HelperAbstract.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -157,7 +160,7 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      *
      * Implements {@link Zend_View_Helper_Navigation_Interface::setContainer()}.
      *
-     * @param  Zend_Navigation_Container $container        [optional] container
+     * @param  null|Zend_Navigation_Container $container        [optional] container
      *                                                     to operate on.
      *                                                     Default is null,
      *                                                     meaning container
@@ -165,8 +168,10 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      * @return Zend_View_Helper_Navigation_HelperAbstract  fluent interface,
      *                                                     returns self
      */
-    public function setContainer(Zend_Navigation_Container $container = null)
+    public function setContainer($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         $this->_container = $container;
         return $this;
     }
@@ -438,13 +443,15 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      *
      * Implements {@link Zend_View_Helper_Navigation_Helper::setAcl()}.
      *
-     * @param  Zend_Acl $acl                               [optional] ACL object.
+     * @param  Zend_Acl|null $acl                          [optional] ACL object.
      *                                                     Default is null.
      * @return Zend_View_Helper_Navigation_HelperAbstract  fluent interface,
      *                                                     returns self
      */
-    public function setAcl(Zend_Acl $acl = null)
+    public function setAcl($acl = null)
     {
+        Types::isNullable('acl', $acl, 'Zend_Acl');
+
         $this->_acl = $acl;
         return $this;
     }
@@ -922,7 +929,7 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      * @return string           Normalized ID
      */
     protected function _normalizeId($value)
-    {        
+    {
         if (false === $this->_skipPrefixForId) {
             $prefix = $this->getPrefixForId();
 
@@ -939,12 +946,14 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
     /**
      * Sets default ACL to use if another ACL is not explicitly set
      *
-     * @param  Zend_Acl $acl  [optional] ACL object. Default is null, which
+     * @param  Zend_Acl|null $acl  [optional] ACL object. Default is null, which
      *                        sets no ACL object.
      * @return void
      */
-    public static function setDefaultAcl(Zend_Acl $acl = null)
+    public static function setDefaultAcl($acl = null)
     {
+        Types::isNullable('acl', $acl, 'Zend_Acl');
+
         self::$_defaultAcl = $acl;
     }
 

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -109,13 +112,15 @@ class Zend_View_Helper_Navigation_Links
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on
      * @return Zend_View_Helper_Navigation_Links     fluent interface, returns
      *                                               self
      */
-    public function links(Zend_Navigation_Container $container = null)
+    public function links($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -741,14 +746,16 @@ class Zend_View_Helper_Navigation_Links
      *
      * Implements {@link Zend_View_Helper_Navigation_Helper::render()}.
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Menu.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Menu.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -113,18 +116,20 @@ class Zend_View_Helper_Navigation_Menu
      * @var string
      */
     protected $_innerIndent = '    ';
-    
+
     /**
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on
      * @return Zend_View_Helper_Navigation_Menu      fluent interface,
      *                                               returns self
      */
-    public function menu(Zend_Navigation_Container $container = null)
+    public function menu($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -285,10 +290,10 @@ class Zend_View_Helper_Navigation_Menu
     {
         return $this->_onlyActiveBranch;
     }
-    
+
     /**
      * Sets a flag indicating whether to expand all sibling nodes of the active branch
-     * 
+     *
      * @param  bool $flag                        [optional] expand all siblings of
      *                                           nodes in the active branch. Default is true.
      * @return Zend_View_Helper_Navigation_Menu  fluent interface, returns self
@@ -311,7 +316,7 @@ class Zend_View_Helper_Navigation_Menu
     {
         return $this->_expandSiblingNodesOfActiveBranch;
     }
-    
+
     /**
      * Enables/disables rendering of parents when only rendering active branch
      *
@@ -890,7 +895,7 @@ class Zend_View_Helper_Navigation_Menu
      * Available $options:
      *
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container [optional] container to
      *                                               create menu from. Default
      *                                               is to use the container
      *                                               retrieved from
@@ -899,9 +904,11 @@ class Zend_View_Helper_Navigation_Menu
      *                                               controlling rendering
      * @return string                                rendered menu
      */
-    public function renderMenu(Zend_Navigation_Container $container = null,
+    public function renderMenu($container = null,
                                array $options = array())
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }
@@ -958,7 +965,7 @@ class Zend_View_Helper_Navigation_Menu
      * ));
      * </code>
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to render
      *                                               the container registered in
      *                                               the helper.
@@ -982,13 +989,15 @@ class Zend_View_Helper_Navigation_Menu
      *                                                  {@link getInnerIndent()}.
      * @return string                                   rendered content
      */
-    public function renderSubMenu(Zend_Navigation_Container $container = null,
+    public function renderSubMenu($container = null,
                                   $ulClass = null,
                                   $indent = null,
                                   $ulId   = null,
                                   $addPageClassToLi = false,
                                   $innerIndent = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         return $this->renderMenu($container, array(
             'indent'           => $indent,
             'innerIndent'      => $innerIndent,
@@ -1009,7 +1018,7 @@ class Zend_View_Helper_Navigation_Menu
      * as-is, and will be available in the partial script as 'container', e.g.
      * <code>echo 'Number of pages: ', count($this->container);</code>.
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container [optional] container to
      *                                               pass to view script. Default
      *                                               is to use the container
      *                                               registered in the helper.
@@ -1026,9 +1035,11 @@ class Zend_View_Helper_Navigation_Menu
      *
      * @throws Zend_View_Exception   When no partial script is set
      */
-    public function renderPartial(Zend_Navigation_Container $container = null,
+    public function renderPartial($container = null,
                                   $partial = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }
@@ -1082,14 +1093,16 @@ class Zend_View_Helper_Navigation_Menu
      * @see renderPartial()
      * @see renderMenu()
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if ($partial = $this->getPartial()) {
             return $this->renderPartial($container, $partial);
         } else {

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -85,13 +88,15 @@ class Zend_View_Helper_Navigation_Sitemap
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on
      * @return Zend_View_Helper_Navigation_Sitemap   fluent interface, returns
      *                                               self
      */
-    public function sitemap(Zend_Navigation_Container $container = null)
+    public function sitemap($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -275,7 +280,7 @@ class Zend_View_Helper_Navigation_Sitemap
     /**
      * Returns a DOMDocument containing the Sitemap XML for the given container
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to get
+     * @param  Zend_Navigation_Container|null $container  [optional] container to get
      *                                               breadcrumbs from, defaults
      *                                               to what is registered in the
      *                                               helper
@@ -288,8 +293,10 @@ class Zend_View_Helper_Navigation_Sitemap
      *                                               validators are used and the
      *                                               loc element fails validation
      */
-    public function getDomSitemap(Zend_Navigation_Container $container = null)
+    public function getDomSitemap($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null === $container) {
             $container = $this->getContainer();
         }
@@ -423,15 +430,17 @@ class Zend_View_Helper_Navigation_Sitemap
      *
      * Implements {@link Zend_View_Helper_Navigation_Helper::render()}.
      *
-     * @param Zend_Navigation_Container $container [optional] container to
+     * @param Zend_Navigation_Container|null $container [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @throws Zend_View_Exception
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         $dom = $this->getDomSitemap($container);
 
         $xml = $this->getUseXmlDeclaration() ?

--- a/packages/zend-view/library/Zend/View/Helper/PaginationControl.php
+++ b/packages/zend-view/library/Zend/View/Helper/PaginationControl.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -78,15 +81,17 @@ class Zend_View_Helper_PaginationControl
      * if so, uses that.  Also, if no scrolling style or partial are specified,
      * the defaults will be used (if set).
      *
-     * @param  Zend_Paginator (Optional) $paginator
+     * @param  Zend_Paginator|null $paginator (Optional)
      * @param  string $scrollingStyle (Optional) Scrolling style
      * @param  string $partial (Optional) View partial
      * @param  array|string $params (Optional) params to pass to the partial
      * @return string
      * @throws Zend_View_Exception
      */
-    public function paginationControl(Zend_Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
+    public function paginationControl($paginator = null, $scrollingStyle = null, $partial = null, $params = null)
     {
+        Types::isNullable('paginator', $paginator, 'Zend_Paginator');
+
         if ($paginator === null) {
             if (isset($this->view->paginator) and $this->view->paginator !== null and $this->view->paginator instanceof Zend_Paginator) {
                 $paginator = $this->view->paginator;

--- a/packages/zend-view/library/Zend/View/Helper/UserAgent.php
+++ b/packages/zend-view/library/Zend/View/Helper/UserAgent.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -42,11 +45,13 @@ class Zend_View_Helper_UserAgent extends Zend_View_Helper_Abstract
     /**
      * Helper method: retrieve or set UserAgent instance
      *
-     * @param  null|Zend_Http_UserAgent $userAgent
+     * @param  Zend_Http_UserAgent|null $userAgent
      * @return Zend_Http_UserAgent
      */
-    public function userAgent(Zend_Http_UserAgent $userAgent = null)
+    public function userAgent($userAgent = null)
     {
+        Types::isNullable('userAgent', $userAgent, 'Zend_Http_UserAgent');
+
         if (null !== $userAgent) {
             $this->setUserAgent($userAgent);
         }

--- a/packages/zend-xml/library/Zend/Xml/Security.php
+++ b/packages/zend-xml/library/Zend/Xml/Security.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -19,7 +22,7 @@
  * @version    $Id$
  */
 
- 
+
 /**
  * @category   Zend
  * @package    Zend_Xml_SecurityScan
@@ -77,12 +80,14 @@ class Zend_Xml_Security
      * Scan XML string for potential XXE and XEE attacks
      *
      * @param   string $xml
-     * @param   DomDocument $dom
+     * @param   DomDocument|null $dom
      * @throws  Zend_Xml_Exception
      * @return  SimpleXMLElement|DomDocument|boolean
      */
-    public static function scan($xml, DOMDocument $dom = null)
+    public static function scan($xml, $dom = null)
     {
+        Types::isNullable('dom', $dom, 'DOMDocument');
+
         // If running with PHP-FPM we perform an heuristic scan
         // We cannot use libxml_disable_entity_loader because of this bug
         // @see https://bugs.php.net/bug.php?id=64938
@@ -148,12 +153,14 @@ class Zend_Xml_Security
      * Scan XML file for potential XXE/XEE attacks
      *
      * @param  string $file
-     * @param  DOMDocument $dom
+     * @param  DOMDocument|null $dom
      * @throws Zend_Xml_Exception
      * @return SimpleXMLElement|DomDocument
      */
-    public static function scanFile($file, DOMDocument $dom = null)
+    public static function scanFile($file, $dom = null)
     {
+        Types::isNullable('dom', $dom, 'DOMDocument');
+
         if (!file_exists($file)) {
             // require_once 'Exception.php';
             throw new Zend_Xml_Exception(

--- a/packages/zend-xmlrpc/library/Zend/XmlRpc/Client.php
+++ b/packages/zend-xmlrpc/library/Zend/XmlRpc/Client.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -124,11 +127,13 @@ class Zend_XmlRpc_Client
      *
      * @param  string $server      Full address of the XML-RPC service
      *                             (e.g. http://time.xmlrpc.com/RPC2)
-     * @param  Zend_Http_Client $httpClient HTTP Client to use for requests
+     * @param  Zend_Http_Client|null $httpClient HTTP Client to use for requests
      * @return void
      */
-    public function __construct($server, Zend_Http_Client $httpClient = null)
+    public function __construct($server, $httpClient = null)
     {
+        Types::isNullable('httpClient', $httpClient, 'Zend_Http_Client');
+
         if ($httpClient === null) {
             $this->_httpClient = new Zend_Http_Client();
         } else {

--- a/tests/Zend/Acl/_files/AssertionZF7973.php
+++ b/tests/Zend/Acl/_files/AssertionZF7973.php
@@ -1,12 +1,18 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 // require_once 'Zend/Acl/Assert/Interface.php';
 
 class Zend_Acl_AclTest_AssertionZF7973 implements Zend_Acl_Assert_Interface {
     public function assert(Zend_Acl $acl,
-                Zend_Acl_Role_Interface $role = null,
-                Zend_Acl_Resource_Interface $resource = null,
+                $role = null,
+                $resource = null,
                 $privilege = null)
     {
+        Types::isNullable('role', $role, 'Zend_Acl_Role_Interface');
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         if($privilege != 'privilege') {
             return false;
         }

--- a/tests/Zend/Acl/_files/ExtendedAclZF2234.php
+++ b/tests/Zend/Acl/_files/ExtendedAclZF2234.php
@@ -1,22 +1,30 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class Zend_Acl_ExtendedAclZF2234 extends Zend_Acl
 {
-    public function roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, $resource = null,
                                               &$dfs = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         return $this->_roleDFSVisitAllPrivileges($role, $resource, $dfs);
     }
 
-    public function roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, $resource = null,
                                         $privilege = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         return $this->_roleDFSOnePrivilege($role, $resource, $privilege);
     }
 
-    public function roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, $resource = null,
                                              $privilege = null, &$dfs = null)
     {
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
         return $this->_roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);
     }
 }

--- a/tests/Zend/Acl/_files/MockAssertion.php
+++ b/tests/Zend/Acl/_files/MockAssertion.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class Zend_Acl_MockAssertion implements Zend_Acl_Assert_Interface
 {
     protected $_returnValue;
@@ -9,9 +11,12 @@ class Zend_Acl_MockAssertion implements Zend_Acl_Assert_Interface
         $this->_returnValue = (bool) $returnValue;
     }
 
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $role = null, Zend_Acl_Resource_Interface $resource = null,
+    public function assert(Zend_Acl $acl, $role = null, $resource = null,
                            $privilege = null)
     {
+        Types::isNullable('role', $role, 'Zend_Acl_Role_Interface');
+        Types::isNullable('resource', $resource, 'Zend_Acl_Resource_Interface');
+
        return $this->_returnValue;
     }
 }

--- a/tests/Zend/Acl/_files/UseCase1/UserIsBlogPostOwnerAssertion.php
+++ b/tests/Zend/Acl/_files/UseCase1/UserIsBlogPostOwnerAssertion.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class Zend_Acl_UseCase1_UserIsBlogPostOwnerAssertion implements Zend_Acl_Assert_Interface
 {
 
@@ -8,8 +10,11 @@ class Zend_Acl_UseCase1_UserIsBlogPostOwnerAssertion implements Zend_Acl_Assert_
     public $lastAssertPrivilege = null;
     public $assertReturnValue = true;
 
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $user = null, Zend_Acl_Resource_Interface $blogPost = null, $privilege = null)
+    public function assert(Zend_Acl $acl, $user = null, $blogPost = null, $privilege = null)
     {
+        Types::isNullable('user', $user, 'Zend_Acl_Role_Interface');
+        Types::isNullable('blogPost', $blogPost, 'Zend_Acl_Resource_Interface');
+
         $this->lastAssertRole = $user;
         $this->lastAssertResource = $blogPost;
         $this->lastAssertPrivilege = $privilege;

--- a/tests/Zend/Db/Table/_files/My/ZendDbTable/Row/TestMockRow.php
+++ b/tests/Zend/Db/Table/_files/My/ZendDbTable/Row/TestMockRow.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -48,21 +51,27 @@ class My_ZendDbTable_Row_TestMockRow extends Zend_Db_Table_Row_Abstract
     public $callerRefRuleKey  = null;
     public $matchRefRuleKey   = null;
 
-    public function findDependentRowset($dependentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findDependentRowset($dependentTable, $ruleKey = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $this->dependentTable    = $dependentTable;
         $this->ruleKey           = $ruleKey;
     }
 
-    public function findParentRow($parentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findParentRow($parentTable, $ruleKey = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $this->parentTable       = $parentTable;
         $this->ruleKey           = $ruleKey;
     }
 
     public function findManyToManyRowset($matchTable, $intersectionTable, $callerRefRule = null,
-                                         $matchRefRule = null, Zend_Db_Table_Select $select = null)
+                                         $matchRefRule = null, $select = null)
     {
+        Types::isNullable('select', $select, 'Zend_Db_Table_Select');
+
         $this->matchTable        = $matchTable;
         $this->intersectionTable = $intersectionTable;
         $this->callerRefRuleKey  = $callerRefRule;

--- a/tests/Zend/EventManager/TestAsset/ClassWithEvents.php
+++ b/tests/Zend/EventManager/TestAsset/ClassWithEvents.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -34,8 +37,10 @@ class Zend_EventManager_TestAsset_ClassWithEvents
 {
     protected $events;
 
-    public function events(Zend_EventManager_EventCollection $events = null)
+    public function events($events = null)
     {
+        Types::isNullable('events', $events, 'Zend_EventManager_EventCollection');
+
         if (null !== $events) {
             $this->events = $events;
         }

--- a/tests/Zend/Oauth/Oauth/ConsumerTest.php
+++ b/tests/Zend/Oauth/Oauth/ConsumerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -254,7 +257,8 @@ class Zend_Oauth_ConsumerTest extends PHPUnit_Framework_TestCase
 class Test_Http_RequestToken_48231 extends Zend_Oauth_Http_RequestToken
 {
     public function __construct(){}
-    public function execute(array $params = null){
+    public function execute($params = null){
+        Types::isNullable('params', $params, 'array');
         $return = new Zend_Oauth_Token_Request;
         return $return;}
     public function setParams(array $customServiceParameters){}
@@ -263,7 +267,8 @@ class Test_Http_RequestToken_48231 extends Zend_Oauth_Http_RequestToken
 class Test_Http_AccessToken_48231 extends Zend_Oauth_Http_AccessToken
 {
     public function __construct(){}
-    public function execute(array $params = null){
+    public function execute($params = null){
+        Types::isNullable('params', $params, 'array');
         $return = new Zend_Oauth_Token_Access;
         return $return;}
     public function setParams(array $customServiceParameters){}

--- a/tests/Zend/Queue/Custom/DbForUpdate.php
+++ b/tests/Zend/Queue/Custom/DbForUpdate.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -47,11 +50,13 @@ class Custom_DbForUpdate extends Zend_Queue_Adapter_Db
      *
      * @param  integer    $maxMessages
      * @param  integer    $timeout
-     * @param  Zend_Queue $queue
+     * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, $queue=null)
     {
+        Types::isNullable('queue', $queue, 'Zend_Queue');
+
         if ($maxMessages === null) {
             $maxMessages = 1;
         }

--- a/tests/Zend/Service/Twitter/TwitterTest.php
+++ b/tests/Zend/Service/Twitter/TwitterTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Zf1s\Compat\Types;
+
 /**
  * Zend Framework
  *
@@ -80,8 +83,10 @@ class Zend_Service_Twitter_TwitterTest extends PHPUnit_Framework_TestCase
      * @param array $params Expected GET/POST parameters for the request
      * @return Zend_Http_Client
      */
-    protected function stubTwitter($path, $method, $responseFile = null, array $params = null)
+    protected function stubTwitter($path, $method, $responseFile = null, $params = null)
     {
+        Types::isNullable('params', $params, 'array');
+        
         $client = $this->getMock('Zend_Oauth_Client', array(), array(), '', false);
         $client->expects($this->any())->method('resetParameters')
             ->will($this->returnValue($client));

--- a/tests/Zend/View/Helper/Navigation/_files/helpers/Menu.php
+++ b/tests/Zend/View/Helper/Navigation/_files/helpers/Menu.php
@@ -1,5 +1,7 @@
 <?php
 
+use Zf1s\Compat\Types;
+
 class My_View_Helper_Navigation_Menu
     extends Zend_View_Helper_Navigation_HelperAbstract
 {
@@ -7,13 +9,15 @@ class My_View_Helper_Navigation_Menu
      * View helper entry point:
      * Retrieves helper and optionally sets container to operate on
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               operate on
      * @return My_View_Helper_Navigation_Menu        fluent interface,
      *                                               returns self
      */
-    public function menu(Zend_Navigation_Container $container = null)
+    public function menu($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         if (null !== $container) {
             $this->setContainer($container);
         }
@@ -26,14 +30,16 @@ class My_View_Helper_Navigation_Menu
      *
      * Implements {@link Zend_View_Helper_Navigation_Helper::render()}.
      *
-     * @param  Zend_Navigation_Container $container  [optional] container to
+     * @param  Zend_Navigation_Container|null $container  [optional] container to
      *                                               render. Default is to
      *                                               render the container
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render($container = null)
     {
+        Types::isNullable('container', $container, 'Zend_Navigation_Container');
+
         return '<menu/>';
     }
 }


### PR DESCRIPTION
PHP 8.4: Implicitly nullable parameter declarations deprecated

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Fixes error:
Implicitly marking parameter ? as nullable is deprecated, the explicit nullable type must be used instead

Fix using Zf1s\Compat\Types