### PR TITLE
slow tests fix: remove unnecessary sleep from memcached backend tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,10 @@
         </whitelist>
     </filter>
 
+    <listeners>
+        <listener class="SlowTestListener" file="tests/SlowTestListener.php"/>
+    </listeners>
+
     <php>
         <ini name="date.timezone" value="UTC"/>
     </php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,16 @@
         </whitelist>
     </filter>
 
+    <!-- uncomment to identify slow tests (default threshold: 0.5s) -->
+    <!--
     <listeners>
-        <listener class="SlowTestListener" file="tests/SlowTestListener.php"/>
+        <listener class="SlowTestListener" file="tests/SlowTestListener.php">
+            <arguments>
+                <double>0.5</double>
+            </arguments>
+        </listener>
     </listeners>
+    -->
 
     <php>
         <ini name="date.timezone" value="UTC"/>

--- a/tests/SlowTestListener.php
+++ b/tests/SlowTestListener.php
@@ -1,0 +1,32 @@
+<?php
+class SlowTestListener implements PHPUnit_Framework_TestListener
+{
+    private $startTime;
+    private $threshold = 0.5; // seconds
+
+    public function startTest(PHPUnit_Framework_Test $test)
+    {
+        $this->startTime = microtime(true);
+    }
+
+    public function endTest(PHPUnit_Framework_Test $test, $time)
+    {
+        $elapsed = microtime(true) - $this->startTime;
+        if ($elapsed > $this->threshold) {
+            fprintf(STDERR, "\nSLOW TEST (%.1fs): %s\n", $elapsed, $test->toString());
+        }
+    }
+
+    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {}
+    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {
+        if (strpos($suite->getName(), 'Zend_') === 0) {
+            fprintf(STDERR, "\n>>> SUITE START: %s (%d tests)\n", $suite->getName(), $suite->count());
+        }
+    }
+    public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {}
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+}

--- a/tests/SlowTestListener.php
+++ b/tests/SlowTestListener.php
@@ -1,19 +1,28 @@
 <?php
+/**
+ * PHPUnit test listener that reports slow tests and suite starts.
+ *
+ * Prints a warning to stderr for any test exceeding the threshold,
+ * and logs suite starts with test counts for progress tracking.
+ *
+ * Usage: uncomment the <listeners> block in phpunit.xml.dist to enable.
+ */
 class SlowTestListener implements PHPUnit_Framework_TestListener
 {
-    private $startTime;
-    private $threshold = 0.5; // seconds
+    private $threshold;
 
-    public function startTest(PHPUnit_Framework_Test $test)
+    public function __construct($threshold = 0.5)
     {
-        $this->startTime = microtime(true);
+        $this->threshold = $threshold;
     }
+
+    public function startTest(PHPUnit_Framework_Test $test) {}
 
     public function endTest(PHPUnit_Framework_Test $test, $time)
     {
-        $elapsed = microtime(true) - $this->startTime;
-        if ($elapsed > $this->threshold) {
-            fprintf(STDERR, "\nSLOW TEST (%.1fs): %s\n", $elapsed, $test->toString());
+        if ($time > $this->threshold) {
+            $name = $test instanceof PHPUnit_Framework_SelfDescribing ? $test->toString() : get_class($test);
+            fprintf(STDERR, "\nSLOW TEST (%.1fs): %s\n", $time, $name);
         }
     }
 

--- a/tests/Zend/Cache/LibmemcachedBackendTest.php
+++ b/tests/Zend/Cache/LibmemcachedBackendTest.php
@@ -76,7 +76,11 @@ class Zend_Cache_LibmemcachedBackendTest extends Zend_Cache_CommonExtendedBacken
         parent::tearDown();
         $this->_instance = null;
         // We have to wait after a memcached flush
-        sleep(1);
+        // sleep(1);
+        // flush_all sets an oldest_live timestamp and lazily invalidates items on access.
+        // in old memcached, this timestamp had 1s resolution - items stored in the same second
+        // as flush_all could get invalidated too. modern memcached (1.4.x+) handles this correctly,
+        // so the sleep is no longer needed.
     }
 
     public function testConstructorCorrectCall()

--- a/tests/Zend/Cache/MemcachedBackendTest.php
+++ b/tests/Zend/Cache/MemcachedBackendTest.php
@@ -77,7 +77,11 @@ class Zend_Cache_MemcachedBackendTest extends Zend_Cache_CommonExtendedBackendTe
         parent::tearDown();
         unset($this->_instance);
         // We have to wait after a memcache flush
-        sleep(1);
+        // sleep(1);
+        // flush_all sets an oldest_live timestamp and lazily invalidates items on access.
+        // in old memcached, this timestamp had 1s resolution - items stored in the same second
+        // as flush_all could get invalidated too. modern memcached (1.4.x+) handles this correctly,
+        // so the sleep is no longer needed.
     }
 
     public function testConstructorCorrectCall()


