### PR TITLE
[zend-cache] fix flaky cache backend tests: race condition in getTmpDir()

### DIFF
--- a/tests/Zend/Cache/CommonBackendTest.php
+++ b/tests/Zend/Cache/CommonBackendTest.php
@@ -36,6 +36,7 @@ abstract class Zend_Cache_CommonBackendTest extends PHPUnit_Framework_TestCase {
     protected $_instance;
     protected $_className;
     protected $_root;
+    protected $_tmpDir;
 
     public function __construct($name = null, array $data = array(), $dataName = '')
     {
@@ -75,19 +76,32 @@ abstract class Zend_Cache_CommonBackendTest extends PHPUnit_Framework_TestCase {
 
     public function getTmpDir($date = true)
     {
+        // cache the path within a test run - multiple calls during the same test
+        // can land on different seconds in the timestamp suffix, causing mkdir()
+        // and cache_dir to point to different directories
+        if ($date && $this->_tmpDir !== null) {
+            return $this->_tmpDir;
+        }
+
         $suffix = '';
         if ($date) {
             $suffix = date('mdyHis');
         }
         if (is_writable($this->_root)) {
-            return $this->_root . DIRECTORY_SEPARATOR . 'zend_cache_tmp_dir_' . $suffix;
+            $dir = $this->_root . DIRECTORY_SEPARATOR . 'zend_cache_tmp_dir_' . $suffix;
         } else {
             if (getenv('TMPDIR')){
-                return getenv('TMPDIR') . DIRECTORY_SEPARATOR . 'zend_cache_tmp_dir_' . $suffix;
+                $dir = getenv('TMPDIR') . DIRECTORY_SEPARATOR . 'zend_cache_tmp_dir_' . $suffix;
             } else {
                 die("no writable tmpdir found");
             }
         }
+
+        if ($date) {
+            $this->_tmpDir = $dir;
+        }
+
+        return $dir;
     }
 
     public function tearDown()
@@ -96,6 +110,7 @@ abstract class Zend_Cache_CommonBackendTest extends PHPUnit_Framework_TestCase {
             $this->_instance->clean();
         }
         $this->rmdir();
+        $this->_tmpDir = null;
     }
 
     public function testConstructorCorrectCall()


### PR DESCRIPTION
`getTmpDir()` generates a path using `date('mdyHis')` on every call. in `FileBackendTest::setUp()`, it's called twice - once by `mkdir()` and once to set `cache_dir`. if a second boundary is crossed between the two calls, `mkdir()` creates one directory but `cache_dir` points to a different (non-existent) one, causing:

```
Zend_Cache_Exception: cache_dir "...zend_cache_tmp_dir_040326040450/" must be a directory
```

fix: cache the `getTmpDir()` result for the duration of a test, reset in `tearDown()`.