### PR TITLE
bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "ext-spl": "*",
         "ext-xml": "*",
         "ext-zlib": "*",
-        "php-parallel-lint/php-parallel-lint": "1.3.0",
-        "staabm/annotate-pull-request-from-checkstyle": "1.5.0",
+        "php-parallel-lint/php-parallel-lint": "1.4.0",
+        "staabm/annotate-pull-request-from-checkstyle": "1.8.6",
         "zf1s/dbunit": "1.3.3",
         "zf1s/phpunit": "3.7.43"
     },


### PR DESCRIPTION
#### [`php-parallel-lint`](https://github.com/php-parallel-lint/PHP-Parallel-Lint) 1.3.0 -> [1.4.0](https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.4.0)

adds php 8.3 and 8.4 support, including a fix for a php 8.4 deprecation notice that would show up during linting. Also includes several minor bug fixes around error message formatting.

#### [`annotate-pull-request-from-checkstyle`](https://github.com/staabm/annotate-pull-request-from-checkstyle) 1.5.0 -> [1.8.6](https://github.com/staabm/annotate-pull-request-from-checkstyle/releases/tag/1.8.6)

adds php 8.1-8.4 compatibility. Also improves output escaping and adds a fallback to first line when no line number is available in the checkstyle report.