### PR TITLE
php 8.4 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,6 @@ jobs:
         experimental:
           - false
         php:
-          - "5.3"
-          - "5.4"
-          - "5.5"
-          - "5.6"
-          - "7.0"
           - "7.1"
           - "7.2"
           - "7.3"
@@ -31,6 +26,11 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+        include:
+          - php: "8.4"
+            experimental: true
+          - php: "8.5"
+            experimental: true
 
     env:
       MYSQL_USER: "zftest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,8 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         include:
-          - php: "8.4"
-            experimental: true
           - php: "8.5"
             experimental: true
 

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "description": "Zend Framework 1 complete package, PHP 5.3-8.3 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.1",
-        "symfony/polyfill-php70": "^1.19"
+        "php": ">=7.1"
     },
     "require-dev": {
         "ext-ctype": "*",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "ext-zlib": "*",
         "php-parallel-lint/php-parallel-lint": "1.4.0",
         "staabm/annotate-pull-request-from-checkstyle": "1.8.6",
-        "zf1s/dbunit": "1.3.3",
-        "zf1s/phpunit": "3.7.43"
+        "zf1s/dbunit": "1.3.4",
+        "zf1s/phpunit": "3.7.44"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Zend Framework 1 complete package, PHP 5.3-8.3 compatible. Please consider using individual zf1s/zend-* packages instead - see README.",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "symfony/polyfill-php70": "^1.19"
     },
     "require-dev": {

--- a/packages/zend-acl/composer.json
+++ b/packages/zend-acl/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-acl/library/Zend/Acl.php
+++ b/packages/zend-acl/library/Zend/Acl.php
@@ -499,7 +499,7 @@ class Zend_Acl
      * @uses   Zend_Acl::setRule()
      * @return Zend_Acl Provides a fluent interface
      */
-    public function allow($roles = null, $resources = null, $privileges = null, Zend_Acl_Assert_Interface $assert = null)
+    public function allow($roles = null, $resources = null, $privileges = null, ?Zend_Acl_Assert_Interface $assert = null)
     {
         return $this->setRule(self::OP_ADD, self::TYPE_ALLOW, $roles, $resources, $privileges, $assert);
     }
@@ -514,7 +514,7 @@ class Zend_Acl
      * @uses   Zend_Acl::setRule()
      * @return Zend_Acl Provides a fluent interface
      */
-    public function deny($roles = null, $resources = null, $privileges = null, Zend_Acl_Assert_Interface $assert = null)
+    public function deny($roles = null, $resources = null, $privileges = null, ?Zend_Acl_Assert_Interface $assert = null)
     {
         return $this->setRule(self::OP_ADD, self::TYPE_DENY, $roles, $resources, $privileges, $assert);
     }
@@ -600,7 +600,7 @@ class Zend_Acl
      * @return Zend_Acl Provides a fluent interface
      */
     public function setRule($operation, $type, $roles = null, $resources = null, $privileges = null,
-                            Zend_Acl_Assert_Interface $assert = null)
+                            ?Zend_Acl_Assert_Interface $assert = null)
     {
         // ensure that the rule type is valid; normalize input to uppercase
         $type = strtoupper($type);
@@ -919,7 +919,7 @@ class Zend_Acl
      * @param  Zend_Acl_Resource_Interface $resource
      * @return boolean|null
      */
-    protected function _roleDFSAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null)
+    protected function _roleDFSAllPrivileges(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null)
     {
         $dfs = array(
             'visited' => array(),
@@ -955,7 +955,7 @@ class Zend_Acl
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                                  &$dfs = null)
     {
         if (null === $dfs) {
@@ -998,7 +998,7 @@ class Zend_Acl
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                             $privilege = null)
     {
         if (null === $privilege) {
@@ -1044,7 +1044,7 @@ class Zend_Acl
      * @return boolean|null
      * @throws Zend_Acl_Exception
      */
-    protected function _roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    protected function _roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                                 $privilege = null, &$dfs = null)
     {
         if (null === $privilege) {
@@ -1098,7 +1098,7 @@ class Zend_Acl
      * @param  string                      $privilege
      * @return string|null
      */
-    protected function _getRuleType(Zend_Acl_Resource_Interface $resource = null, Zend_Acl_Role_Interface $role = null,
+    protected function _getRuleType(?Zend_Acl_Resource_Interface $resource = null, ?Zend_Acl_Role_Interface $role = null,
                                     $privilege = null)
     {
         // get the rules for the $resource and $role
@@ -1154,7 +1154,7 @@ class Zend_Acl
      * @param  boolean                     $create
      * @return array|null
      */
-    protected function &_getRules(Zend_Acl_Resource_Interface $resource = null, Zend_Acl_Role_Interface $role = null,
+    protected function &_getRules(?Zend_Acl_Resource_Interface $resource = null, ?Zend_Acl_Role_Interface $role = null,
                                   $create = false)
     {
         // create a reference to null

--- a/packages/zend-acl/library/Zend/Acl/Assert/Interface.php
+++ b/packages/zend-acl/library/Zend/Acl/Assert/Interface.php
@@ -59,6 +59,6 @@ interface Zend_Acl_Assert_Interface
      * @param  string                      $privilege
      * @return boolean
      */
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $role = null, Zend_Acl_Resource_Interface $resource = null,
+    public function assert(Zend_Acl $acl, ?Zend_Acl_Role_Interface $role = null, ?Zend_Acl_Resource_Interface $resource = null,
                            $privilege = null);
 }

--- a/packages/zend-amf/composer.json
+++ b/packages/zend-amf/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-server": "^1.15.6",

--- a/packages/zend-application/composer.json
+++ b/packages/zend-application/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-config": "^1.15.6",
         "zf1s/zend-controller": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-auth/composer.json
+++ b/packages/zend-auth/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-auth/library/Zend/Auth/Adapter/DbTable.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/DbTable.php
@@ -133,7 +133,7 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
      * @param  string                   $credentialColumn
      * @param  string                   $credentialTreatment
      */
-    public function __construct(Zend_Db_Adapter_Abstract $zendDb = null, $tableName = null, $identityColumn = null,
+    public function __construct(?Zend_Db_Adapter_Abstract $zendDb = null, $tableName = null, $identityColumn = null,
                                 $credentialColumn = null, $credentialTreatment = null)
     {
         $this->_setDbAdapter($zendDb);
@@ -162,7 +162,7 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
      * @throws Zend_Auth_Adapter_Exception
      * @return Zend_Auth_Adapter_DbTable
      */
-    protected function _setDbAdapter(Zend_Db_Adapter_Abstract $zendDb = null)
+    protected function _setDbAdapter(?Zend_Db_Adapter_Abstract $zendDb = null)
     {
         $this->_zendDb = $zendDb;
 

--- a/packages/zend-auth/library/Zend/Auth/Adapter/Http/Resolver/File.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/Http/Resolver/File.php
@@ -152,7 +152,7 @@ class Zend_Auth_Adapter_Http_Resolver_File implements Zend_Auth_Adapter_Http_Res
 
         // No real validation is done on the contents of the password file. The
         // assumption is that we trust the administrators to keep it secure.
-        while (($line = fgetcsv($fp, 512, ':')) !== false) {
+        while (($line = fgetcsv($fp, 512, ':', '"', '\\')) !== false) {
             if ($line[0] == $username && $line[1] == $realm) {
                 $password = $line[2];
                 fclose($fp);

--- a/packages/zend-auth/library/Zend/Auth/Adapter/OpenId.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/OpenId.php
@@ -115,11 +115,11 @@ class Zend_Auth_Adapter_OpenId implements Zend_Auth_Adapter_Interface
      *        object to perform HTTP or HTML form redirection
      */
     public function __construct($id = null,
-                                Zend_OpenId_Consumer_Storage $storage = null,
+                                ?Zend_OpenId_Consumer_Storage $storage = null,
                                 $returnTo = null,
                                 $root = null,
                                 $extensions = null,
-                                Zend_Controller_Response_Abstract $response = null) {
+                                ?Zend_Controller_Response_Abstract $response = null) {
         $this->_id         = $id;
         $this->_storage    = $storage;
         $this->_returnTo   = $returnTo;

--- a/packages/zend-barcode/composer.json
+++ b/packages/zend-barcode/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-validate": "^1.15.6"
     },

--- a/packages/zend-cache/composer.json
+++ b/packages/zend-cache/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-cache/library/Zend/Cache.php
+++ b/packages/zend-cache/library/Zend/Cache.php
@@ -202,7 +202,7 @@ abstract class Zend_Cache
      * @param  string $msg  Message for the exception
      * @throws Zend_Cache_Exception
      */
-    public static function throwException($msg, Exception $e = null)
+    public static function throwException($msg, ?Exception $e = null)
     {
         // For perfs reasons, we use this dynamic inclusion
         // require_once 'Zend/Cache/Exception.php';

--- a/packages/zend-captcha/composer.json
+++ b/packages/zend-captcha/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-gd": "*",
         "zf1s/zend-crypt": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-captcha/library/Zend/Captcha/Adapter.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Adapter.php
@@ -50,7 +50,7 @@ interface Zend_Captcha_Adapter extends Zend_Validate_Interface
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null);
+    public function render(?Zend_View_Interface $view = null, $element = null);
 
     /**
      * Set captcha name

--- a/packages/zend-captcha/library/Zend/Captcha/Dumb.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Dumb.php
@@ -66,7 +66,7 @@ class Zend_Captcha_Dumb extends Zend_Captcha_Word
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render(?Zend_View_Interface $view = null, $element = null)
     {
         return $this->getLabel() . ': <b>'
              . strrev($this->getWord())

--- a/packages/zend-captcha/library/Zend/Captcha/Figlet.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Figlet.php
@@ -75,7 +75,7 @@ class Zend_Captcha_Figlet extends Zend_Captcha_Word
      * @param mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render(?Zend_View_Interface $view = null, $element = null)
     {
         return '<pre>'
              . $this->_figlet->render($this->getWord())

--- a/packages/zend-captcha/library/Zend/Captcha/Image.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Image.php
@@ -616,7 +616,7 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
      * @param mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render(?Zend_View_Interface $view = null, $element = null)
     {
         $endTag = ' />';
         if (($view instanceof Zend_View_Abstract) && !$view->doctype()->isXhtml()) {

--- a/packages/zend-captcha/library/Zend/Captcha/ReCaptcha.php
+++ b/packages/zend-captcha/library/Zend/Captcha/ReCaptcha.php
@@ -259,7 +259,7 @@ class Zend_Captcha_ReCaptcha extends Zend_Captcha_Base
      * @param  mixed $element
      * @return string
      */
-    public function render(Zend_View_Interface $view = null, $element = null)
+    public function render(?Zend_View_Interface $view = null, $element = null)
     {
         $name = null;
         if ($element instanceof Zend_Form_Element) {

--- a/packages/zend-cloud/composer.json
+++ b/packages/zend-cloud/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter.php
@@ -72,7 +72,7 @@ interface Zend_Cloud_DocumentService_Adapter
      * @param  null|array $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null);
+    public function listDocuments($collectionName, ?array $options = null);
 
     /**
      * Insert document

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/SimpleDb.php
@@ -157,7 +157,7 @@ class Zend_Cloud_DocumentService_Adapter_SimpleDb
      * @param  array|null $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null)
+    public function listDocuments($collectionName, ?array $options = null)
     {
         $query = $this->select('*')->from($collectionName);
         $items = $this->query($collectionName, $query, $options);

--- a/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
+++ b/packages/zend-cloud/library/Zend/Cloud/DocumentService/Adapter/WindowsAzure.php
@@ -265,7 +265,7 @@ class Zend_Cloud_DocumentService_Adapter_WindowsAzure
      * @param  null|array $options
      * @return Zend_Cloud_DocumentService_DocumentSet
      */
-    public function listDocuments($collectionName, array $options = null)
+    public function listDocuments($collectionName, ?array $options = null)
     {
         $select = $this->select()->from($collectionName);
         return $this->query($collectionName, $select);

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/InstanceList.php
@@ -41,7 +41,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param  array $instances
      * @return void
      */
-    public function __construct($adapter, array $instances = null)
+    public function __construct($adapter, ?array $instances = null)
     {
         if (!($adapter instanceof Zend_Cloud_Infrastructure_Adapter)) {
             // require_once 'Zend/Cloud/Infrastructure/Exception.php';

--- a/packages/zend-codegenerator/composer.json
+++ b/packages/zend-codegenerator/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-reflection": "^1.15.6"
     },

--- a/packages/zend-config/composer.json
+++ b/packages/zend-config/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6"
     },

--- a/packages/zend-config/library/Zend/Config/Writer.php
+++ b/packages/zend-config/library/Zend/Config/Writer.php
@@ -50,7 +50,7 @@ abstract class Zend_Config_Writer
      *
      * @param null|array $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         if (is_array($options)) {
             $this->setOptions($options);

--- a/packages/zend-config/library/Zend/Config/Writer/FileAbstract.php
+++ b/packages/zend-config/library/Zend/Config/Writer/FileAbstract.php
@@ -80,7 +80,7 @@ class Zend_Config_Writer_FileAbstract extends Zend_Config_Writer
      * @param bool $exclusiveLock
      * @return void
      */
-    public function write($filename = null, Zend_Config $config = null, $exclusiveLock = null)
+    public function write($filename = null, ?Zend_Config $config = null, $exclusiveLock = null)
     {
         if ($filename !== null) {
             $this->setFilename($filename);

--- a/packages/zend-console-getopt/composer.json
+++ b/packages/zend-console-getopt/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-controller/composer.json
+++ b/packages/zend-controller/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-reflection": "*",
         "ext-session": "*",
         "zf1s/zend-config": "^1.15.6",

--- a/packages/zend-controller/library/Zend/Controller/Action.php
+++ b/packages/zend-controller/library/Zend/Controller/Action.php
@@ -558,7 +558,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * object to use
      * @return Zend_Controller_Response_Abstract
      */
-    public function run(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
+    public function run(?Zend_Controller_Request_Abstract $request = null, ?Zend_Controller_Response_Abstract $response = null)
     {
         if (null !== $request) {
             $this->setRequest($request);
@@ -726,7 +726,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             forward() instead.
      */
-    final protected function _forward($action, $controller = null, $module = null, array $params = null)
+    final protected function _forward($action, $controller = null, $module = null, ?array $params = null)
     {
         $this->forward($action, $controller, $module, $params);
     }
@@ -757,7 +757,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param array $params
      * @return void
      */
-    final public function forward($action, $controller = null, $module = null, array $params = null)
+    final public function forward($action, $controller = null, $module = null, ?array $params = null)
     {
         $request = $this->getRequest();
 

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/Abstract.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/Abstract.php
@@ -52,7 +52,7 @@ abstract class Zend_Controller_Action_Helper_Abstract
      * @param  Zend_Controller_Action $actionController
      * @return Zend_Controller_ActionHelper_Abstract Provides a fluent interface
      */
-    public function setActionController(Zend_Controller_Action $actionController = null)
+    public function setActionController(?Zend_Controller_Action $actionController = null)
     {
         $this->_actionController = $actionController;
         return $this;

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/Url.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/Url.php
@@ -46,7 +46,7 @@ class Zend_Controller_Action_Helper_Url extends Zend_Controller_Action_Helper_Ab
      * @param  array  $params
      * @return string
      */
-    public function simple($action, $controller = null, $module = null, array $params = null)
+    public function simple($action, $controller = null, $module = null, ?array $params = null)
     {
         $request = $this->getRequest();
 
@@ -110,7 +110,7 @@ class Zend_Controller_Action_Helper_Url extends Zend_Controller_Action_Helper_Ab
      * @param  array  $params
      * @return string
      */
-    public function direct($action, $controller = null, $module = null, array $params = null)
+    public function direct($action, $controller = null, $module = null, ?array $params = null)
     {
         return $this->simple($action, $controller, $module, $params);
     }

--- a/packages/zend-controller/library/Zend/Controller/Action/Helper/ViewRenderer.php
+++ b/packages/zend-controller/library/Zend/Controller/Action/Helper/ViewRenderer.php
@@ -179,7 +179,7 @@ class Zend_Controller_Action_Helper_ViewRenderer extends Zend_Controller_Action_
      * @param  array               $options
      * @return void
      */
-    public function __construct(Zend_View_Interface $view = null, array $options = array())
+    public function __construct(?Zend_View_Interface $view = null, array $options = array())
     {
         if (null !== $view) {
             $this->setView($view);

--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Abstract.php
@@ -356,7 +356,7 @@ abstract class Zend_Controller_Dispatcher_Abstract implements Zend_Controller_Di
      * @param Zend_Controller_Response_Abstract|null $response
      * @return Zend_Controller_Dispatcher_Abstract
      */
-    public function setResponse(Zend_Controller_Response_Abstract $response = null)
+    public function setResponse(?Zend_Controller_Response_Abstract $response = null)
     {
         $this->_response = $response;
         return $this;

--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Interface.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Interface.php
@@ -129,7 +129,7 @@ interface Zend_Controller_Dispatcher_Interface
      * @param Zend_Controller_Response_Abstract|null $response
      * @return void
      */
-    public function setResponse(Zend_Controller_Response_Abstract $response = null);
+    public function setResponse(?Zend_Controller_Response_Abstract $response = null);
 
     /**
      * Retrieve the response object, if any

--- a/packages/zend-controller/library/Zend/Controller/Front.php
+++ b/packages/zend-controller/library/Zend/Controller/Front.php
@@ -832,7 +832,7 @@ class Zend_Controller_Front
      * @param Zend_Controller_Response_Abstract|null $response
      * @return void|Zend_Controller_Response_Abstract Returns response object if returnResponse() is true
      */
-    public function dispatch(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
+    public function dispatch(?Zend_Controller_Request_Abstract $request = null, ?Zend_Controller_Response_Abstract $response = null)
     {
         if (!$this->getParam('noErrorHandler') && !$this->_plugins->hasPlugin('Zend_Controller_Plugin_ErrorHandler')) {
             // Register with stack index of 100

--- a/packages/zend-controller/library/Zend/Controller/Plugin/ActionStack.php
+++ b/packages/zend-controller/library/Zend/Controller/Plugin/ActionStack.php
@@ -73,7 +73,7 @@ class Zend_Controller_Plugin_ActionStack extends Zend_Controller_Plugin_Abstract
      * @param  string $key
      * @return void
      */
-    public function __construct(Zend_Registry $registry = null, $key = null)
+    public function __construct(?Zend_Registry $registry = null, $key = null)
     {
         if (null === $registry) {
             $registry = Zend_Registry::getInstance();

--- a/packages/zend-controller/library/Zend/Controller/Router/Route.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route.php
@@ -171,7 +171,7 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
      * @param mixed|null     $locale
      */
     public function __construct(
-        $route, $defaults = array(), $reqs = array(), Zend_Translate $translator = null, $locale = null
+        $route, $defaults = array(), $reqs = array(), ?Zend_Translate $translator = null, $locale = null
     )
     {
         $route               = trim($route, $this->_urlDelimiter);
@@ -487,7 +487,7 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
      * @param  Zend_Translate $translator
      * @return void
      */
-    public static function setDefaultTranslator(Zend_Translate $translator = null)
+    public static function setDefaultTranslator(?Zend_Translate $translator = null)
     {
         self::$_defaultTranslator = $translator;
     }

--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Chain.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Chain.php
@@ -183,7 +183,7 @@ class Zend_Controller_Router_Route_Chain extends Zend_Controller_Router_Route_Ab
      * @param  Zend_Controller_Request_Abstract|null $request
      * @return void
      */
-    public function setRequest(Zend_Controller_Request_Abstract $request = null)
+    public function setRequest(?Zend_Controller_Request_Abstract $request = null)
     {
         $this->_request = $request;
 

--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Hostname.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Hostname.php
@@ -121,7 +121,7 @@ class Zend_Controller_Router_Route_Hostname extends Zend_Controller_Router_Route
      *
      * @param  Zend_Controller_Request_Abstract|null $request
      */
-    public function setRequest(Zend_Controller_Request_Abstract $request = null)
+    public function setRequest(?Zend_Controller_Request_Abstract $request = null)
     {
         $this->_request = $request;
     }

--- a/packages/zend-controller/library/Zend/Controller/Router/Route/Module.php
+++ b/packages/zend-controller/library/Zend/Controller/Router/Route/Module.php
@@ -117,8 +117,8 @@ class Zend_Controller_Router_Route_Module extends Zend_Controller_Router_Route_A
      */
     public function __construct(
         array $defaults = array(),
-        Zend_Controller_Dispatcher_Interface $dispatcher = null,
-        Zend_Controller_Request_Abstract $request = null
+        ?Zend_Controller_Dispatcher_Interface $dispatcher = null,
+        ?Zend_Controller_Request_Abstract $request = null
     )
     {
         $this->_defaults = $defaults;

--- a/packages/zend-crypt/composer.json
+++ b/packages/zend-crypt/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-crypt/library/Zend/Crypt/Rsa.php
+++ b/packages/zend-crypt/library/Zend/Crypt/Rsa.php
@@ -67,7 +67,7 @@ class Zend_Crypt_Rsa
      * @param array $options
      * @throws Zend_Crypt_Rsa_Exception
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         if (!extension_loaded('openssl')) {
             // require_once 'Zend/Crypt/Rsa/Exception.php';
@@ -125,7 +125,7 @@ class Zend_Crypt_Rsa
      * @param string $format
      * @return string
      */
-    public function sign($data, Zend_Crypt_Rsa_Key_Private $privateKey = null, $format = null)
+    public function sign($data, ?Zend_Crypt_Rsa_Key_Private $privateKey = null, $format = null)
     {
         $signature = '';
         if (isset($privateKey)) {
@@ -208,7 +208,7 @@ class Zend_Crypt_Rsa
      * 
      * @return ArrayObject
      */
-    public function generateKeys(array $configargs = null)
+    public function generateKeys(?array $configargs = null)
     {
         $config = null;
         $passPhrase = null;
@@ -320,7 +320,7 @@ class Zend_Crypt_Rsa
         return $this->_hashAlgorithm;
     }
 
-    protected function _parseConfigArgs(array $config = null)
+    protected function _parseConfigArgs(?array $config = null)
     {
         $configs = array();
         if (isset($config['private_key_bits'])) {

--- a/packages/zend-currency/composer.json
+++ b/packages/zend-currency/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-iconv": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-locale": "^1.15.6"

--- a/packages/zend-date/composer.json
+++ b/packages/zend-date/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-locale": "^1.15.6"
     },

--- a/packages/zend-db/composer.json
+++ b/packages/zend-db/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6"
     },

--- a/packages/zend-db/library/Zend/Db/Adapter/Db2/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Db2/Exception.php
@@ -38,7 +38,7 @@ class Zend_Db_Adapter_Db2_Exception extends Zend_Db_Adapter_Exception
    protected $code = '00000';
    protected $message = 'unknown exception';
 
-   function __construct($message = 'unknown exception', $code = '00000', Exception $e = null)
+   function __construct($message = 'unknown exception', $code = '00000', ?Exception $e = null)
    {
        parent::__construct($message, $code, $e);
    }

--- a/packages/zend-db/library/Zend/Db/Adapter/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Exception.php
@@ -36,7 +36,7 @@ class Zend_Db_Adapter_Exception extends Zend_Db_Exception
 {
     protected $_chainedException = null;
 
-    public function __construct($message = '', $code = 0, Exception $e = null)
+    public function __construct($message = '', $code = 0, ?Exception $e = null)
     {
         if ($e && (0 === $code)) {
             $code = $e->getCode();

--- a/packages/zend-db/library/Zend/Db/Statement.php
+++ b/packages/zend-db/library/Zend/Db/Statement.php
@@ -294,7 +294,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
      * @param array $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      */
-    public function execute(array $params = null)
+    public function execute(?array $params = null)
     {
         /*
          * Simple case - no query profiler to manage.

--- a/packages/zend-db/library/Zend/Db/Statement/Db2.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Db2.php
@@ -191,7 +191,7 @@ class Zend_Db_Statement_Db2 extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Db2_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         if (!$this->_stmt) {
             return false;

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli.php
@@ -184,7 +184,7 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Mysqli_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         if (!$this->_stmt) {
             return false;

--- a/packages/zend-db/library/Zend/Db/Statement/Oracle.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Oracle.php
@@ -226,7 +226,7 @@ class Zend_Db_Statement_Oracle extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         $connection = $this->_adapter->getConnection();
 

--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -221,7 +221,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         try {
             if ($params !== null) {

--- a/packages/zend-db/library/Zend/Db/Statement/Sqlsrv.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Sqlsrv.php
@@ -174,7 +174,7 @@ class Zend_Db_Statement_Sqlsrv extends Zend_Db_Statement
      * @return bool
      * @throws Zend_Db_Statement_Exception
      */
-    public function _execute(array $params = null)
+    public function _execute(?array $params = null)
     {
         $connection = $this->_adapter->getConnection();
         if (!$this->_stmt) {

--- a/packages/zend-db/library/Zend/Db/Table/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Abstract.php
@@ -1587,7 +1587,7 @@ abstract class Zend_Db_Table_Abstract
      * @throws Zend_Db_Table_Row_Exception
      * @return Zend_Db_Table_Abstract
      */
-    public static function getTableFromString($tableName, Zend_Db_Table_Abstract $referenceTable = null)
+    public static function getTableFromString($tableName, ?Zend_Db_Table_Abstract $referenceTable = null)
     {
         if ($referenceTable instanceof Zend_Db_Table_Abstract) {
             $tableDefinition = $referenceTable->getDefinition();

--- a/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
+++ b/packages/zend-db/library/Zend/Db/Table/Row/Abstract.php
@@ -336,7 +336,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @return boolean
      * @throws Zend_Db_Table_Row_Exception
      */
-    public function setTable(Zend_Db_Table_Abstract $table = null)
+    public function setTable(?Zend_Db_Table_Abstract $table = null)
     {
         if ($table == null) {
             $this->_table = null;
@@ -880,7 +880,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @return Zend_Db_Table_Rowset_Abstract Query result from $dependentTable
      * @throws Zend_Db_Table_Row_Exception If $dependentTable is not a table or is not loadable.
      */
-    public function findDependentRowset($dependentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findDependentRowset($dependentTable, $ruleKey = null, ?Zend_Db_Table_Select $select = null)
     {
         $db = $this->_getTable()->getAdapter();
 
@@ -936,7 +936,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @return Zend_Db_Table_Row_Abstract   Query result from $parentTable
      * @throws Zend_Db_Table_Row_Exception If $parentTable is not a table or is not loadable.
      */
-    public function findParentRow($parentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findParentRow($parentTable, $ruleKey = null, ?Zend_Db_Table_Select $select = null)
     {
         $db = $this->_getTable()->getAdapter();
 
@@ -1004,7 +1004,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @throws Zend_Db_Table_Row_Exception If $matchTable or $intersectionTable is not a table class or is not loadable.
      */
     public function findManyToManyRowset($matchTable, $intersectionTable, $callerRefRule = null,
-                                         $matchRefRule = null, Zend_Db_Table_Select $select = null)
+                                         $matchRefRule = null, ?Zend_Db_Table_Select $select = null)
     {
         $db = $this->_getTable()->getAdapter();
 

--- a/packages/zend-debug/composer.json
+++ b/packages/zend-debug/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-dojo/composer.json
+++ b/packages/zend-dojo/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-form": "^1.15.6",
         "zf1s/zend-json": "^1.15.6",

--- a/packages/zend-dojo/library/Zend/Dojo/Form.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form.php
@@ -77,7 +77,7 @@ class Zend_Dojo_Form extends Zend_Form
      * @param  Zend_View_Interface $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {

--- a/packages/zend-dojo/library/Zend/Dojo/Form/DisplayGroup.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form/DisplayGroup.php
@@ -56,7 +56,7 @@ class Zend_Dojo_Form_DisplayGroup extends Zend_Form_DisplayGroup
      * @param  Zend_View_Interface $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {

--- a/packages/zend-dojo/library/Zend/Dojo/Form/Element/Dijit.php
+++ b/packages/zend-dojo/library/Zend/Dojo/Form/Element/Dijit.php
@@ -177,7 +177,7 @@ abstract class Zend_Dojo_Form_Element_Dijit extends Zend_Form_Element
      * @param  Zend_View_Interface $view
      * @return Zend_Dojo_Form_Element_Dijit
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             if (false === $view->getPluginLoader('helper')->getPaths('Zend_Dojo_View_Helper')) {

--- a/packages/zend-dojo/library/Zend/Dojo/View/Helper/CheckBox.php
+++ b/packages/zend-dojo/library/Zend/Dojo/View/Helper/CheckBox.php
@@ -62,7 +62,7 @@ class Zend_Dojo_View_Helper_CheckBox extends Zend_Dojo_View_Helper_Dijit
      * @param  array $checkedOptions Should contain either two items, or the keys checkedValue and uncheckedValue
      * @return string
      */
-    public function checkBox($id, $value = null, array $params = array(), array $attribs = array(), array $checkedOptions = null)
+    public function checkBox($id, $value = null, array $params = array(), array $attribs = array(), ?array $checkedOptions = null)
     {
         // Prepare the checkbox options
         // require_once 'Zend/View/Helper/FormCheckbox.php';

--- a/packages/zend-dojo/library/Zend/Dojo/View/Helper/ComboBox.php
+++ b/packages/zend-dojo/library/Zend/Dojo/View/Helper/ComboBox.php
@@ -62,7 +62,7 @@ class Zend_Dojo_View_Helper_ComboBox extends Zend_Dojo_View_Helper_Dijit
      * @param  array|null $options Select options
      * @return string
      */
-    public function comboBox($id, $value = null, array $params = array(), array $attribs = array(), array $options = null)
+    public function comboBox($id, $value = null, array $params = array(), array $attribs = array(), ?array $options = null)
     {
         $html = '';
         if (!array_key_exists('id', $attribs)) {

--- a/packages/zend-dojo/library/Zend/Dojo/View/Helper/FilteringSelect.php
+++ b/packages/zend-dojo/library/Zend/Dojo/View/Helper/FilteringSelect.php
@@ -56,7 +56,7 @@ class Zend_Dojo_View_Helper_FilteringSelect extends Zend_Dojo_View_Helper_ComboB
      * @param  array|null $options Select options
      * @return string
      */
-    public function filteringSelect($id, $value = null, array $params = array(), array $attribs = array(), array $options = null)
+    public function filteringSelect($id, $value = null, array $params = array(), array $attribs = array(), ?array $options = null)
     {
         return $this->comboBox($id, $value, $params, $attribs, $options);
     }

--- a/packages/zend-dojo/library/Zend/Dojo/View/Helper/RadioButton.php
+++ b/packages/zend-dojo/library/Zend/Dojo/View/Helper/RadioButton.php
@@ -62,7 +62,7 @@ class Zend_Dojo_View_Helper_RadioButton extends Zend_Dojo_View_Helper_Dijit
         $value = null,
         array $params = array(),
         array $attribs = array(),
-        array $options = null,
+        ?array $options = null,
         $listsep = "<br />\n"
     ) {
         $attribs['name'] = $id;

--- a/packages/zend-dom/composer.json
+++ b/packages/zend-dom/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6"

--- a/packages/zend-eventmanager/composer.json
+++ b/packages/zend-eventmanager/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-stdlib": "^1.15.6"
     },

--- a/packages/zend-eventmanager/library/Zend/EventManager/GlobalEventManager.php
+++ b/packages/zend-eventmanager/library/Zend/EventManager/GlobalEventManager.php
@@ -45,7 +45,7 @@ class Zend_EventManager_GlobalEventManager
      * @param  null|Zend_EventManager_EventCollection $events 
      * @return void
      */
-    public static function setEventCollection(Zend_EventManager_EventCollection $events = null)
+    public static function setEventCollection(?Zend_EventManager_EventCollection $events = null)
     {
         self::$events = $events;
     }

--- a/packages/zend-exception/composer.json
+++ b/packages/zend-exception/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-feed/composer.json
+++ b/packages/zend-feed/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",

--- a/packages/zend-feed/composer.json
+++ b/packages/zend-feed/composer.json
@@ -14,8 +14,7 @@
         "zf1s/zend-loader": "^1.15.6",
         "zf1s/zend-uri": "^1.15.6",
         "zf1s/zend-version": "^1.15.6",
-        "zf1s/zend-xml": "^1.15.6",
-        "symfony/polyfill-php70": "^1.19"
+        "zf1s/zend-xml": "^1.15.6"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-feed/library/Zend/Feed/Abstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Abstract.php
@@ -71,7 +71,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      * @return void
      * @throws Zend_Feed_Exception If loading the feed failed.
      */
-    public function __construct($uri = null, $string = null, Zend_Feed_Builder_Interface $builder = null)
+    public function __construct($uri = null, $string = null, ?Zend_Feed_Builder_Interface $builder = null)
     {
         if ($uri !== null) {
             // Retrieve the feed via HTTP

--- a/packages/zend-feed/library/Zend/Feed/Atom.php
+++ b/packages/zend-feed/library/Zend/Feed/Atom.php
@@ -98,7 +98,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             }
 
             $doc = new DOMDocument($this->_element->version,
-                                   $this->_element->actualEncoding);
+                                   $this->_element->encoding);
             $feed = $doc->appendChild($doc->createElement('feed'));
             $feed->appendChild($doc->importNode($element, true));
             $element = $feed;
@@ -360,7 +360,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         $doc->formatOutput = true;
 
@@ -383,7 +383,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send ATOM because headers have already been sent.');
         }
 
-        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXML();
     }

--- a/packages/zend-feed/library/Zend/Feed/Element.php
+++ b/packages/zend-feed/library/Zend/Feed/Element.php
@@ -135,7 +135,7 @@ class Zend_Feed_Element implements ArrayAccess
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument((string) $this->_element->ownerDocument->version,
-                               (string) $this->_element->ownerDocument->actualEncoding);
+                               (string) $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         return $doc->saveXML();
     }

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/CallbackInterface.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/CallbackInterface.php
@@ -37,7 +37,7 @@ interface Zend_Feed_Pubsubhubbub_CallbackInterface
      * @param array $httpData GET/POST data if available and not in $_GET/POST
      * @param bool $sendResponseNow Whether to send response now or when asked
      */
-    public function handle(array $httpData = null, $sendResponseNow = false);
+    public function handle(?array $httpData = null, $sendResponseNow = false);
 
     /**
      * Send the response, including all headers.

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Model/ModelAbstract.php
@@ -49,7 +49,7 @@ class Zend_Feed_Pubsubhubbub_Model_ModelAbstract
      *
      * @param  Zend_Db_Table_Abstract $tableGateway
      */
-    public function __construct(Zend_Db_Table_Abstract $tableGateway = null)
+    public function __construct(?Zend_Db_Table_Abstract $tableGateway = null)
     {
         if ($tableGateway === null) {
             $parts = explode('_', get_class($this));

--- a/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
+++ b/packages/zend-feed/library/Zend/Feed/Pubsubhubbub/Subscriber/Callback.php
@@ -89,7 +89,7 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * @param  bool $sendResponseNow Whether to send response now or when asked
      * @return void
      */
-    public function handle(array $httpGetData = null, $sendResponseNow = false)
+    public function handle(?array $httpGetData = null, $sendResponseNow = false)
     {
         if ($httpGetData === null) {
             $httpGetData = $_GET;
@@ -234,7 +234,7 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * @param  bool $checkValue
      * @return bool
      */
-    protected function _hasValidVerifyToken(array $httpGetData = null, $checkValue = true)
+    protected function _hasValidVerifyToken(?array $httpGetData = null, $checkValue = true)
     {
         $verifyTokenKey = $this->_detectVerifyTokenKey($httpGetData);
         if (empty($verifyTokenKey)) {
@@ -264,7 +264,7 @@ class Zend_Feed_Pubsubhubbub_Subscriber_Callback
      * @param  null|array $httpGetData
      * @return false|string
      */
-    protected function _detectVerifyTokenKey(array $httpGetData = null)
+    protected function _detectVerifyTokenKey(?array $httpGetData = null)
     {
         /**
          * Available when sub keys encoding in Callback URL path

--- a/packages/zend-feed/library/Zend/Feed/Reader/Extension/FeedAbstract.php
+++ b/packages/zend-feed/library/Zend/Feed/Reader/Extension/FeedAbstract.php
@@ -78,7 +78,7 @@ abstract class Zend_Feed_Reader_Extension_FeedAbstract
      * @param  string $type Feed type
      * @return void
      */
-    public function __construct(DomDocument $dom, $type = null, DOMXPath $xpath = null)
+    public function __construct(DomDocument $dom, $type = null, ?DOMXPath $xpath = null)
     {
         $this->_domDocument = $dom;
 

--- a/packages/zend-feed/library/Zend/Feed/Rss.php
+++ b/packages/zend-feed/library/Zend/Feed/Rss.php
@@ -487,7 +487,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $root = $doc->createElement('rss');
 
         // Use rss version 2.0
@@ -522,7 +522,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send RSS because headers have already been sent.');
         }
 
-        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXml();
     }

--- a/packages/zend-file-transfer/composer.json
+++ b/packages/zend-file-transfer/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-file/composer.json
+++ b/packages/zend-file/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-filter/composer.json
+++ b/packages/zend-filter/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-reflection": "*",
         "zf1s/zend-crypt": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-filter/library/Zend/Filter/Input.php
+++ b/packages/zend-filter/library/Zend/Filter/Input.php
@@ -162,7 +162,7 @@ class Zend_Filter_Input
      * @param array $data       OPTIONAL
      * @param array $options    OPTIONAL
      */
-    public function __construct($filterRules, $validatorRules, array $data = null, array $options = null)
+    public function __construct($filterRules, $validatorRules, ?array $data = null, ?array $options = null)
     {
         if ($options) {
             $this->setOptions($options);

--- a/packages/zend-filter/library/Zend/Filter/LocalizedToNormalized.php
+++ b/packages/zend-filter/library/Zend/Filter/LocalizedToNormalized.php
@@ -81,7 +81,7 @@ class Zend_Filter_LocalizedToNormalized implements Zend_Filter_Interface
      * @param  array $options (Optional) Options to use
      * @return Zend_Filter_LocalizedToNormalized
      */
-    public function setOptions(array $options = null)
+    public function setOptions(?array $options = null)
     {
         $this->_options = $options + $this->_options;
         return $this;

--- a/packages/zend-filter/library/Zend/Filter/NormalizedToLocalized.php
+++ b/packages/zend-filter/library/Zend/Filter/NormalizedToLocalized.php
@@ -80,7 +80,7 @@ class Zend_Filter_NormalizedToLocalized implements Zend_Filter_Interface
      * @param  array $options (Optional) Options to use
      * @return Zend_Filter_LocalizedToNormalized
      */
-    public function setOptions(array $options = null)
+    public function setOptions(?array $options = null)
     {
         $this->_options = $options + $this->_options;
         return $this;

--- a/packages/zend-form/composer.json
+++ b/packages/zend-form/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-filter": "^1.15.6",
         "zf1s/zend-validate": "^1.15.6"

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -2674,7 +2674,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @param  Zend_View_Interface $view
      * @return Zend_Form
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         $this->_view = $view;
         return $this;
@@ -2912,7 +2912,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @param  bool $include Whether $elements is an inclusion or exclusion list
      * @return Zend_Form
      */
-    public function setElementDecorators(array $decorators, array $elements = null, $include = true)
+    public function setElementDecorators(array $decorators, ?array $elements = null, $include = true)
     {
         if (is_array($elements)) {
             if ($include) {
@@ -2982,7 +2982,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @param  Zend_View_Interface $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             $this->setView($view);

--- a/packages/zend-form/library/Zend/Form/Decorator/HtmlTag.php
+++ b/packages/zend-form/library/Zend/Form/Decorator/HtmlTag.php
@@ -159,7 +159,7 @@ class Zend_Form_Decorator_HtmlTag extends Zend_Form_Decorator_Abstract
      * @param  array $attribs
      * @return string
      */
-    protected function _getOpenTag($tag, array $attribs = null)
+    protected function _getOpenTag($tag, ?array $attribs = null)
     {
         $html = '<' . $tag;
         if (null !== $attribs) {

--- a/packages/zend-form/library/Zend/Form/DisplayGroup.php
+++ b/packages/zend-form/library/Zend/Form/DisplayGroup.php
@@ -888,7 +888,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      * @param  Zend_View_Interface $view
      * @return Zend_Form_DisplayGroup
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         $this->_view = $view;
         return $this;
@@ -915,7 +915,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             $this->setView($view);

--- a/packages/zend-form/library/Zend/Form/Element.php
+++ b/packages/zend-form/library/Zend/Form/Element.php
@@ -1822,7 +1822,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * @param  Zend_View_Interface $view
      * @return Zend_Form_Element
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         $this->_view = $view;
         return $this;
@@ -2056,7 +2056,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      * @param  Zend_View_Interface $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         if ($this->_isPartialRendering) {
             return '';

--- a/packages/zend-form/library/Zend/Form/Element/Captcha.php
+++ b/packages/zend-form/library/Zend/Form/Element/Captcha.php
@@ -161,7 +161,7 @@ class Zend_Form_Element_Captcha extends Zend_Form_Element_Xhtml
      * @param  Zend_View_Interface $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         $captcha    = $this->getCaptcha();
         $captcha->setName($this->getFullyQualifiedName());

--- a/packages/zend-form/library/Zend/Form/Element/File.php
+++ b/packages/zend-form/library/Zend/Form/Element/File.php
@@ -864,7 +864,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      * @return string
      * @throws Zend_Form_Element_Exception
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         $marker = false;
         foreach ($this->getDecorators() as $decorator) {

--- a/packages/zend-form/library/Zend/Form/Element/Hash.php
+++ b/packages/zend-form/library/Zend/Form/Element/Hash.php
@@ -235,7 +235,7 @@ class Zend_Form_Element_Hash extends Zend_Form_Element_Xhtml
      * @param  Zend_View_Interface $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         $this->initCsrfToken();
         return parent::render($view);

--- a/packages/zend-gdata/composer.json
+++ b/packages/zend-gdata/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "ext-dom": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-gdata/composer.json
+++ b/packages/zend-gdata/composer.json
@@ -12,8 +12,7 @@
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-mime": "^1.15.6",
         "zf1s/zend-version": "^1.15.6",
-        "zf1s/zend-xml": "^1.15.6",
-        "symfony/polyfill-php70": "^1.19"
+        "zf1s/zend-xml": "^1.15.6"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-http/composer.json
+++ b/packages/zend-http/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",

--- a/packages/zend-json/composer.json
+++ b/packages/zend-json/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-reflection": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-server": "^1.15.6",

--- a/packages/zend-layout/composer.json
+++ b/packages/zend-layout/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-controller": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-filter": "^1.15.6",

--- a/packages/zend-layout/library/Zend/Layout/Controller/Action/Helper/Layout.php
+++ b/packages/zend-layout/library/Zend/Layout/Controller/Action/Helper/Layout.php
@@ -56,7 +56,7 @@ class Zend_Layout_Controller_Action_Helper_Layout extends Zend_Controller_Action
      * @param  Zend_Layout $layout
      * @return void
      */
-    public function __construct(Zend_Layout $layout = null)
+    public function __construct(?Zend_Layout $layout = null)
     {
         if (null !== $layout) {
             $this->setLayoutInstance($layout);

--- a/packages/zend-layout/library/Zend/Layout/Controller/Plugin/Layout.php
+++ b/packages/zend-layout/library/Zend/Layout/Controller/Plugin/Layout.php
@@ -48,7 +48,7 @@ class Zend_Layout_Controller_Plugin_Layout extends Zend_Controller_Plugin_Abstra
      * @param  Zend_Layout $layout
      * @return void
      */
-    public function __construct(Zend_Layout $layout = null)
+    public function __construct(?Zend_Layout $layout = null)
     {
         if (null !== $layout) {
             $this->setLayout($layout);

--- a/packages/zend-ldap/composer.json
+++ b/packages/zend-ldap/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ldap": "*",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-ldap/library/Zend/Ldap.php
+++ b/packages/zend-ldap/library/Zend/Ldap.php
@@ -103,7 +103,7 @@ class Zend_Ldap
      * @return boolean True if the DN was successfully parsed or false if the string is
      * not a valid DN.
      */
-    public static function explodeDn($dn, array &$keys = null, array &$vals = null)
+    public static function explodeDn($dn, ?array &$keys = null, ?array &$vals = null)
     {
         /**
          * @see Zend_Ldap_Dn
@@ -188,7 +188,7 @@ class Zend_Ldap
      * @param  array $errorMessages
      * @return string
      */
-    public function getLastError(&$errorCode = null, array &$errorMessages = null)
+    public function getLastError(&$errorCode = null, ?array &$errorMessages = null)
     {
         $errorCode = $this->getLastErrorCode();
         $errorMessages = array();
@@ -643,7 +643,7 @@ class Zend_Ldap
      * @return array An array of the attributes representing the account
      * @throws Zend_Ldap_Exception
      */
-    protected function _getAccount($acctname, array $attrs = null)
+    protected function _getAccount($acctname, ?array $attrs = null)
     {
         $baseDn = $this->getBaseDn();
         if (!$baseDn) {

--- a/packages/zend-ldap/library/Zend/Ldap/Dn.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Dn.php
@@ -588,7 +588,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @return array
      * @throws Zend_Ldap_Exception
      */
-    public static function explodeDn($dn, array &$keys = null, array &$vals = null,
+    public static function explodeDn($dn, ?array &$keys = null, ?array &$vals = null,
         $caseFold = self::ATTR_CASEFOLD_NONE)
     {
         $k = array();
@@ -626,7 +626,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @param  string $caseFold
      * @return boolean True if the DN was successfully parsed or false if the string is not a valid DN.
      */
-    public static function checkDn($dn, array &$keys = null, array &$vals = null,
+    public static function checkDn($dn, ?array &$keys = null, ?array &$vals = null,
         $caseFold = self::ATTR_CASEFOLD_NONE)
     {
         /* This is a classic state machine parser. Each iteration of the

--- a/packages/zend-ldap/library/Zend/Ldap/Exception.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Exception.php
@@ -120,7 +120,7 @@ class Zend_Ldap_Exception extends Zend_Exception
      * @param string    $str  An informtive exception message
      * @param int       $code An LDAP error code
      */
-    public function __construct(Zend_Ldap $ldap = null, $str = null, $code = 0)
+    public function __construct(?Zend_Ldap $ldap = null, $str = null, $code = 0)
     {
         $errorMessages = array();
         $message = '';
@@ -153,7 +153,7 @@ class Zend_Ldap_Exception extends Zend_Exception
      * @param Zend_Ldap $ldap A Zend_Ldap object
      * @return int The current error code for the resource
      */
-    public static function getLdapCode(Zend_Ldap $ldap = null)
+    public static function getLdapCode(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             return $ldap->getLastErrorCode();

--- a/packages/zend-ldap/library/Zend/Ldap/Node.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node.php
@@ -96,7 +96,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @param  Zend_Ldap    $ldap
      * @throws Zend_Ldap_Exception
      */
-    protected function __construct(Zend_Ldap_Dn $dn, array $data, $fromDataSource, Zend_Ldap $ldap = null)
+    protected function __construct(Zend_Ldap_Dn $dn, array $data, $fromDataSource, ?Zend_Ldap $ldap = null)
     {
         parent::__construct($dn, $data, $fromDataSource);
         if ($ldap !== null) $this->attachLdap($ldap);
@@ -419,7 +419,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function update(Zend_Ldap $ldap = null)
+    public function update(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $this->attachLdap($ldap);
@@ -907,7 +907,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return boolean
      * @throws Zend_Ldap_Exception
      */
-    public function exists(Zend_Ldap $ldap = null)
+    public function exists(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $this->attachLdap($ldap);
@@ -925,7 +925,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function reload(Zend_Ldap $ldap = null)
+    public function reload(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $this->attachLdap($ldap);
@@ -1057,7 +1057,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node
      * @throws Zend_Ldap_Exception
      */
-    public function getParent(Zend_Ldap $ldap = null)
+    public function getParent(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $this->attachLdap($ldap);

--- a/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
+++ b/packages/zend-ldap/library/Zend/Ldap/Node/Abstract.php
@@ -98,7 +98,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @return Zend_Ldap_Node_Abstract Provides a fluent interface
      * @throws Zend_Ldap_Exception
      */
-    public function reload(Zend_Ldap $ldap = null)
+    public function reload(?Zend_Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $data = $ldap->getEntry($this->_getDn(), array('*', '+'), true);

--- a/packages/zend-loader/composer.json
+++ b/packages/zend-loader/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-locale/composer.json
+++ b/packages/zend-locale/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-iconv": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6",

--- a/packages/zend-log/composer.json
+++ b/packages/zend-log/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-reflection": "*",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-log/library/Zend/Log.php
+++ b/packages/zend-log/library/Zend/Log.php
@@ -116,7 +116,7 @@ class Zend_Log
      *
      * @param Zend_Log_Writer_Abstract|null  $writer  default writer
      */
-    public function __construct(Zend_Log_Writer_Abstract $writer = null)
+    public function __construct(?Zend_Log_Writer_Abstract $writer = null)
     {
         $r = new ReflectionClass($this);
         $this->_priorities = array_flip($r->getConstants());

--- a/packages/zend-log/library/Zend/Log.php
+++ b/packages/zend-log/library/Zend/Log.php
@@ -594,7 +594,6 @@ class Zend_Log
             E_USER_ERROR        => Zend_Log::ERR,
             E_CORE_ERROR        => Zend_Log::ERR,
             E_RECOVERABLE_ERROR => Zend_Log::ERR,
-            E_STRICT            => Zend_Log::DEBUG,
         );
         // PHP 5.3.0+
         if (defined('E_DEPRECATED')) {
@@ -602,6 +601,10 @@ class Zend_Log
         }
         if (defined('E_USER_DEPRECATED')) {
             $this->_errorHandlerMap['E_USER_DEPRECATED'] = Zend_Log::DEBUG;
+        }
+        // E_STRICT has been deprecated in PHP 8.4
+        if (defined('E_STRICT')) {
+            $this->_errorHandlerMap['E_STRICT'] = Zend_Log::DEBUG;
         }
 
         $this->_registeredErrorHandler = true;

--- a/packages/zend-log/library/Zend/Log/Writer/Mail.php
+++ b/packages/zend-log/library/Zend/Log/Writer/Mail.php
@@ -123,7 +123,7 @@ class Zend_Log_Writer_Mail extends Zend_Log_Writer_Abstract
      * @param  Zend_Layout $layout Layout instance; optional
      * @return void
      */
-    public function __construct(Zend_Mail $mail, Zend_Layout $layout = null)
+    public function __construct(Zend_Mail $mail, ?Zend_Layout $layout = null)
     {
         $this->_mail = $mail;
         if (null !== $layout) {

--- a/packages/zend-mail/composer.json
+++ b/packages/zend-mail/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-mime": "^1.15.6",
         "zf1s/zend-registry": "^1.15.6",

--- a/packages/zend-mail/library/Zend/Mail/Transport/Sendmail.php
+++ b/packages/zend-mail/library/Zend/Mail/Transport/Sendmail.php
@@ -211,7 +211,7 @@ class Zend_Mail_Transport_Sendmail extends Zend_Mail_Transport_Abstract
      * @param array  $errcontext
      * @return true
      */
-    public function _handleMailErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function _handleMailErrors($errno, $errstr, $errfile = null, $errline = null, ?array $errcontext = null)
     {
         $this->_errstr = $errstr;
         return true;

--- a/packages/zend-markup/composer.json
+++ b/packages/zend-markup/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-filter": "^1.15.6"
     },

--- a/packages/zend-markup/library/Zend/Markup/Token.php
+++ b/packages/zend-markup/library/Zend/Markup/Token.php
@@ -101,7 +101,7 @@ class Zend_Markup_Token
         $type,
         $name = '',
         array $attributes = array(),
-        Zend_Markup_Token $parent = null
+        ?Zend_Markup_Token $parent = null
     ) {
         $this->_tag        = $tag;
         $this->_type       = $type;

--- a/packages/zend-measure/composer.json
+++ b/packages/zend-measure/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-locale": "^1.15.6",
         "zf1s/zend-registry": "^1.15.6"

--- a/packages/zend-memory/composer.json
+++ b/packages/zend-memory/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-cache": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-mime/composer.json
+++ b/packages/zend-mime/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-iconv": "*",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-mobile/composer.json
+++ b/packages/zend-mobile/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-uri": "^1.15.6",

--- a/packages/zend-mobile/library/Zend/Mobile/Push/Response/Gcm.php
+++ b/packages/zend-mobile/library/Zend/Mobile/Push/Response/Gcm.php
@@ -87,7 +87,7 @@ class Zend_Mobile_Push_Response_Gcm
      * @return Zend_Mobile_Push_Response_Gcm
      * @throws Zend_Mobile_Push_Exception_ServerUnavailable
      */
-    public function __construct($responseString = null, Zend_Mobile_Push_Message_Gcm $message = null)
+    public function __construct($responseString = null, ?Zend_Mobile_Push_Message_Gcm $message = null)
     {
         if ($responseString) {
             if (!$response = json_decode($responseString, true)) {

--- a/packages/zend-navigation/composer.json
+++ b/packages/zend-navigation/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-controller": "^1.15.6"
     },

--- a/packages/zend-navigation/library/Zend/Navigation/Page.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Page.php
@@ -1005,7 +1005,7 @@ abstract class Zend_Navigation_Page extends Zend_Navigation_Container
      *                                            no parent.
      * @return Zend_Navigation_Page               fluent interface, returns self
      */
-    public function setParent(Zend_Navigation_Container $parent = null)
+    public function setParent(?Zend_Navigation_Container $parent = null)
     {
         if ($parent === $this) {
             // require_once 'Zend/Navigation/Exception.php';

--- a/packages/zend-navigation/library/Zend/Navigation/Page/Mvc.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Page/Mvc.php
@@ -400,7 +400,7 @@ class Zend_Navigation_Page_Mvc extends Zend_Navigation_Page
      *                                      which clears all params.
      * @return Zend_Navigation_Page_Mvc     fluent interface, returns self
      */
-    public function setParams(array $params = null)
+    public function setParams(?array $params = null)
     {
         $this->clearParams();
 

--- a/packages/zend-oauth/composer.json
+++ b/packages/zend-oauth/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-uri": "^1.15.6",

--- a/packages/zend-oauth/library/Zend/Oauth/Consumer.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Consumer.php
@@ -98,9 +98,9 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return Zend_Oauth_Token_Request
      */
     public function getRequestToken(
-        array $customServiceParameters = null,
+        ?array $customServiceParameters = null,
         $httpMethod = null,
-        Zend_Oauth_Http_RequestToken $request = null
+        ?Zend_Oauth_Http_RequestToken $request = null
     ) {
         if ($request === null) {
             $request = new Zend_Oauth_Http_RequestToken($this, $customServiceParameters);
@@ -130,9 +130,9 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return string
      */
     public function getRedirectUrl(
-        array $customServiceParameters = null,
-        Zend_Oauth_Token_Request $token = null,
-        Zend_Oauth_Http_UserAuthorization $redirect = null
+        ?array $customServiceParameters = null,
+        ?Zend_Oauth_Token_Request $token = null,
+        ?Zend_Oauth_Http_UserAuthorization $redirect = null
     ) {
         if ($redirect === null) {
             $redirect = new Zend_Oauth_Http_UserAuthorization($this, $customServiceParameters);
@@ -157,9 +157,9 @@ class Zend_Oauth_Consumer extends Zend_Oauth
      * @return void
      */
     public function redirect(
-        array $customServiceParameters = null,
-        Zend_Oauth_Token_Request $token = null,
-        Zend_Oauth_Http_UserAuthorization $request = null
+        ?array $customServiceParameters = null,
+        ?Zend_Oauth_Token_Request $token = null,
+        ?Zend_Oauth_Http_UserAuthorization $request = null
     ) {
         if ($token instanceof Zend_Oauth_Http_UserAuthorization) {
             $request = $token;
@@ -185,7 +185,7 @@ class Zend_Oauth_Consumer extends Zend_Oauth
         $queryData,
         Zend_Oauth_Token_Request $token,
         $httpMethod = null,
-        Zend_Oauth_Http_AccessToken $request = null
+        ?Zend_Oauth_Http_AccessToken $request = null
     ) {
         $authorizedToken = new Zend_Oauth_Token_AuthorizedRequest($queryData);
         if (!$authorizedToken->isValid()) {

--- a/packages/zend-oauth/library/Zend/Oauth/Http.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Http.php
@@ -81,8 +81,8 @@ class Zend_Oauth_Http
      */
     public function __construct(
         Zend_Oauth_Consumer $consumer,
-        array $parameters = null,
-        Zend_Oauth_Http_Utility $utility = null
+        ?array $parameters = null,
+        ?Zend_Oauth_Http_Utility $utility = null
     ) {
         $this->_consumer = $consumer;
         $this->_preferredRequestScheme = $this->_consumer->getRequestScheme();
@@ -220,7 +220,7 @@ class Zend_Oauth_Http
      * @return void
      * @throws Zend_Oauth_Exception if unable to retrieve valid token response
      */
-    protected function _assessRequestAttempt(Zend_Http_Response $response = null)
+    protected function _assessRequestAttempt(?Zend_Http_Response $response = null)
     {
         switch ($this->_preferredRequestScheme) {
             case Zend_Oauth::REQUEST_SCHEME_HEADER:

--- a/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Http/Utility.php
@@ -45,7 +45,7 @@ class Zend_Oauth_Http_Utility
     public function assembleParams(
         $url,
         Zend_Oauth_Config_ConfigInterface $config,
-        array $serviceProviderParams = null
+        ?array $serviceProviderParams = null
     ) {
         $params = array(
             'oauth_consumer_key'     => $config->getConsumerKey(),

--- a/packages/zend-oauth/library/Zend/Oauth/Token.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token.php
@@ -65,8 +65,8 @@ abstract class Zend_Oauth_Token
      * @return void
      */
     public function __construct(
-        Zend_Http_Response $response = null,
-        Zend_Oauth_Http_Utility $utility = null
+        ?Zend_Http_Response $response = null,
+        ?Zend_Oauth_Http_Utility $utility = null
     ) {
         if ($response !== null) {
             $this->_response = $response;

--- a/packages/zend-oauth/library/Zend/Oauth/Token/Access.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/Access.php
@@ -49,7 +49,7 @@ class Zend_Oauth_Token_Access extends Zend_Oauth_Token
      * @return string
      */
     public function toHeader(
-        $url, Zend_Oauth_Config_ConfigInterface $config, array $customParams = null, $realm = null
+        $url, Zend_Oauth_Config_ConfigInterface $config, ?array $customParams = null, $realm = null
     ) {
         if (!Zend_Uri::check($url)) {
             // require_once 'Zend/Oauth/Exception.php';
@@ -69,7 +69,7 @@ class Zend_Oauth_Token_Access extends Zend_Oauth_Token
      * @param  null|array $params
      * @return string
      */
-    public function toQueryString($url, Zend_Oauth_Config_ConfigInterface $config, array $params = null)
+    public function toQueryString($url, Zend_Oauth_Config_ConfigInterface $config, ?array $params = null)
     {
         if (!Zend_Uri::check($url)) {
             // require_once 'Zend/Oauth/Exception.php';

--- a/packages/zend-oauth/library/Zend/Oauth/Token/AuthorizedRequest.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/AuthorizedRequest.php
@@ -42,7 +42,7 @@ class Zend_Oauth_Token_AuthorizedRequest extends Zend_Oauth_Token
      * @param  null|Zend_Oauth_Http_Utility $utility
      * @return void
      */
-    public function __construct(array $data = null, Zend_Oauth_Http_Utility $utility = null)
+    public function __construct(?array $data = null, ?Zend_Oauth_Http_Utility $utility = null)
     {
         if ($data !== null) {
             $this->_data = $data;

--- a/packages/zend-oauth/library/Zend/Oauth/Token/Request.php
+++ b/packages/zend-oauth/library/Zend/Oauth/Token/Request.php
@@ -37,8 +37,8 @@ class Zend_Oauth_Token_Request extends Zend_Oauth_Token
      * @param null|Zend_Oauth_Http_Utility $utility
      */
     public function __construct(
-        Zend_Http_Response $response = null,
-        Zend_Oauth_Http_Utility $utility = null
+        ?Zend_Http_Response $response = null,
+        ?Zend_Oauth_Http_Utility $utility = null
     ) {
         parent::__construct($response, $utility);
 

--- a/packages/zend-openid/composer.json
+++ b/packages/zend-openid/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-controller": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",

--- a/packages/zend-openid/library/Zend/OpenId.php
+++ b/packages/zend-openid/library/Zend/OpenId.php
@@ -428,7 +428,7 @@ class Zend_OpenId
      * @param string $method redirection method ('GET' or 'POST')
      */
     static public function redirect($url, $params = null,
-        Zend_Controller_Response_Abstract $response = null, $method = 'GET')
+        ?Zend_Controller_Response_Abstract $response = null, $method = 'GET')
     {
         $url = Zend_OpenId::absoluteUrl($url);
         $body = "";

--- a/packages/zend-openid/library/Zend/OpenId/Consumer.php
+++ b/packages/zend-openid/library/Zend/OpenId/Consumer.php
@@ -111,7 +111,7 @@ class Zend_OpenId_Consumer
      * @param bool $dumbMode Enables or disables consumer to use association
      *  with server based on Diffie-Hellman key agreement
      */
-    public function __construct(Zend_OpenId_Consumer_Storage $storage = null,
+    public function __construct(?Zend_OpenId_Consumer_Storage $storage = null,
                                 $dumbMode = false)
     {
         if ($storage === null) {
@@ -139,7 +139,7 @@ class Zend_OpenId_Consumer
      * @return bool
      */
     public function login($id, $returnTo = null, $root = null, $extensions = null,
-                          Zend_Controller_Response_Abstract $response = null)
+                          ?Zend_Controller_Response_Abstract $response = null)
     {
         return $this->_checkId(
             false,
@@ -166,7 +166,7 @@ class Zend_OpenId_Consumer
      * @return bool
      */
     public function check($id, $returnTo=null, $root=null, $extensions = null,
-                          Zend_Controller_Response_Abstract $response = null)
+                          ?Zend_Controller_Response_Abstract $response = null)
 
     {
         return $this->_checkId(
@@ -854,7 +854,7 @@ class Zend_OpenId_Consumer
      * @return bool
      */
     protected function _checkId($immediate, $id, $returnTo=null, $root=null,
-        $extensions=null, Zend_Controller_Response_Abstract $response = null)
+        $extensions=null, ?Zend_Controller_Response_Abstract $response = null)
     {
         $this->_setError('');
 

--- a/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
+++ b/packages/zend-openid/library/Zend/OpenId/Extension/Sreg.php
@@ -53,7 +53,7 @@ class Zend_OpenId_Extension_Sreg extends Zend_OpenId_Extension
      * @param float $version SREG version
      * @return array
      */
-    public function __construct(array $props=null, $policy_url=null, $version=1.0)
+    public function __construct(?array $props=null, $policy_url=null, $version=1.0)
     {
         $this->_props = $props;
         $this->_policy_url = $policy_url;

--- a/packages/zend-openid/library/Zend/OpenId/Provider.php
+++ b/packages/zend-openid/library/Zend/OpenId/Provider.php
@@ -106,8 +106,8 @@ class Zend_OpenId_Provider
      */
     public function __construct($loginUrl = null,
                                 $trustUrl = null,
-                                Zend_OpenId_Provider_User $user = null,
-                                Zend_OpenId_Provider_Storage $storage = null,
+                                ?Zend_OpenId_Provider_User $user = null,
+                                ?Zend_OpenId_Provider_Storage $storage = null,
                                 $sessionTtl = 3600)
     {
         if ($loginUrl === null) {
@@ -334,7 +334,7 @@ class Zend_OpenId_Provider
      * @return mixed
      */
     public function handle($params=null, $extensions=null,
-                           Zend_Controller_Response_Abstract $response = null)
+                           ?Zend_Controller_Response_Abstract $response = null)
     {
         if ($params === null) {
             if ($_SERVER["REQUEST_METHOD"] == "GET") {
@@ -512,7 +512,7 @@ class Zend_OpenId_Provider
      * @return array
      */
     protected function _checkId($version, $params, $immediate, $extensions=null,
-        Zend_Controller_Response_Abstract $response = null)
+        ?Zend_Controller_Response_Abstract $response = null)
     {
         $ret = array();
 
@@ -643,7 +643,7 @@ class Zend_OpenId_Provider
      * @return bool
      */
     public function respondToConsumer($params, $extensions=null,
-                           Zend_Controller_Response_Abstract $response = null)
+                           ?Zend_Controller_Response_Abstract $response = null)
     {
         $version = 1.1;
         if (isset($params['openid_ns']) &&

--- a/packages/zend-openid/library/Zend/OpenId/Provider/User/Session.php
+++ b/packages/zend-openid/library/Zend/OpenId/Provider/User/Session.php
@@ -56,7 +56,7 @@ class Zend_OpenId_Provider_User_Session extends Zend_OpenId_Provider_User
      *
      * @param Zend_Session_Namespace $session
      */
-    public function __construct(Zend_Session_Namespace $session = null)
+    public function __construct(?Zend_Session_Namespace $session = null)
     {
         if ($session === null) {
             $this->_session = new Zend_Session_Namespace("openid");

--- a/packages/zend-paginator/composer.json
+++ b/packages/zend-paginator/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-json": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6"

--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -268,7 +268,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      * @return Zend_Paginator
      */
     public static function factory($data, $adapter = self::INTERNAL_ADAPTER,
-                                   array $prefixPaths = null)
+                                   ?array $prefixPaths = null)
     {
         if ($data instanceof Zend_Paginator_AdapterAggregate) {
             return new self($data->getPaginatorAdapter());
@@ -936,7 +936,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      * @param  Zend_View_Interface $view
      * @return Zend_Paginator
      */
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         $this->_view = $view;
 
@@ -993,7 +993,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      * @param  Zend_View_Interface $view
      * @return string
      */
-    public function render(Zend_View_Interface $view = null)
+    public function render(?Zend_View_Interface $view = null)
     {
         if (null !== $view) {
             $this->setView($view);

--- a/packages/zend-pdf/composer.json
+++ b/packages/zend-pdf/composer.json
@@ -12,8 +12,7 @@
         "ext-zlib": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-log": "^1.15.6",
-        "zf1s/zend-memory": "^1.15.6",
-        "symfony/polyfill-php70": "^1.19"
+        "zf1s/zend-memory": "^1.15.6"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-pdf/composer.json
+++ b/packages/zend-pdf/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "ext-gd": "*",
         "ext-iconv": "*",

--- a/packages/zend-pdf/library/Zend/Pdf.php
+++ b/packages/zend-pdf/library/Zend/Pdf.php
@@ -1011,7 +1011,7 @@ class Zend_Pdf
      * @param Zend_Pdf_Target $openAction
      * @returns Zend_Pdf
      */
-    public function setOpenAction(Zend_Pdf_Target $openAction = null)
+    public function setOpenAction(?Zend_Pdf_Target $openAction = null)
     {
         $root = $this->_trailer->Root;
         $root->touch();

--- a/packages/zend-pdf/library/Zend/Pdf/Action.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Action.php
@@ -117,7 +117,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      * @return Zend_Pdf_Action
      * @throws Zend_Pdf_Exception
      */
-    public static function load(Zend_Pdf_Element $dictionary, SplObjectStorage $processedActions = null)
+    public static function load(Zend_Pdf_Element $dictionary, ?SplObjectStorage $processedActions = null)
     {
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();
@@ -257,7 +257,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      * @param SplObjectStorage $processedActions  list of already processed actions (used to prevent infinity loop caused by cyclic references)
      * @return Zend_Pdf_Element_Object|Zend_Pdf_Element_Reference   Dictionary indirect object
      */
-    public function dumpAction(Zend_Pdf_ElementFactory_Interface $factory, SplObjectStorage $processedActions = null)
+    public function dumpAction(Zend_Pdf_ElementFactory_Interface $factory, ?SplObjectStorage $processedActions = null)
     {
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();

--- a/packages/zend-pdf/library/Zend/Pdf/Outline.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline.php
@@ -288,8 +288,8 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
     abstract public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                            $updateNavigation,
                                                           Zend_Pdf_Element $parent,
-                                                          Zend_Pdf_Element $prev = null,
-                                                          SplObjectStorage $processedOutlines = null);
+                                                          ?Zend_Pdf_Element $prev = null,
+                                                          ?SplObjectStorage $processedOutlines = null);
 
 
     ////////////////////////////////////////////////////////////////////////

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
@@ -246,8 +246,8 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
     public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                   $updateNavigation,
                                                  Zend_Pdf_Element $parent,
-                                                 Zend_Pdf_Element $prev = null,
-                                                 SplObjectStorage $processedOutlines = null)
+                                                 ?Zend_Pdf_Element $prev = null,
+                                                 ?SplObjectStorage $processedOutlines = null)
     {
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
@@ -308,7 +308,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
      * @return Zend_Pdf_Action
      * @throws Zend_Pdf_Exception
      */
-    public function __construct(Zend_Pdf_Element $dictionary, SplObjectStorage $processedDictionaries = null)
+    public function __construct(Zend_Pdf_Element $dictionary, ?SplObjectStorage $processedDictionaries = null)
     {
         if ($dictionary->getType() != Zend_Pdf_Element::TYPE_DICTIONARY) {
             // require_once 'Zend/Pdf/Exception.php';
@@ -372,8 +372,8 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
     public function dumpOutline(Zend_Pdf_ElementFactory_Interface $factory,
                                                                   $updateNavigation,
                                                  Zend_Pdf_Element $parent,
-                                                 Zend_Pdf_Element $prev = null,
-                                                 SplObjectStorage $processedOutlines = null)
+                                                 ?Zend_Pdf_Element $prev = null,
+                                                 ?SplObjectStorage $processedOutlines = null)
     {
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/GraphicsState.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/GraphicsState.php
@@ -50,7 +50,7 @@ class Zend_Pdf_Resource_GraphicsState extends Zend_Pdf_Resource
      * @param Zend_Pdf_Element_Object $extGStateObject
      * @throws Zend_Pdf_Exception
      */
-    public function __construct(Zend_Pdf_Element_Object $extGStateObject = null)
+    public function __construct(?Zend_Pdf_Element_Object $extGStateObject = null)
     {
         if ($extGStateObject == null) {
             // Create new Graphics State object

--- a/packages/zend-pdf/library/Zend/Pdf/Trailer/Keeper.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Trailer/Keeper.php
@@ -57,7 +57,7 @@ class Zend_Pdf_Trailer_Keeper extends Zend_Pdf_Trailer
      */
     public function __construct(Zend_Pdf_Element_Dictionary $dict,
                                 Zend_Pdf_Element_Reference_Context $context,
-                                Zend_Pdf_Trailer $prev = null)
+                                ?Zend_Pdf_Trailer $prev = null)
     {
         parent::__construct($dict);
 

--- a/packages/zend-progressbar/composer.json
+++ b/packages/zend-progressbar/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-config": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-json": "^1.15.6"

--- a/packages/zend-queue/composer.json
+++ b/packages/zend-queue/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-validate": "^1.15.6"
     },

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Activemq.php
@@ -67,7 +67,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue The Zend_Queue object that created this class
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         parent::__construct($options);
 
@@ -230,7 +230,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, ?Zend_Queue $queue=null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;
@@ -296,7 +296,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue $queue
      * @return Zend_Queue_Message
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, ?Zend_Queue $queue=null)
     {
         if ($queue === null) {
             $queue = $this->_queue;
@@ -345,7 +345,7 @@ class Zend_Queue_Adapter_Activemq extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception (not supported)
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count(?Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception('count() is not supported in this adapter');

--- a/packages/zend-queue/library/Zend/Queue/Adapter/AdapterAbstract.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/AdapterAbstract.php
@@ -96,7 +96,7 @@ abstract class Zend_Queue_Adapter_AdapterAbstract
      * @return void
      * @throws Zend_Queue_Exception
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();

--- a/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/AdapterInterface.php
@@ -38,7 +38,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null);
+    public function __construct($options, ?Zend_Queue $queue = null);
 
     /**
      * Retrieve queue instance
@@ -108,7 +108,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @return integer
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null);
+    public function count(?Zend_Queue $queue = null);
 
     /********************************************************************
      * Messsage management functions
@@ -121,7 +121,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message
      */
-    public function send($message, Zend_Queue $queue = null);
+    public function send($message, ?Zend_Queue $queue = null);
 
     /**
      * Get messages in the queue
@@ -131,7 +131,7 @@ interface Zend_Queue_Adapter_AdapterInterface
      * @param  Zend_Queue|null $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null);
+    public function receive($maxMessages = null, $timeout = null, ?Zend_Queue $queue = null);
 
     /**
      * Delete a message from the queue

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Array.php
@@ -48,7 +48,7 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         parent::__construct($options, $queue);
     }
@@ -137,7 +137,7 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count(?Zend_Queue $queue=null)
     {
         if ($queue === null) {
             $queue = $this->_queue;
@@ -166,7 +166,7 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, ?Zend_Queue $queue=null)
     {
         if ($queue === null) {
             $queue = $this->_queue;
@@ -215,7 +215,7 @@ class Zend_Queue_Adapter_Array extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, ?Zend_Queue $queue = null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Db.php
@@ -78,7 +78,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         parent::__construct($options, $queue);
 
@@ -289,7 +289,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null)
+    public function count(?Zend_Queue $queue = null)
     {
         if ($queue === null) {
             $queue = $this->_queue;
@@ -317,7 +317,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception - database error
      */
-    public function send($message, Zend_Queue $queue = null)
+    public function send($message, ?Zend_Queue $queue = null)
     {
         if ($this->_messageRow === null) {
             $this->_messageRow = $this->_messageTable->createRow();
@@ -375,7 +375,7 @@ class Zend_Queue_Adapter_Db extends Zend_Queue_Adapter_AdapterAbstract
      * @return Zend_Queue_Message_Iterator
      * @throws Zend_Queue_Exception - database error
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, ?Zend_Queue $queue = null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Memcacheq.php
@@ -71,7 +71,7 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * @param  null|Zend_Queue $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         if (!extension_loaded('memcache')) {
             // require_once 'Zend/Queue/Exception.php';
@@ -232,7 +232,7 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception (not supported)
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count(?Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception('count() is not supported in this adapter');
@@ -250,7 +250,7 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, ?Zend_Queue $queue=null)
     {
         if ($queue === null) {
             $queue = $this->_queue;
@@ -297,7 +297,7 @@ class Zend_Queue_Adapter_Memcacheq extends Zend_Queue_Adapter_AdapterAbstract
      * @return Zend_Queue_Message_Iterator
      * @throws Zend_Queue_Exception
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, ?Zend_Queue $queue=null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;

--- a/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/Null.php
@@ -43,7 +43,7 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      * @param  null|Zend_Queue $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         parent::__construct($options, $queue);
     }
@@ -103,7 +103,7 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      * @throws Zend_Queue_Exception - not supported.
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue=null)
+    public function count(?Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));
@@ -118,7 +118,7 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @throws Zend_Queue_Exception - not supported.
      */
-    public function send($message, Zend_Queue $queue=null)
+    public function send($message, ?Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));
@@ -129,7 +129,7 @@ class Zend_Queue_Adapter_Null extends Zend_Queue_Adapter_AdapterAbstract
      *
      * @throws Zend_Queue_Exception - not supported.
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, ?Zend_Queue $queue=null)
     {
         // require_once 'Zend/Queue/Exception.php';
         throw new Zend_Queue_Exception(__FUNCTION__ . '() is not supported by ' . get_class($this));

--- a/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
+++ b/packages/zend-queue/library/Zend/Queue/Adapter/PlatformJobQueue.php
@@ -48,7 +48,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @param  Zend_Queue|null $queue
      * @return void
      */
-    public function __construct($options, Zend_Queue $queue = null)
+    public function __construct($options, ?Zend_Queue $queue = null)
     {
         parent::__construct($options, $queue);
 
@@ -152,7 +152,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @return integer
      */
     #[ReturnTypeWillChange]
-    public function count(Zend_Queue $queue = null)
+    public function count(?Zend_Queue $queue = null)
     {
         if ($queue !== null) {
             // require_once 'Zend/Queue/Exception.php';
@@ -174,7 +174,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @return Zend_Queue_Message
      * @throws Zend_Queue_Exception
      */
-    public function send($message, Zend_Queue $queue = null)
+    public function send($message, ?Zend_Queue $queue = null)
     {
         if ($queue !== null) {
             // require_once 'Zend/Queue/Exception.php';
@@ -218,7 +218,7 @@ class Zend_Queue_Adapter_PlatformJobQueue extends Zend_Queue_Adapter_AdapterAbst
      * @throws Zend_Queue_Exception
      * @return ArrayIterator
      */
-    public function receive($maxMessages = null, $timeout = null, Zend_Queue $queue = null)
+    public function receive($maxMessages = null, $timeout = null, ?Zend_Queue $queue = null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;

--- a/packages/zend-reflection/composer.json
+++ b/packages/zend-reflection/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-registry/composer.json
+++ b/packages/zend-registry/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-rest/composer.json
+++ b/packages/zend-rest/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-reflection": "*",

--- a/packages/zend-rest/library/Zend/Rest/Client.php
+++ b/packages/zend-rest/library/Zend/Rest/Client.php
@@ -158,7 +158,7 @@ class Zend_Rest_Client extends Zend_Service_Abstract
      * @throws Zend_Http_Client_Exception
      * @return Zend_Http_Response
      */
-    public function restGet($path, array $query = null)
+    public function restGet($path, ?array $query = null)
     {
         $this->_prepareRest($path);
         $client = self::getHttpClient();

--- a/packages/zend-rest/library/Zend/Rest/Client/Result.php
+++ b/packages/zend-rest/library/Zend/Rest/Client/Result.php
@@ -74,7 +74,7 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
      * @param array  $errcontext
      * @return true
      */
-    public function handleXmlErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handleXmlErrors($errno, $errstr, $errfile = null, $errline = null, ?array $errcontext = null)
     {
         $this->_errstr = $errstr;
         return true;

--- a/packages/zend-search-lucene/composer.json
+++ b/packages/zend-search-lucene/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",

--- a/packages/zend-search-lucene/composer.json
+++ b/packages/zend-search-lucene/composer.json
@@ -11,8 +11,7 @@
         "ext-iconv": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-search": "^1.15.6",
-        "zf1s/zend-xml": "^1.15.6",
-        "symfony/polyfill-php70": "^1.19"
+        "zf1s/zend-xml": "^1.15.6"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-search/composer.json
+++ b/packages/zend-search/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-serializer/composer.json
+++ b/packages/zend-serializer/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6"

--- a/packages/zend-server/composer.json
+++ b/packages/zend-server/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-spl": "*",
         "ext-reflection": "*",
         "zf1s/zend-exception": "^1.15.6"

--- a/packages/zend-server/library/Zend/Server/Reflection/Node.php
+++ b/packages/zend-server/library/Zend/Server/Reflection/Node.php
@@ -55,7 +55,7 @@ class Zend_Server_Reflection_Node
      * @param Zend_Server_Reflection_Node $parent Optional
      * @return Zend_Server_Reflection_Node
      */
-    public function __construct($value, Zend_Server_Reflection_Node $parent = null)
+    public function __construct($value, ?Zend_Server_Reflection_Node $parent = null)
     {
         $this->_value = $value;
         if (null !== $parent) {

--- a/packages/zend-service-akismet/composer.json
+++ b/packages/zend-service-akismet/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-uri": "^1.15.6",

--- a/packages/zend-service-amazon/composer.json
+++ b/packages/zend-service-amazon/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-service-audioscrobbler/composer.json
+++ b/packages/zend-service-audioscrobbler/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-iconv": "*",
         "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-service-console/composer.json
+++ b/packages/zend-service-console/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-service-delicious/composer.json
+++ b/packages/zend-service-delicious/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "zf1s/zend-date": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-service-delicious/library/Zend/Service/Delicious.php
+++ b/packages/zend-service-delicious/library/Zend/Service/Delicious.php
@@ -287,7 +287,7 @@ class Zend_Service_Delicious
      * @throws Zend_Service_Delicious_Exception
      * @return Zend_Service_Delicious_PostList
      */
-    public function getPosts($tag = null, Zend_Date $dt = null, $url = null)
+    public function getPosts($tag = null, ?Zend_Date $dt = null, $url = null)
     {
         $parms = array();
         if ($tag) {

--- a/packages/zend-service-ebay/composer.json
+++ b/packages/zend-service-ebay/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-service": "^1.15.6",
         "zf1s/zend-rest": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6"

--- a/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding.php
+++ b/packages/zend-service-ebay/library/Zend/Service/Ebay/Finding.php
@@ -327,7 +327,7 @@ class Zend_Service_Ebay_Finding extends Zend_Service_Ebay_Abstract
      * @link   http://developer.ebay.com/DevZone/finding/Concepts/MakingACall.html#StandardURLParameters
      * @return DOMDocument
      */
-    protected function _request($operation, array $options = null)
+    protected function _request($operation, ?array $options = null)
     {
         // generate default options
         // constructor load global-id and application-id values

--- a/packages/zend-service-flickr/composer.json
+++ b/packages/zend-service-flickr/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-iconv": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-service-flickr/library/Zend/Service/Flickr.php
+++ b/packages/zend-service-flickr/library/Zend/Service/Flickr.php
@@ -144,7 +144,7 @@ class Zend_Service_Flickr
      * @return Zend_Service_Flickr_ResultSet
      * @throws Zend_Service_Exception
      */
-    public function userSearch($query, array $options = null)
+    public function userSearch($query, ?array $options = null)
     {
         static $method = 'flickr.people.getPublicPhotos';
         static $defaultOptions = array('per_page' => 10,

--- a/packages/zend-service-livedocx/composer.json
+++ b/packages/zend-service-livedocx/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-service": "^1.15.6",
         "zf1s/zend-date": "^1.15.6",
         "zf1s/zend-soap": "^1.15.6"

--- a/packages/zend-service-rackspace/composer.json
+++ b/packages/zend-service-rackspace/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-service": "^1.15.6",
         "zf1s/zend-validate": "^1.15.6"
     },

--- a/packages/zend-service-recaptcha/composer.json
+++ b/packages/zend-service-recaptcha/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-json": "^1.15.6"

--- a/packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha/Response.php
+++ b/packages/zend-service-recaptcha/library/Zend/Service/ReCaptcha/Response.php
@@ -57,7 +57,7 @@ class Zend_Service_ReCaptcha_Response
      * @param string $errorCode
      * @param Zend_Http_Response $httpResponse If this is set the content will override $status and $errorCode
      */
-    public function __construct($status = null, $errorCode = null, Zend_Http_Response $httpResponse = null)
+    public function __construct($status = null, $errorCode = null, ?Zend_Http_Response $httpResponse = null)
     {
         if ($status !== null) {
             $this->setStatus($status);

--- a/packages/zend-service-shorturl/composer.json
+++ b/packages/zend-service-shorturl/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-service": "^1.15.6",
         "zf1s/zend-uri": "^1.15.6"
     },

--- a/packages/zend-service-slideshare/composer.json
+++ b/packages/zend-service-slideshare/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-cache": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",

--- a/packages/zend-service-strikeiron/composer.json
+++ b/packages/zend-service-strikeiron/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6"

--- a/packages/zend-service-twitter/composer.json
+++ b/packages/zend-service-twitter/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-feed": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",

--- a/packages/zend-service-twitter/library/Zend/Service/Twitter.php
+++ b/packages/zend-service-twitter/library/Zend/Service/Twitter.php
@@ -143,7 +143,7 @@ class Zend_Service_Twitter
      * @param  null|Zend_Oauth_Consumer $consumer
      * @param  null|Zend_Http_Client $httpClient
      */
-    public function __construct($options = null, Zend_Oauth_Consumer $consumer = null, Zend_Http_Client $httpClient = null)
+    public function __construct($options = null, ?Zend_Oauth_Consumer $consumer = null, ?Zend_Http_Client $httpClient = null)
     {
         if ($options instanceof Zend_Config) {
             $options = $options->toArray();

--- a/packages/zend-service-windowsazure/composer.json
+++ b/packages/zend-service-windowsazure/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-mbstring": "*",
         "zf1s/zend-service": "^1.15.6",
         "zf1s/zend-xml": "^1.15.6"

--- a/packages/zend-service-windowsazure/library/Zend/Service/SqlAzure/Management/Client.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/SqlAzure/Management/Client.php
@@ -125,7 +125,7 @@ class Zend_Service_SqlAzure_Management_Client
 		$subscriptionId,
 		$certificatePath,
 		$certificatePassphrase,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
 	) {
 		$this->_subscriptionId = $subscriptionId;
 		$this->_certificatePath = $certificatePath;
@@ -275,7 +275,7 @@ class Zend_Service_SqlAzure_Management_Client
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse(?Zend_Http_Response $response = null)
 	{
 		if (is_null($response)) {
 			// require_once 'Zend/Service/SqlAzure/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
@@ -54,7 +54,7 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 	 * @param Zend_Service_WindowsAzure_Storage_Blob $blobStorageClient Blob storage client
 	 * @param string $controlContainer Control container name
 	 */
-	public function __construct(Zend_Service_WindowsAzure_Storage_Blob $blobStorageClient = null, $controlContainer = 'wad-control-container')
+	public function __construct(?Zend_Service_WindowsAzure_Storage_Blob $blobStorageClient = null, $controlContainer = 'wad-control-container')
 	{
 		$this->_blobStorageClient = $blobStorageClient;
 		$this->_controlContainer = $controlContainer;

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Management/Client.php
@@ -164,7 +164,7 @@ class Zend_Service_WindowsAzure_Management_Client
 		$subscriptionId,
 		$certificatePath,
 		$certificatePassphrase,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
 	) {
 		$this->_subscriptionId = $subscriptionId;
 		$this->_certificatePath = $certificatePath;
@@ -314,7 +314,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse(?Zend_Http_Response $response = null)
 	{
 		if (is_null($response)) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -538,7 +538,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Blob
 	 */
-	public function createBlobClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createBlobClientForService($serviceName, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		if ($serviceName == '' || is_null($serviceName)) {
     		throw new Zend_Service_WindowsAzure_Management_Exception('Service name should be specified.');
@@ -564,7 +564,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Table
 	 */
-	public function createTableClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createTableClientForService($serviceName, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		if ($serviceName == '' || is_null($serviceName)) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';
@@ -589,7 +589,7 @@ class Zend_Service_WindowsAzure_Management_Client
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 * @return Zend_Service_WindowsAzure_Storage_Queue
 	 */
-	public function createQueueClientForService($serviceName, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function createQueueClientForService($serviceName, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		if ($serviceName == '' || is_null($serviceName)) {
 			// require_once 'Zend/Service/WindowsAzure/Management/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage.php
@@ -176,7 +176,7 @@ class Zend_Service_WindowsAzure_Storage
 		$accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT,
 		$accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY,
 		$usePathStyleUri = false,
-		Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
+		?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null
 	) {
 		$this->_host = $host;
 		$this->_accountName = $accountName;
@@ -242,7 +242,7 @@ class Zend_Service_WindowsAzure_Storage
 	 *
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 */
-	public function setRetryPolicy(Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function setRetryPolicy(?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		$this->_retryPolicy = $retryPolicy;
 		if (is_null($this->_retryPolicy)) {
@@ -407,7 +407,7 @@ class Zend_Service_WindowsAzure_Storage
 	 * @return object
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _parseResponse(Zend_Http_Response $response = null)
+	protected function _parseResponse(?Zend_Http_Response $response = null)
 	{
 		if (is_null($response)) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -70,7 +70,7 @@ class Zend_Service_WindowsAzure_Storage_Batch
      * 
      * @param Zend_Service_WindowsAzure_Storage_BatchStorageAbstract $storageClient Storage client the batch is defined on
      */
-    public function __construct(Zend_Service_WindowsAzure_Storage_BatchStorageAbstract $storageClient = null, $baseUrl = '')
+    public function __construct(?Zend_Service_WindowsAzure_Storage_BatchStorageAbstract $storageClient = null, $baseUrl = '')
     {
         $this->_storageClient = $storageClient;
         $this->_baseUrl       = $baseUrl;

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/BatchStorageAbstract.php
@@ -48,7 +48,7 @@ abstract class Zend_Service_WindowsAzure_Storage_BatchStorageAbstract
      * @param Zend_Service_WindowsAzure_Storage_Batch $batch Current batch
      * @throws Zend_Service_WindowsAzure_Exception
      */
-    public function setCurrentBatch(Zend_Service_WindowsAzure_Storage_Batch $batch = null)
+    public function setCurrentBatch(?Zend_Service_WindowsAzure_Storage_Batch $batch = null)
     {
         if (!is_null($batch) && $this->isInBatch()) {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -138,7 +138,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 	 * @param boolean $usePathStyleUri Use path-style URI's
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_BLOB, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_BLOB, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
 

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Queue.php
@@ -63,7 +63,7 @@ class Zend_Service_WindowsAzure_Storage_Queue extends Zend_Service_WindowsAzure_
 	 * @param boolean $usePathStyleUri Use path-style URI's
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_QUEUE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_QUEUE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
 		

--- a/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Table.php
+++ b/packages/zend-service-windowsazure/library/Zend/Service/WindowsAzure/Storage/Table.php
@@ -91,7 +91,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param boolean $usePathStyleUri Use path-style URI's
 	 * @param Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy Retry policy to use when making requests
 	 */
-	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_TABLE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
+	public function __construct($host = Zend_Service_WindowsAzure_Storage::URL_DEV_TABLE, $accountName = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_ACCOUNT, $accountKey = Zend_Service_WindowsAzure_Credentials_CredentialsAbstract::DEVSTORE_KEY, $usePathStyleUri = false, ?Zend_Service_WindowsAzure_RetryPolicy_RetryPolicyAbstract $retryPolicy = null)
 	{
 		parent::__construct($host, $accountName, $accountKey, $usePathStyleUri, $retryPolicy);
 
@@ -298,7 +298,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @return Zend_Service_WindowsAzure_Storage_TableEntity
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function insertEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
+	public function insertEntity($tableName = '', ?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
 	{
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -371,7 +371,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function deleteEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	public function deleteEntity($tableName = '', ?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
 	{
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -649,7 +649,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function updateEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	public function updateEntity($tableName = '', ?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
 	{
 	    return $this->_changeEntity(Zend_Http_Client::PUT, $tableName, $entity, $verifyEtag);
 	}
@@ -663,7 +663,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param array                               $properties  Properties to merge. All properties will be used when omitted.
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	public function mergeEntity($tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false, $properties = array())
+	public function mergeEntity($tableName = '', ?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false, $properties = array())
 	{
 		$mergeEntity = null;
 		if (is_array($properties) && count($properties) > 0) {
@@ -714,7 +714,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param boolean                             $verifyEtag  Verify etag of the entity (used for concurrency)
 	 * @throws Zend_Service_WindowsAzure_Exception
 	 */
-	protected function _changeEntity($httpVerb = Zend_Http_Client::PUT, $tableName = '', Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
+	protected function _changeEntity($httpVerb = Zend_Http_Client::PUT, $tableName = '', ?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null, $verifyEtag = false)
 	{
 		if ($tableName === '') {
 			// require_once 'Zend/Service/WindowsAzure/Exception.php';
@@ -819,7 +819,7 @@ class Zend_Service_WindowsAzure_Storage_Table
 	 * @param Zend_Service_WindowsAzure_Storage_TableEntity $entity
 	 * @return string
 	 */
-	protected function _generateAzureRepresentation(Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
+	protected function _generateAzureRepresentation(?Zend_Service_WindowsAzure_Storage_TableEntity $entity = null)
 	{
 		// Generate Azure representation from entity
 		$azureRepresentation = array();

--- a/packages/zend-service-yahoo/composer.json
+++ b/packages/zend-service-yahoo/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6",
         "zf1s/zend-rest": "^1.15.6",

--- a/packages/zend-service/composer.json
+++ b/packages/zend-service/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-http": "^1.15.6"
     },

--- a/packages/zend-session/composer.json
+++ b/packages/zend-session/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-session": "*",
         "zf1s/zend-exception": "^1.15.6"
     },

--- a/packages/zend-soap/composer.json
+++ b/packages/zend-soap/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-simplexml": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-soap/library/Zend/Soap/Server.php
+++ b/packages/zend-soap/library/Zend/Soap/Server.php
@@ -169,7 +169,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * @param array $options
      * @return void
      */
-    public function __construct($wsdl = null, array $options = null)
+    public function __construct($wsdl = null, ?array $options = null)
     {
         if (!extension_loaded('soap')) {
             // require_once 'Zend/Soap/Server/Exception.php';
@@ -1015,7 +1015,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
      * @return void
      * @throws SoapFault
      */
-    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, array $errcontext = null)
+    public function handlePhpErrors($errno, $errstr, $errfile = null, $errline = null, ?array $errcontext = null)
     {
         throw $this->fault($errstr, "Receiver");
     }

--- a/packages/zend-stdlib/composer.json
+++ b/packages/zend-stdlib/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/CallbackHandler.php
@@ -92,9 +92,13 @@ class Zend_Stdlib_CallbackHandler
      */
     protected function registerCallback($callback)
     {
-        set_error_handler(array($this, 'errorHandler'), E_STRICT);
+        if (PHP_VERSION_ID < 70400) {
+            set_error_handler(array($this, 'errorHandler'), E_STRICT);
+        }
         $callable = is_callable($callback);
-        restore_error_handler();
+        if (PHP_VERSION_ID < 70400) {
+            restore_error_handler();
+        }
         if (!$callable || $this->error) {
             // require_once 'Zend/Stdlib/Exception/InvalidCallbackException.php';
             throw new Zend_Stdlib_Exception_InvalidCallbackException('Invalid callback provided; not callable');

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -46,6 +46,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  mixed $priority 
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function insert($datum, $priority)
     {
         // If using the native PHP SplPriorityQueue implementation, we need to

--- a/packages/zend-tag/composer.json
+++ b/packages/zend-tag/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6"
     },

--- a/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
+++ b/packages/zend-tag/library/Zend/Tag/Cloud/Decorator/HtmlTag.php
@@ -94,7 +94,7 @@ class Zend_Tag_Cloud_Decorator_HtmlTag extends Zend_Tag_Cloud_Decorator_Tag
      * @throws Zend_Tag_Cloud_Decorator_Exception When the classlist contains an invalid classname
      * @return Zend_Tag_Cloud_Decorator_HtmlTag
      */
-    public function setClassList(array $classList = null)
+    public function setClassList(?array $classList = null)
     {
         if (is_array($classList)) {
             if (count($classList) === 0) {

--- a/packages/zend-test/composer.json
+++ b/packages/zend-test/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-controller": "^1.15.6",
         "zf1s/zend-dom": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery37.php
@@ -222,7 +222,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery37 extends PHPUnit_Framework_Constrai
      *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/DomQuery41.php
@@ -224,7 +224,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery41 extends PHPUnit_Framework_Constrai
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect37.php
@@ -176,7 +176,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect37 extends PHPUnit_Framework_Constrai
      *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/Redirect41.php
@@ -178,7 +178,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect41 extends PHPUnit_Framework_Constrai
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader37.php
@@ -202,7 +202,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader37 extends PHPUnit_Framework_Co
      *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
      * We use the new interface for PHP-strict checking
      */
-    public function fail($other, $description, PHPUnit_Framework_ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Constraint/ResponseHeader41.php
@@ -204,7 +204,7 @@ class Zend_Test_PHPUnit_Constraint_ResponseHeader41 extends PHPUnit_Framework_Co
      * NOTE 2:
      * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
      */
-    public function fail($other, $description, \SebastianBergmann\Comparator\ComparisonFailure $cannot_be_used = NULL)
+    public function fail($other, $description, $cannot_be_used = NULL)
     {
         // require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
         switch ($this->_assertType) {

--- a/packages/zend-text/composer.json
+++ b/packages/zend-text/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6"
     },
     "autoload": {

--- a/packages/zend-text/library/Zend/Text/Table/Row.php
+++ b/packages/zend-text/library/Zend/Text/Table/Row.php
@@ -50,7 +50,7 @@ class Zend_Text_Table_Row
      * @param  array  $options
      * @return Zend_Text_Table_Row
      */
-    public function createColumn($content, array $options = null)
+    public function createColumn($content, ?array $options = null)
     {
         $align    = null;
         $colSpan  = null;

--- a/packages/zend-timesync/composer.json
+++ b/packages/zend-timesync/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-date": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6"

--- a/packages/zend-tool/composer.json
+++ b/packages/zend-tool/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-tool/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Client/Console/HelpSystem.php
@@ -58,7 +58,7 @@ class Zend_Tool_Framework_Client_Console_HelpSystem
      * @param string $errorMessage
      * @param Exception $exception
      */
-    public function respondWithErrorMessage($errorMessage, Exception $exception = null)
+    public function respondWithErrorMessage($errorMessage, ?Exception $exception = null)
     {
         // break apart the message into wrapped chunks
         $errorMessages = explode(PHP_EOL, wordwrap($errorMessage, 70, PHP_EOL, false));

--- a/packages/zend-tool/library/Zend/Tool/Framework/Loader/Abstract.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Loader/Abstract.php
@@ -95,10 +95,14 @@ abstract class Zend_Tool_Framework_Loader_Abstract
             }
 
             $classesLoadedBefore = get_declared_classes();
-            $oldLevel = error_reporting(E_ALL | ~E_STRICT); // remove strict so that other packages wont throw warnings
+            if (PHP_VERSION_ID < 70400) {
+                $oldLevel = error_reporting(E_ALL | ~E_STRICT); // remove strict so that other packages wont throw warnings
+            }
             // should we lint the files here? i think so
             include_once $file;
-            error_reporting($oldLevel); // restore old error level
+            if (PHP_VERSION_ID < 70400) {
+                error_reporting($oldLevel); // restore old error level
+            }
             $classesLoadedAfter = get_declared_classes();
             $loadedClasses = array_merge($loadedClasses, array_diff($classesLoadedAfter, $classesLoadedBefore));
         }

--- a/packages/zend-tool/library/Zend/Tool/Project/Profile/FileParser/Xml.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Profile/FileParser/Xml.php
@@ -185,7 +185,7 @@ class Zend_Tool_Project_Profile_FileParser_Xml implements Zend_Tool_Project_Prof
      * @param SimpleXMLIterator $xmlIterator
      * @param Zend_Tool_Project_Profile_Resource $resource
      */
-    protected function _unserializeRecurser(SimpleXMLIterator $xmlIterator, Zend_Tool_Project_Profile_Resource $resource = null)
+    protected function _unserializeRecurser(SimpleXMLIterator $xmlIterator, ?Zend_Tool_Project_Profile_Resource $resource = null)
     {
 
         foreach ($xmlIterator as $resourceName => $resourceData) {

--- a/packages/zend-tool/library/Zend/Tool/Project/Provider/Module.php
+++ b/packages/zend-tool/library/Zend/Tool/Project/Provider/Module.php
@@ -51,7 +51,7 @@ class Zend_Tool_Project_Provider_Module
     implements Zend_Tool_Framework_Provider_Pretendable
 {
 
-    public static function createResources(Zend_Tool_Project_Profile $profile, $moduleName, Zend_Tool_Project_Profile_Resource $targetModuleResource = null)
+    public static function createResources(Zend_Tool_Project_Profile $profile, $moduleName, ?Zend_Tool_Project_Profile_Resource $targetModuleResource = null)
     {
 
         // find the appliction directory, it will serve as our module skeleton

--- a/packages/zend-translate/composer.json
+++ b/packages/zend-translate/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",
         "zf1s/zend-locale": "^1.15.6",

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
@@ -94,7 +94,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
             throw new Zend_Translate_Exception('Error opening translation file \'' . $filename . '\'.');
         }
 
-        while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'])) !== false) {
+        while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'], '\\')) !== false) {
             if (is_string($data[0]) && substr($data[0], 0, 1) === '#') {
                 continue;
             }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
         
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
@@ -80,10 +80,9 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
         $encoding      = $this->_findEncoding($filename);
         $this->_target = $locale;
         $this->_file   = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
 
         $encoding    = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-uri/composer.json
+++ b/packages/zend-uri/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",

--- a/packages/zend-validate/composer.json
+++ b/packages/zend-validate/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-ctype": "*",
         "ext-reflection": "*",
         "zf1s/zend-exception": "^1.15.6",

--- a/packages/zend-validate/library/Zend/Validate/EmailAddress.php
+++ b/packages/zend-validate/library/Zend/Validate/EmailAddress.php
@@ -243,7 +243,7 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
      * @param int                    $allow             OPTIONAL
      * @return $this
      */
-    public function setHostnameValidator(Zend_Validate_Hostname $hostnameValidator = null, $allow = Zend_Validate_Hostname::ALLOW_DNS)
+    public function setHostnameValidator(?Zend_Validate_Hostname $hostnameValidator = null, $allow = Zend_Validate_Hostname::ALLOW_DNS)
     {
         if (!$hostnameValidator) {
             $hostnameValidator = new Zend_Validate_Hostname($allow);

--- a/packages/zend-validate/library/Zend/Validate/Hostname.php
+++ b/packages/zend-validate/library/Zend/Validate/Hostname.php
@@ -2045,7 +2045,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
      * @param Zend_Validate_Ip $ipValidator OPTIONAL
      * @return Zend_Validate_Hostname
      */
-    public function setIpValidator(Zend_Validate_Ip $ipValidator = null)
+    public function setIpValidator(?Zend_Validate_Ip $ipValidator = null)
     {
         if ($ipValidator === null) {
             $ipValidator = new Zend_Validate_Ip();

--- a/packages/zend-version/composer.json
+++ b/packages/zend-version/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "autoload": {
         "psr-0": {

--- a/packages/zend-view/composer.json
+++ b/packages/zend-view/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-reflection": "*",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-loader": "^1.15.6",

--- a/packages/zend-view/library/Zend/View/Exception.php
+++ b/packages/zend-view/library/Zend/View/Exception.php
@@ -38,7 +38,7 @@ class Zend_View_Exception extends Zend_Exception
 {
     protected $view = null;
 
-    public function setView(Zend_View_Interface $view = null)
+    public function setView(?Zend_View_Interface $view = null)
     {
         $this->view = $view;
         return $this;

--- a/packages/zend-view/library/Zend/View/Helper/FormCheckbox.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormCheckbox.php
@@ -59,7 +59,7 @@ class Zend_View_Helper_FormCheckbox extends Zend_View_Helper_FormElement
      * @param array $attribs Attributes for the element tag.
      * @return string The element XHTML.
      */
-    public function formCheckbox($name, $value = null, $attribs = null, array $checkedOptions = null)
+    public function formCheckbox($name, $value = null, $attribs = null, ?array $checkedOptions = null)
     {
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, id, value, attribs, options, listsep, disable
@@ -113,7 +113,7 @@ class Zend_View_Helper_FormCheckbox extends Zend_View_Helper_FormElement
      * @param  array|null $checkedOptions
      * @return array
      */
-    public static function determineCheckboxInfo($value, $checked, array $checkedOptions = null)
+    public static function determineCheckboxInfo($value, $checked, ?array $checkedOptions = null)
     {
         // Checked/unchecked values
         $checkedValue   = null;

--- a/packages/zend-view/library/Zend/View/Helper/FormErrors.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormErrors.php
@@ -57,7 +57,7 @@ class Zend_View_Helper_FormErrors extends Zend_View_Helper_FormElement
      * @param  array $options
      * @return string
      */
-    public function formErrors($errors, array $options = null)
+    public function formErrors($errors, ?array $options = null)
     {
         $escape = true;
         if (isset($options['escape'])) {

--- a/packages/zend-view/library/Zend/View/Helper/FormHidden.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormHidden.php
@@ -50,7 +50,7 @@ class Zend_View_Helper_FormHidden extends Zend_View_Helper_FormElement
      * @param array $attribs Attributes for the element tag.
      * @return string The element XHTML.
      */
-    public function formHidden($name, $value = null, array $attribs = null)
+    public function formHidden($name, $value = null, ?array $attribs = null)
     {
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, value, attribs, options, listsep, disable

--- a/packages/zend-view/library/Zend/View/Helper/FormLabel.php
+++ b/packages/zend-view/library/Zend/View/Helper/FormLabel.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormLabel extends Zend_View_Helper_FormElement
      * @param  array $attribs Form element attributes (used to determine if disabled)
      * @return string The element XHTML.
      */
-    public function formLabel($name, $value = null, array $attribs = null)
+    public function formLabel($name, $value = null, ?array $attribs = null)
     {
         $info = $this->_getInfo($name, $value, $attribs);
         extract($info); // name, value, attribs, options, listsep, disable, escape

--- a/packages/zend-view/library/Zend/View/Helper/HeadLink.php
+++ b/packages/zend-view/library/Zend/View/Helper/HeadLink.php
@@ -88,7 +88,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
      *
      * @return Zend_View_Helper_HeadLink
      */
-    public function headLink(array $attributes = null, $placement = Zend_View_Helper_Placeholder_Container_Abstract::APPEND)
+    public function headLink(?array $attributes = null, $placement = Zend_View_Helper_Placeholder_Container_Abstract::APPEND)
     {
         if (null !== $attributes) {
             $item = $this->createData($attributes);

--- a/packages/zend-view/library/Zend/View/Helper/Navigation.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation.php
@@ -91,7 +91,7 @@ class Zend_View_Helper_Navigation
      * @return Zend_View_Helper_Navigation           fluent interface, returns
      *                                               self
      */
-    public function navigation(Zend_Navigation_Container $container = null)
+    public function navigation(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -342,7 +342,7 @@ class Zend_View_Helper_Navigation
      *                                               the interface specified in
      *                                               {@link findHelper()}
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         $helper = $this->findHelper($this->getDefaultProxy());
         return $helper->render($container);

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Breadcrumbs.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Breadcrumbs.php
@@ -74,7 +74,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      * @return Zend_View_Helper_Navigation_Breadcrumbs  fluent interface,
      *                                                  returns self
      */
-    public function breadcrumbs(Zend_Navigation_Container $container = null)
+    public function breadcrumbs(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -180,7 +180,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function renderStraight(Zend_Navigation_Container $container = null)
+    public function renderStraight(?Zend_Navigation_Container $container = null)
     {
         if (null === $container) {
             $container = $this->getContainer();
@@ -247,7 +247,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *                                               be found.
      * @return string                                helper output
      */
-    public function renderPartial(Zend_Navigation_Container $container = null,
+    public function renderPartial(?Zend_Navigation_Container $container = null,
                                   $partial = null)
     {
         if (null === $container) {
@@ -320,7 +320,7 @@ class Zend_View_Helper_Navigation_Breadcrumbs
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         if ($partial = $this->getPartial()) {
             return $this->renderPartial($container, $partial);

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Helper.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Helper.php
@@ -42,7 +42,7 @@ interface Zend_View_Helper_Navigation_Helper
      * @return Zend_View_Helper_Navigation_Helper    fluent interface, returns
      *                                               self
      */
-    public function setContainer(Zend_Navigation_Container $container = null);
+    public function setContainer(?Zend_Navigation_Container $container = null);
 
     /**
      * Returns the navigation container the helper operates on by default
@@ -78,7 +78,7 @@ interface Zend_View_Helper_Navigation_Helper
      * @return Zend_View_Helper_Navigation_Helper  fluent interface, returns
      *                                             self
      */
-    public function setAcl(Zend_Acl $acl = null);
+    public function setAcl(?Zend_Acl $acl = null);
 
     /**
      * Returns ACL or null if it isn't set using {@link setAcl()} or
@@ -208,5 +208,5 @@ interface Zend_View_Helper_Navigation_Helper
      * @return string                                helper output
      * @throws Zend_View_Exception                   if unable to render
      */
-    public function render(Zend_Navigation_Container $container = null);
+    public function render(?Zend_Navigation_Container $container = null);
 }

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/HelperAbstract.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/HelperAbstract.php
@@ -165,7 +165,7 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      * @return Zend_View_Helper_Navigation_HelperAbstract  fluent interface,
      *                                                     returns self
      */
-    public function setContainer(Zend_Navigation_Container $container = null)
+    public function setContainer(?Zend_Navigation_Container $container = null)
     {
         $this->_container = $container;
         return $this;
@@ -443,7 +443,7 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      * @return Zend_View_Helper_Navigation_HelperAbstract  fluent interface,
      *                                                     returns self
      */
-    public function setAcl(Zend_Acl $acl = null)
+    public function setAcl(?Zend_Acl $acl = null)
     {
         $this->_acl = $acl;
         return $this;
@@ -943,7 +943,7 @@ abstract class Zend_View_Helper_Navigation_HelperAbstract
      *                        sets no ACL object.
      * @return void
      */
-    public static function setDefaultAcl(Zend_Acl $acl = null)
+    public static function setDefaultAcl(?Zend_Acl $acl = null)
     {
         self::$_defaultAcl = $acl;
     }

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Links.php
@@ -114,7 +114,7 @@ class Zend_View_Helper_Navigation_Links
      * @return Zend_View_Helper_Navigation_Links     fluent interface, returns
      *                                               self
      */
-    public function links(Zend_Navigation_Container $container = null)
+    public function links(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -747,7 +747,7 @@ class Zend_View_Helper_Navigation_Links
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         if (null === $container) {
             $container = $this->getContainer();

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Menu.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Menu.php
@@ -123,7 +123,7 @@ class Zend_View_Helper_Navigation_Menu
      * @return Zend_View_Helper_Navigation_Menu      fluent interface,
      *                                               returns self
      */
-    public function menu(Zend_Navigation_Container $container = null)
+    public function menu(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -899,7 +899,7 @@ class Zend_View_Helper_Navigation_Menu
      *                                               controlling rendering
      * @return string                                rendered menu
      */
-    public function renderMenu(Zend_Navigation_Container $container = null,
+    public function renderMenu(?Zend_Navigation_Container $container = null,
                                array $options = array())
     {
         if (null === $container) {
@@ -982,7 +982,7 @@ class Zend_View_Helper_Navigation_Menu
      *                                                  {@link getInnerIndent()}.
      * @return string                                   rendered content
      */
-    public function renderSubMenu(Zend_Navigation_Container $container = null,
+    public function renderSubMenu(?Zend_Navigation_Container $container = null,
                                   $ulClass = null,
                                   $indent = null,
                                   $ulId   = null,
@@ -1026,7 +1026,7 @@ class Zend_View_Helper_Navigation_Menu
      *
      * @throws Zend_View_Exception   When no partial script is set
      */
-    public function renderPartial(Zend_Navigation_Container $container = null,
+    public function renderPartial(?Zend_Navigation_Container $container = null,
                                   $partial = null)
     {
         if (null === $container) {
@@ -1088,7 +1088,7 @@ class Zend_View_Helper_Navigation_Menu
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         if ($partial = $this->getPartial()) {
             return $this->renderPartial($container, $partial);

--- a/packages/zend-view/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/packages/zend-view/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -90,7 +90,7 @@ class Zend_View_Helper_Navigation_Sitemap
      * @return Zend_View_Helper_Navigation_Sitemap   fluent interface, returns
      *                                               self
      */
-    public function sitemap(Zend_Navigation_Container $container = null)
+    public function sitemap(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -288,7 +288,7 @@ class Zend_View_Helper_Navigation_Sitemap
      *                                               validators are used and the
      *                                               loc element fails validation
      */
-    public function getDomSitemap(Zend_Navigation_Container $container = null)
+    public function getDomSitemap(?Zend_Navigation_Container $container = null)
     {
         if (null === $container) {
             $container = $this->getContainer();
@@ -430,7 +430,7 @@ class Zend_View_Helper_Navigation_Sitemap
      * @throws Zend_View_Exception
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         $dom = $this->getDomSitemap($container);
 

--- a/packages/zend-view/library/Zend/View/Helper/PaginationControl.php
+++ b/packages/zend-view/library/Zend/View/Helper/PaginationControl.php
@@ -85,7 +85,7 @@ class Zend_View_Helper_PaginationControl
      * @return string
      * @throws Zend_View_Exception
      */
-    public function paginationControl(Zend_Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
+    public function paginationControl(?Zend_Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
     {
         if ($paginator === null) {
             if (isset($this->view->paginator) and $this->view->paginator !== null and $this->view->paginator instanceof Zend_Paginator) {

--- a/packages/zend-view/library/Zend/View/Helper/UserAgent.php
+++ b/packages/zend-view/library/Zend/View/Helper/UserAgent.php
@@ -45,7 +45,7 @@ class Zend_View_Helper_UserAgent extends Zend_View_Helper_Abstract
      * @param  null|Zend_Http_UserAgent $userAgent
      * @return Zend_Http_UserAgent
      */
-    public function userAgent(Zend_Http_UserAgent $userAgent = null)
+    public function userAgent(?Zend_Http_UserAgent $userAgent = null)
     {
         if (null !== $userAgent) {
             $this->setUserAgent($userAgent);

--- a/packages/zend-wildfire/composer.json
+++ b/packages/zend-wildfire/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "zf1s/zend-controller": "^1.15.6",
         "zf1s/zend-exception": "^1.15.6",
         "zf1s/zend-json": "^1.15.6",

--- a/packages/zend-xml/composer.json
+++ b/packages/zend-xml/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",

--- a/packages/zend-xml/library/Zend/Xml/Security.php
+++ b/packages/zend-xml/library/Zend/Xml/Security.php
@@ -81,7 +81,7 @@ class Zend_Xml_Security
      * @throws  Zend_Xml_Exception
      * @return  SimpleXMLElement|DomDocument|boolean
      */
-    public static function scan($xml, DOMDocument $dom = null)
+    public static function scan($xml, ?DOMDocument $dom = null)
     {
         // If running with PHP-FPM we perform an heuristic scan
         // We cannot use libxml_disable_entity_loader because of this bug
@@ -152,7 +152,7 @@ class Zend_Xml_Security
      * @throws Zend_Xml_Exception
      * @return SimpleXMLElement|DomDocument
      */
-    public static function scanFile($file, DOMDocument $dom = null)
+    public static function scanFile($file, ?DOMDocument $dom = null)
     {
         if (!file_exists($file)) {
             // require_once 'Exception.php';

--- a/packages/zend-xmlrpc/composer.json
+++ b/packages/zend-xmlrpc/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.1",
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-reflection": "*",

--- a/packages/zend-xmlrpc/library/Zend/XmlRpc/Client.php
+++ b/packages/zend-xmlrpc/library/Zend/XmlRpc/Client.php
@@ -127,7 +127,7 @@ class Zend_XmlRpc_Client
      * @param  Zend_Http_Client $httpClient HTTP Client to use for requests
      * @return void
      */
-    public function __construct($server, Zend_Http_Client $httpClient = null)
+    public function __construct($server, ?Zend_Http_Client $httpClient = null)
     {
         if ($httpClient === null) {
             $this->_httpClient = new Zend_Http_Client();

--- a/tests/Zend/Acl/_files/AssertionZF7973.php
+++ b/tests/Zend/Acl/_files/AssertionZF7973.php
@@ -3,8 +3,8 @@
 
 class Zend_Acl_AclTest_AssertionZF7973 implements Zend_Acl_Assert_Interface {
     public function assert(Zend_Acl $acl,
-                Zend_Acl_Role_Interface $role = null,
-                Zend_Acl_Resource_Interface $resource = null,
+                ?Zend_Acl_Role_Interface $role = null,
+                ?Zend_Acl_Resource_Interface $resource = null,
                 $privilege = null)
     {
         if($privilege != 'privilege') {

--- a/tests/Zend/Acl/_files/ExtendedAclZF2234.php
+++ b/tests/Zend/Acl/_files/ExtendedAclZF2234.php
@@ -2,19 +2,19 @@
 
 class Zend_Acl_ExtendedAclZF2234 extends Zend_Acl
 {
-    public function roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSVisitAllPrivileges(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                               &$dfs = null)
     {
         return $this->_roleDFSVisitAllPrivileges($role, $resource, $dfs);
     }
 
-    public function roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSOnePrivilege(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                         $privilege = null)
     {
         return $this->_roleDFSOnePrivilege($role, $resource, $privilege);
     }
 
-    public function roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, Zend_Acl_Resource_Interface $resource = null,
+    public function roleDFSVisitOnePrivilege(Zend_Acl_Role_Interface $role, ?Zend_Acl_Resource_Interface $resource = null,
                                              $privilege = null, &$dfs = null)
     {
         return $this->_roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);

--- a/tests/Zend/Acl/_files/MockAssertion.php
+++ b/tests/Zend/Acl/_files/MockAssertion.php
@@ -9,7 +9,7 @@ class Zend_Acl_MockAssertion implements Zend_Acl_Assert_Interface
         $this->_returnValue = (bool) $returnValue;
     }
 
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $role = null, Zend_Acl_Resource_Interface $resource = null,
+    public function assert(Zend_Acl $acl, ?Zend_Acl_Role_Interface $role = null, ?Zend_Acl_Resource_Interface $resource = null,
                            $privilege = null)
     {
        return $this->_returnValue;

--- a/tests/Zend/Acl/_files/UseCase1/UserIsBlogPostOwnerAssertion.php
+++ b/tests/Zend/Acl/_files/UseCase1/UserIsBlogPostOwnerAssertion.php
@@ -8,7 +8,7 @@ class Zend_Acl_UseCase1_UserIsBlogPostOwnerAssertion implements Zend_Acl_Assert_
     public $lastAssertPrivilege = null;
     public $assertReturnValue = true;
 
-    public function assert(Zend_Acl $acl, Zend_Acl_Role_Interface $user = null, Zend_Acl_Resource_Interface $blogPost = null, $privilege = null)
+    public function assert(Zend_Acl $acl, ?Zend_Acl_Role_Interface $user = null, ?Zend_Acl_Resource_Interface $blogPost = null, $privilege = null)
     {
         $this->lastAssertRole = $user;
         $this->lastAssertResource = $blogPost;

--- a/tests/Zend/Application/Resource/SessionTest.php
+++ b/tests/Zend/Application/Resource/SessionTest.php
@@ -76,19 +76,27 @@ class Zend_Application_Resource_SessionTest extends PHPUnit_Framework_TestCase
      */
     public function testSetOptions()
     {
-        Zend_Session::setOptions(array(
-            'use_only_cookies' => false,
+        $options = array(
             'remember_me_seconds' => 3600,
-        ));
+        );
+        $resourceOptions = array(
+            'remember_me_seconds' => 7200,
+        );
 
-        $this->resource->setOptions(array(
-             'use_only_cookies' => true,
-             'remember_me_seconds' => 7200,
-        ));
+        // disabling session.use_only_cookies is deprecated in php 8.4
+        if (PHP_VERSION_ID < 80400) {
+            $options['use_only_cookies'] = false;
+            $resourceOptions['use_only_cookies'] = true;
+        }
+
+        Zend_Session::setOptions($options);
+        $this->resource->setOptions($resourceOptions);
 
         $this->resource->init();
 
-        $this->assertEquals(1, Zend_Session::getOptions('use_only_cookies'));
+        if (PHP_VERSION_ID < 80400) {
+            $this->assertEquals(1, Zend_Session::getOptions('use_only_cookies'));
+        }
         $this->assertEquals(7200, Zend_Session::getOptions('remember_me_seconds'));
     }
 

--- a/tests/Zend/Db/Table/_files/My/ZendDbTable/Row/TestMockRow.php
+++ b/tests/Zend/Db/Table/_files/My/ZendDbTable/Row/TestMockRow.php
@@ -48,20 +48,20 @@ class My_ZendDbTable_Row_TestMockRow extends Zend_Db_Table_Row_Abstract
     public $callerRefRuleKey  = null;
     public $matchRefRuleKey   = null;
 
-    public function findDependentRowset($dependentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findDependentRowset($dependentTable, $ruleKey = null, ?Zend_Db_Table_Select $select = null)
     {
         $this->dependentTable    = $dependentTable;
         $this->ruleKey           = $ruleKey;
     }
 
-    public function findParentRow($parentTable, $ruleKey = null, Zend_Db_Table_Select $select = null)
+    public function findParentRow($parentTable, $ruleKey = null, ?Zend_Db_Table_Select $select = null)
     {
         $this->parentTable       = $parentTable;
         $this->ruleKey           = $ruleKey;
     }
 
     public function findManyToManyRowset($matchTable, $intersectionTable, $callerRefRule = null,
-                                         $matchRefRule = null, Zend_Db_Table_Select $select = null)
+                                         $matchRefRule = null, ?Zend_Db_Table_Select $select = null)
     {
         $this->matchTable        = $matchTable;
         $this->intersectionTable = $intersectionTable;

--- a/tests/Zend/EventManager/TestAsset/ClassWithEvents.php
+++ b/tests/Zend/EventManager/TestAsset/ClassWithEvents.php
@@ -34,7 +34,7 @@ class Zend_EventManager_TestAsset_ClassWithEvents
 {
     protected $events;
 
-    public function events(Zend_EventManager_EventCollection $events = null)
+    public function events(?Zend_EventManager_EventCollection $events = null)
     {
         if (null !== $events) {
             $this->events = $events;

--- a/tests/Zend/Json/JsonXMLTest.php
+++ b/tests/Zend/Json/JsonXMLTest.php
@@ -20,7 +20,10 @@
  * @version    $Id$
  */
 
-error_reporting( E_ALL | E_STRICT ); // now required for each test suite
+error_reporting(E_ALL); // now required for each test suite
+if (PHP_VERSION_ID < 70400) {
+    error_reporting(E_ALL | E_STRICT);
+}
 
 /**
  * Zend_Json

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -334,7 +334,11 @@ class Zend_Log_LogTest extends PHPUnit_Framework_TestCase
         $oldErrorLevel = error_reporting();
 
         $this->expectingLogging = true;
-        error_reporting(E_ALL | E_STRICT);
+        
+        error_reporting(E_ALL);
+        if (PHP_VERSION_ID < 70400) {
+            error_reporting(E_ALL | E_STRICT);
+        }
 
         $oldHandler = set_error_handler(array($this, 'verifyHandlerData'));
         $logger->registerErrorHandler();

--- a/tests/Zend/Oauth/Oauth/ConsumerTest.php
+++ b/tests/Zend/Oauth/Oauth/ConsumerTest.php
@@ -254,7 +254,7 @@ class Zend_Oauth_ConsumerTest extends PHPUnit_Framework_TestCase
 class Test_Http_RequestToken_48231 extends Zend_Oauth_Http_RequestToken
 {
     public function __construct(){}
-    public function execute(array $params = null){
+    public function execute(?array $params = null){
         $return = new Zend_Oauth_Token_Request;
         return $return;}
     public function setParams(array $customServiceParameters){}
@@ -263,7 +263,7 @@ class Test_Http_RequestToken_48231 extends Zend_Oauth_Http_RequestToken
 class Test_Http_AccessToken_48231 extends Zend_Oauth_Http_AccessToken
 {
     public function __construct(){}
-    public function execute(array $params = null){
+    public function execute(?array $params = null){
         $return = new Zend_Oauth_Token_Access;
         return $return;}
     public function setParams(array $customServiceParameters){}

--- a/tests/Zend/Queue/Custom/DbForUpdate.php
+++ b/tests/Zend/Queue/Custom/DbForUpdate.php
@@ -50,7 +50,7 @@ class Custom_DbForUpdate extends Zend_Queue_Adapter_Db
      * @param  Zend_Queue $queue
      * @return Zend_Queue_Message_Iterator
      */
-    public function receive($maxMessages=null, $timeout=null, Zend_Queue $queue=null)
+    public function receive($maxMessages=null, $timeout=null, ?Zend_Queue $queue=null)
     {
         if ($maxMessages === null) {
             $maxMessages = 1;

--- a/tests/Zend/Service/Twitter/TwitterTest.php
+++ b/tests/Zend/Service/Twitter/TwitterTest.php
@@ -80,7 +80,7 @@ class Zend_Service_Twitter_TwitterTest extends PHPUnit_Framework_TestCase
      * @param array $params Expected GET/POST parameters for the request
      * @return Zend_Http_Client
      */
-    protected function stubTwitter($path, $method, $responseFile = null, array $params = null)
+    protected function stubTwitter($path, $method, $responseFile = null, ?array $params = null)
     {
         $client = $this->getMock('Zend_Oauth_Client', array(), array(), '', false);
         $client->expects($this->any())->method('resetParameters')

--- a/tests/Zend/Session/SessionTest.php
+++ b/tests/Zend/Session/SessionTest.php
@@ -93,11 +93,19 @@ class Zend_SessionTest extends PHPUnit_Framework_TestCase
 
         session_save_path($this->_savePath);
 
-        $this->assertSame(
-            E_ALL | E_STRICT,
-            error_reporting( E_ALL | E_STRICT ),
-            'A test altered error_reporting to something other than E_ALL | E_STRICT'
-            );
+        if (PHP_VERSION_ID < 70400) {
+            $this->assertSame(
+                E_ALL | E_STRICT,
+                error_reporting(E_ALL | E_STRICT),
+                'A test altered error_reporting to something other than E_ALL | E_STRICT'
+                );
+        } else {
+            $this->assertSame(
+                E_ALL,
+                error_reporting(E_ALL),
+                'A test altered error_reporting to something other than E_ALL'
+                );
+        }
     }
 
     /**

--- a/tests/Zend/View/Helper/Navigation/_files/helpers/Menu.php
+++ b/tests/Zend/View/Helper/Navigation/_files/helpers/Menu.php
@@ -12,7 +12,7 @@ class My_View_Helper_Navigation_Menu
      * @return My_View_Helper_Navigation_Menu        fluent interface,
      *                                               returns self
      */
-    public function menu(Zend_Navigation_Container $container = null)
+    public function menu(?Zend_Navigation_Container $container = null)
     {
         if (null !== $container) {
             $this->setContainer($container);
@@ -32,7 +32,7 @@ class My_View_Helper_Navigation_Menu
      *                                               registered in the helper.
      * @return string                                helper output
      */
-    public function render(Zend_Navigation_Container $container = null)
+    public function render(?Zend_Navigation_Container $container = null)
     {
         return '<menu/>';
     }

--- a/tests/Zend/ViewTest.php
+++ b/tests/Zend/ViewTest.php
@@ -684,7 +684,10 @@ class Zend_ViewTest extends PHPUnit_Framework_TestCase
 
     public function testZf995UndefinedPropertiesReturnNull()
     {
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
+        if (PHP_VERSION_ID < 70400) {
+            error_reporting(E_ALL | E_STRICT);
+        }
         ini_set('display_errors', true);
         $view = new Zend_View();
         $view->setScriptPath(dirname(__FILE__) . '/View/_templates');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,10 @@
 /*
  * Set error reporting to the level to which Zend Framework code must comply.
  */
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
+if (PHP_VERSION_ID < 70400) {
+    error_reporting(E_ALL | E_STRICT);
+}
 
 $rootDir = dirname(__DIR__);
 


### PR DESCRIPTION
### Full PHP 8.4 compatibility for zf1s. Bumps minimum PHP version from 5.3 to 7.1.

A `1.15.x` branch has been created from the last 5.3-compatible release (1.15.6) for projects that can't upgrade yet.

#### Why the version bump

Up until now, this fork maintained compatibility with the full range of PHP versions down to 5.3. That was always a core principle - keep the barrier to entry as low as possible for legacy projects.

PHP 8.4 deprecated implicit nullable parameter declarations (`Type $param = null`), requiring `?Type` syntax which is only available from PHP 7.1. An ingenious alternative approach exists, as proven by @marcing (see [#207](https://github.com/zf1s/zf1/pull/207)), but in the end bumping to 7.1 was chosen as the most reasonable path - see [detailed explanation in PR #216](https://github.com/zf1s/zf1/pull/216).

#### What changed

**Version bump and dependencies:**
- bump minimum PHP to 7.1
- update CI test matrix: drop PHP <7.1, add 8.4 and 8.5 as experimental
- drop `symfony/polyfill-php70` (no longer needed)
- bump `zf1s/phpunit` to [3.7.44](https://github.com/zf1s/phpunit/releases/tag/3.7.44), `zf1s/dbunit` to [1.3.4](https://github.com/zf1s/dbunit/releases/tag/1.3.4)
- [zend-test] remove type hints from `fail()` overrides to match updated phpunit signature

**PHP 8.4 deprecation fixes:**
- fix implicit nullable parameter declarations across 156 files (#216)
- [zend-stdlib] add `#[\ReturnTypeWillChange]` to `SplPriorityQueue::insert()` (#219)
- [zend-translate] replace deprecated `xml_set_object()` with callable arrays (#221)
- [zend-auth, zend-translate] provide explicit `$escape` parameter to `fgetcsv()` (#222)
- [zend-feed] replace deprecated `DOMDocument::$actualEncoding` with `$encoding` (#223)
- [zend-session] skip deprecated `use_only_cookies=false` in test on PHP 8.4+ (#224)
- [zend-log, zend-stdlib, zend-tool, tests] guard `E_STRICT` constant usage for PHP 8.4+ (#205)

#### Test results

PHP 8.4: 16879 tests, 0 errors (24 incomplete, 610 skipped - all pre-existing).