### PR TITLE
php 8.4: [zend-stdlib] add ReturnTypeWillChange to SplPriorityQueue::insert()

### DIFF
--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -46,6 +46,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  mixed $priority 
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function insert($datum, $priority)
     {
         // If using the native PHP SplPriorityQueue implementation, we need to


### PR DESCRIPTION
PHP 8.4 added return type `true` to `SplPriorityQueue::insert()`. Without the `#[\ReturnTypeWillChange]` attribute, inheriting from `SplPriorityQueue` triggers a fatal error during class loading.

This was not caught during the PHP 8.1 `ReturnTypeWillChange` pass because `SplPriorityQueue::insert()` didn't have a return type until PHP 8.4 - only other SPL methods were affected in 8.1.