### PR TITLE
php 8.4: [zend-translate] replace deprecated xml_set_object() in translate adapters

### DIFF
--- a/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
         
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
@@ -80,10 +80,9 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
         $encoding      = $this->_findEncoding($filename);
         $this->_target = $locale;
         $this->_file   = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
 
         $encoding    = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, array($this, '_startElement'), array($this, '_endElement'));
+        xml_set_character_data_handler($this->_file, array($this, '_contentElement'));
 
         try {
             Zend_Xml_Security::scanFile($filename);


### PR DESCRIPTION
`xml_set_object()` is deprecated in php 8.4. The five XML-based translate adapters (Tmx, Qt, Tbx, Xliff, XmlTm) used it to bind string method names to the parser instance.

Replaced with `array($this, 'method')` callable arrays passed directly to `xml_set_element_handler()` and `xml_set_character_data_handler()`, which makes `xml_set_object()` unnecessary. This syntax works on all supported php versions.

Fixes 78 test errors on php 8.4.

See https://wiki.php.net/rfc/deprecations_php_8_4 and https://www.php.net/manual/en/migration84.deprecated.php