### PR TITLE
php 8.4: provide explicit escape parameter to fgetcsv()

### DIFF
--- a/packages/zend-auth/library/Zend/Auth/Adapter/Http/Resolver/File.php
+++ b/packages/zend-auth/library/Zend/Auth/Adapter/Http/Resolver/File.php
@@ -152,7 +152,7 @@ class Zend_Auth_Adapter_Http_Resolver_File implements Zend_Auth_Adapter_Http_Res
 
         // No real validation is done on the contents of the password file. The
         // assumption is that we trust the administrators to keep it secure.
-        while (($line = fgetcsv($fp, 512, ':')) !== false) {
+        while (($line = fgetcsv($fp, 512, ':', '"', '\\')) !== false) {
             if ($line[0] == $username && $line[1] == $realm) {
                 $password = $line[2];
                 fclose($fp);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Csv.php
@@ -94,7 +94,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
             throw new Zend_Translate_Exception('Error opening translation file \'' . $filename . '\'.');
         }
 
-        while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'])) !== false) {
+        while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'], '\\')) !== false) {
             if (is_string($data[0]) && substr($data[0], 0, 1) === '#') {
                 continue;
             }


### PR DESCRIPTION
PHP 8.4 requires the `$escape` parameter to be explicitly provided to `fgetcsv()` as its default value will change in a future version.

Added `'"'` (enclosure) and `'\\'` (escape) parameters to preserve identical behavior to previous PHP versions.

Affected files:
- `Zend/Auth/Adapter/Http/Resolver/File.php`
- `Zend/Translate/Adapter/Csv.php`

Fixes 31 test errors on php 8.4.

https://php.watch/versions/8.4/csv-functions-escape-parameter