### PR TITLE
php 8.4: [zend-feed] replace deprecated DOMDocument::$actualEncoding with $encoding

### DIFF
--- a/packages/zend-feed/library/Zend/Feed/Atom.php
+++ b/packages/zend-feed/library/Zend/Feed/Atom.php
@@ -98,7 +98,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             }
 
             $doc = new DOMDocument($this->_element->version,
-                                   $this->_element->actualEncoding);
+                                   $this->_element->encoding);
             $feed = $doc->appendChild($doc->createElement('feed'));
             $feed->appendChild($doc->importNode($element, true));
             $element = $feed;
@@ -360,7 +360,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         $doc->formatOutput = true;
 
@@ -383,7 +383,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send ATOM because headers have already been sent.');
         }
 
-        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXML();
     }

--- a/packages/zend-feed/library/Zend/Feed/Element.php
+++ b/packages/zend-feed/library/Zend/Feed/Element.php
@@ -135,7 +135,7 @@ class Zend_Feed_Element implements ArrayAccess
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument((string) $this->_element->ownerDocument->version,
-                               (string) $this->_element->ownerDocument->actualEncoding);
+                               (string) $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         return $doc->saveXML();
     }

--- a/packages/zend-feed/library/Zend/Feed/Rss.php
+++ b/packages/zend-feed/library/Zend/Feed/Rss.php
@@ -487,7 +487,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $root = $doc->createElement('rss');
 
         // Use rss version 2.0
@@ -522,7 +522,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send RSS because headers have already been sent.');
         }
 
-        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXml();
     }


### PR DESCRIPTION
`DOMDocument::$actualEncoding` is deprecated in php 8.4. It was an alias for `$encoding` - both properties have existed since PHP 5.0.

Replaced in `Zend/Feed/Atom.php`, `Zend/Feed/Element.php`, and `Zend/Feed/Rss.php`.

Fixes 7 test errors on php 8.4.

https://www.php.net/manual/en/migration84.deprecated.php