### PR TITLE
php 8.4: [zend-session] skip deprecated use_only_cookies=false in test

### DIFF
--- a/tests/Zend/Application/Resource/SessionTest.php
+++ b/tests/Zend/Application/Resource/SessionTest.php
@@ -76,19 +76,27 @@ class Zend_Application_Resource_SessionTest extends PHPUnit_Framework_TestCase
      */
     public function testSetOptions()
     {
-        Zend_Session::setOptions(array(
-            'use_only_cookies' => false,
+        $options = array(
             'remember_me_seconds' => 3600,
-        ));
+        );
+        $resourceOptions = array(
+            'remember_me_seconds' => 7200,
+        );
 
-        $this->resource->setOptions(array(
-             'use_only_cookies' => true,
-             'remember_me_seconds' => 7200,
-        ));
+        // disabling session.use_only_cookies is deprecated in php 8.4
+        if (PHP_VERSION_ID < 80400) {
+            $options['use_only_cookies'] = false;
+            $resourceOptions['use_only_cookies'] = true;
+        }
+
+        Zend_Session::setOptions($options);
+        $this->resource->setOptions($resourceOptions);
 
         $this->resource->init();
 
-        $this->assertEquals(1, Zend_Session::getOptions('use_only_cookies'));
+        if (PHP_VERSION_ID < 80400) {
+            $this->assertEquals(1, Zend_Session::getOptions('use_only_cookies'));
+        }
         $this->assertEquals(7200, Zend_Session::getOptions('remember_me_seconds'));
     }
 


### PR DESCRIPTION
PHP 8.4 deprecated disabling `session.use_only_cookies`. This setting controls whether PHP can pass session IDs via URL query strings (GET/POST) instead of cookies. Disabling it was needed for ancient browsers without cookie support, but it's a security risk (session fixation, leaking IDs in referrer headers, browser history, logs). PHP 9.0 will make `use_only_cookies` permanently enabled.

The library code is fine - `Zend_Session` defaults to `use_only_cookies => 'on'`. Only the test was explicitly setting it to `false` to verify the option override mechanism.

The fix guards the deprecated part with `PHP_VERSION_ID < 80400`, keeping the full test coverage on older PHP versions while avoiding the deprecation on 8.4+. The option override mechanism is still tested via `remember_me_seconds`.

https://wiki.php.net/rfc/deprecate-get-post-sessions