### PR DESCRIPTION
every `Zend_Cache_MemcachedBackendTest` and `Zend_Cache_LibmemcachedBackendTest` test was spending 1s in `tearDown()` due to `sleep(1)` after memcached `flush_all`. With ~41 tests per suite, that's ~82s of pure waiting.

the sleep was originally needed because old memcached's `flush_all` used a 1-second resolution `oldest_live` timestamp for lazy invalidation - items stored in the same second as the flush could get invalidated too. modern memcached (1.4.x+) handles this correctly, so the sleep is no longer needed.

#### slow tests identified

| Test Suite | Tests | Time Wasted | Root Cause |
|---|---|---|---|
| `Zend_Cache_MemcachedBackendTest` | 41 | ~41s | `sleep(1)` in every `tearDown()` |
| `Zend_Cache_LibmemcachedBackendTest` | 41 | ~41s | `sleep(1)` in every `tearDown()` |
| `Zend_Db_Profiler_StaticTest` (3 tests) | 3 | ~7s | `sleep(1-2)` simulating slow queries |
| `Zend_Captcha_ImageTest` (2 tests) | 2 | ~4s | `sleep(2)` for file expiration GC |
| `Zend_Mail_MboxTest::testSleepWake` | 1 | ~2s | `sleep(2)` for mtime change |
| `Zend_Queue_Adapter_ArrayTest::testVisibility` | 1 | ~2s | polling loop with 2s timeout |
| `Zend_Search_Lucene_Storage_DirectoryTest` | 1 | ~1s | `sleep(1)` for mtime change |
| `Zend_Service_WindowsAzure_RetryPolicyTest` | 1 | ~0.9s | 9 retries × 100ms |

this PR only addresses the memcached suites (~82s). assessment of the remaining ones (may be tackled at another time):

- **`Zend_Db_Profiler_StaticTest`** (~7s) - the static adapter could use `usleep()` with sub-second values instead of `sleep(1-2)`, tests would assert on smaller thresholds but exercise the same profiler code paths. safe to optimize.
- **`Zend_Captcha_ImageTest`** (~4s) - instead of `sleep(2)` waiting for file expiration, `touch($file, time() - 2)` can backdate the mtime so GC picks it up immediately. exercises the same GC logic. safe to optimize.
- **`Zend_Service_WindowsAzure_RetryPolicyTest`** (~0.9s) - uses `retryN(10, 100)` (100ms interval) but only asserts retry count, not timing. reducing to `retryN(10, 1)` would work fine.
- **`Zend_Mail_MboxTest::testSleepWake`** (~2s) - needs real mtime change so unserialized Mbox detects the file was recreated. `touch()` would work but real deletion + recreation with natural mtime progression is closer to the real-world scenario being tested. should stay.
- **`Zend_Search_Lucene_Storage_DirectoryTest`** (~1s) - tests that `touchFile()` actually updates mtime. faking with `touch()` would bypass the method being tested. should stay.
- **`Zend_Queue_Adapter_ArrayTest::testVisibility`** (~2s) - timing is what's being tested. reducing the timeout risks flakiness. should stay.

also includes a `SlowTestListener` (disabled by default in `phpunit.xml.dist`) that can be enabled for future slow test debugging - reports tests exceeding a configurable threshold.