### PR TITLE
php 8.5 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,12 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
-        include:
-          - php: "8.5"
-            experimental: true
+          - "8.5"
+        # to add a new PHP version as experimental during compat work
+        # (experimental: true allows CI to pass even if that version fails):
+        # include:
+        #   - php: "8.6"
+        #     experimental: true
 
     env:
       MYSQL_USER: "zftest"

--- a/packages/zend-amf/library/Zend/Amf/Parse/Amf0/Deserializer.php
+++ b/packages/zend-amf/library/Zend/Amf/Parse/Amf0/Deserializer.php
@@ -78,7 +78,7 @@ class Zend_Amf_Parse_Amf0_Deserializer extends Zend_Amf_Parse_Deserializer
 
             // boolean
             case Zend_Amf_Constants::AMF0_BOOLEAN:
-                return (boolean) $this->_stream->readByte();
+                return (bool) $this->_stream->readByte();
 
             // string
             case Zend_Amf_Constants::AMF0_STRING:

--- a/packages/zend-amf/library/Zend/Amf/Parse/Amf3/Serializer.php
+++ b/packages/zend-amf/library/Zend/Amf/Parse/Amf3/Serializer.php
@@ -115,7 +115,7 @@ class Zend_Amf_Parse_Amf3_Serializer extends Zend_Amf_Parse_Serializer
                 case Zend_Amf_Constants::AMF3_BYTEARRAY:
                     $this->writeByteArray($data);
                     break;
-                case Zend_Amf_Constants::AMF3_XMLSTRING;
+                case Zend_Amf_Constants::AMF3_XMLSTRING:
                     $this->writeXml($data);
                     break;
                 default:

--- a/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
+++ b/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
@@ -346,7 +346,9 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
         header("Content-Type: image/" . $this->_imageType);
         $functionName = 'image' . $this->_imageType;
         call_user_func($functionName, $this->_resource);
-        @imagedestroy($this->_resource);
+        if (PHP_VERSION_ID < 80000) {
+            @imagedestroy($this->_resource);
+        }
     }
 
     /**

--- a/packages/zend-captcha/library/Zend/Captcha/Image.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Image.php
@@ -581,8 +581,10 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
         }
 
         imagepng($img2, $img_file);
-        imagedestroy($img);
-        imagedestroy($img2);
+        if (PHP_VERSION_ID < 80000) {
+            imagedestroy($img);
+            imagedestroy($img2);
+        }
     }
 
     /**

--- a/packages/zend-cloud/library/Zend/Cloud/Infrastructure/Adapter/Rackspace.php
+++ b/packages/zend-cloud/library/Zend/Cloud/Infrastructure/Adapter/Rackspace.php
@@ -424,10 +424,10 @@ class Zend_Cloud_Infrastructure_Adapter_Rackspace extends Zend_Cloud_Infrastruct
                         break;
                     case Zend_Cloud_Infrastructure_Instance::MONITOR_RAM:
                         if (preg_match('/(\d+)k total/', $output,$match)) {
-                            $total = (integer) $match[1];
+                            $total = (int) $match[1];
                         }
                         if (preg_match('/(\d+)k used/', $output,$match)) {
-                            $used = (integer) $match[1];
+                            $used = (int) $match[1];
                         }
                         if ($total>0) {
                             $usage= (float) $used/$total;

--- a/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
+++ b/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
@@ -247,7 +247,7 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
 
             if ($type == self::TYPE_ARRAY) {
                 $rii = new RecursiveIteratorIterator(
-                    $it = new RecursiveArrayIterator($value),
+                    $it = new RecursiveArrayIterator((array) $value),
                     RecursiveIteratorIterator::SELF_FIRST
                     );
                 foreach ($rii as $curKey => $curValue) {

--- a/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
+++ b/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
@@ -228,6 +228,38 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
     }
 
     /**
+     * Wraps each array element in a DefaultValue instance for code generation.
+     *
+     * Replaces the old RecursiveArrayIterator approach which had two php 8.5
+     * incompatibilities: it mutated values via offsetSet during iteration
+     * (replacing arrays with DefaultValue objects), and then when the iterator
+     * tried to descend into those replaced values, RecursiveArrayIterator called
+     * new ArrayIterator($object) - deprecated in php 8.5. On older PHP this
+     * silently yielded no children (protected properties aren't iterable), so
+     * only the top-level array was ever processed by the iterator; nested arrays
+     * were handled later by recursive generate() calls. This method does the
+     * same thing explicitly.
+     *
+     * @param  array $array
+     * @param  int   $depth
+     * @return array
+     */
+    protected function _prepareArrayValue(array $array, $depth)
+    {
+        $result = array();
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $value = new self(array('value' => $this->_prepareArrayValue($value, $depth + 1)));
+            } elseif (!$value instanceof self) {
+                $value = new self(array('value' => $value));
+            }
+            $value->setArrayDepth($depth);
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+
+    /**
      * generate()
      *
      * @return string
@@ -246,18 +278,7 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
             $type = $this->_getAutoDeterminedType($value);
 
             if ($type == self::TYPE_ARRAY) {
-                $rii = new RecursiveIteratorIterator(
-                    $it = new RecursiveArrayIterator((array) $value),
-                    RecursiveIteratorIterator::SELF_FIRST
-                    );
-                foreach ($rii as $curKey => $curValue) {
-                    if (!$curValue instanceof Zend_CodeGenerator_Php_Property_DefaultValue) {
-                        $curValue = new self(array('value' => $curValue));
-                        $rii->getSubIterator()->offsetSet($curKey, $curValue);
-                    }
-                    $curValue->setArrayDepth($rii->getDepth());
-                }
-                $value = $rii->getSubIterator()->getArrayCopy();
+                $value = $this->_prepareArrayValue((array) $value, 0);
             }
 
         }

--- a/packages/zend-config/library/Zend/Config.php
+++ b/packages/zend-config/library/Zend/Config.php
@@ -104,7 +104,7 @@ class Zend_Config implements Countable, Iterator
      */
     public function __construct(array $array, $allowModifications = false)
     {
-        $this->_allowModifications = (boolean) $allowModifications;
+        $this->_allowModifications = (bool) $allowModifications;
         $this->_loadedSection = null;
         $this->_index = 0;
         $this->_data = array();

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli.php
@@ -292,7 +292,7 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
         }
 
         if (isset($this->_config['port'])) {
-            $port = (integer) $this->_config['port'];
+            $port = (int) $this->_config['port'];
         } else {
             $port = null;
         }

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
@@ -40,7 +40,9 @@ class Zend_Db_Adapter_Mysqli_Exception extends Zend_Db_Adapter_Exception
     public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
         $sqlstate = $p->getValue($exception);
 
         return new self(

--- a/packages/zend-db/library/Zend/Db/Adapter/Sqlsrv.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Sqlsrv.php
@@ -127,7 +127,7 @@ class Zend_Db_Adapter_Sqlsrv extends Zend_Db_Adapter_Abstract
 
         $serverName = $this->_config['host'];
         if (isset($this->_config['port'])) {
-            $port        = (integer) $this->_config['port'];
+            $port        = (int) $this->_config['port'];
             $serverName .= ', ' . $port;
         }
 

--- a/packages/zend-db/library/Zend/Db/Profiler.php
+++ b/packages/zend-db/library/Zend/Db/Profiler.php
@@ -135,7 +135,7 @@ class Zend_Db_Profiler
      */
     public function setEnabled($enable)
     {
-        $this->_enabled = (boolean) $enable;
+        $this->_enabled = (bool) $enable;
 
         return $this;
     }
@@ -165,7 +165,7 @@ class Zend_Db_Profiler
         if (null === $minimumSeconds) {
             $this->_filterElapsedSecs = null;
         } else {
-            $this->_filterElapsedSecs = (integer) $minimumSeconds;
+            $this->_filterElapsedSecs = (int) $minimumSeconds;
         }
 
         return $this;

--- a/packages/zend-db/library/Zend/Db/Select.php
+++ b/packages/zend-db/library/Zend/Db/Select.php
@@ -268,7 +268,7 @@ class Zend_Db_Select
             $correlationName = current($correlationNameKeys);
         }
 
-        if (!array_key_exists($correlationName, $this->_parts[self::FROM])) {
+        if (!array_key_exists($correlationName ?? '', $this->_parts[self::FROM])) {
             /**
              * @see Zend_Db_Select_Exception
              */

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
@@ -37,7 +37,9 @@ class Zend_Db_Statement_Mysqli_Exception extends Zend_Db_Statement_Exception
     public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
         $sqlstate = $p->getValue($exception);
 
         return new self(

--- a/packages/zend-file-transfer/library/Zend/File/Transfer.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer.php
@@ -72,7 +72,7 @@ class Zend_File_Transfer
             }
         }
 
-        $direction = (integer) $direction;
+        $direction = (int) $direction;
         $this->_adapter[$direction] = new $adapter($options);
         if (!$this->_adapter[$direction] instanceof Zend_File_Transfer_Adapter_Abstract) {
             // require_once 'Zend/File/Transfer/Exception.php';
@@ -96,7 +96,7 @@ class Zend_File_Transfer
             return $this->_adapter;
         }
 
-        $direction = (integer) $direction;
+        $direction = (int) $direction;
         return $this->_adapter[$direction];
     }
 
@@ -110,7 +110,7 @@ class Zend_File_Transfer
     public function __call($method, array $options)
     {
         if (array_key_exists('direction', $options)) {
-            $direction = (integer) $options['direction'];
+            $direction = (int) $options['direction'];
         } else {
             $direction = 0;
         }

--- a/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -586,7 +586,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
                         case 'ignoreNoFile' :
                         case 'useByteString' :
                         case 'detectInfos' :
-                            $this->_files[$key]['options'][$name] = (boolean) $value;
+                            $this->_files[$key]['options'][$name] = (bool) $value;
                             break;
 
                         default:

--- a/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Http.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Http.php
@@ -141,7 +141,8 @@ class Zend_File_Transfer_Adapter_Http extends Zend_File_Transfer_Adapter_Abstrac
                 $files = current($files);
             }
 
-            $temp = array($files => array(
+            $fileKey = $files ?? '';
+            $temp = array($fileKey => array(
                 'name'  => $files,
                 'error' => 1));
             $validator = $this->_validators['Zend_Validate_File_Upload'];

--- a/packages/zend-filter/library/Zend/Filter/Alnum.php
+++ b/packages/zend-filter/library/Zend/Filter/Alnum.php
@@ -83,7 +83,7 @@ class Zend_Filter_Alnum implements Zend_Filter_Interface
             }
         }
 
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         if (null === self::$_unicodeEnabled) {
             self::$_unicodeEnabled = (@preg_match('/\pL/u', 'a')) ? true : false;
         }
@@ -115,7 +115,7 @@ class Zend_Filter_Alnum implements Zend_Filter_Interface
      */
     public function setAllowWhiteSpace($allowWhiteSpace)
     {
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/Alpha.php
+++ b/packages/zend-filter/library/Zend/Filter/Alpha.php
@@ -83,7 +83,7 @@ class Zend_Filter_Alpha implements Zend_Filter_Interface
             }
         }
 
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         if (null === self::$_unicodeEnabled) {
             self::$_unicodeEnabled = (@preg_match('/\pL/u', 'a')) ? true : false;
         }
@@ -115,7 +115,7 @@ class Zend_Filter_Alpha implements Zend_Filter_Interface
      */
     public function setAllowWhiteSpace($allowWhiteSpace)
     {
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/Boolean.php
+++ b/packages/zend-filter/library/Zend/Filter/Boolean.php
@@ -223,7 +223,7 @@ class Zend_Filter_Boolean implements Zend_Filter_Interface
      */
     public function setCasting($casting = true)
     {
-        $this->_casting = (boolean) $casting;
+        $this->_casting = (bool) $casting;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
+++ b/packages/zend-filter/library/Zend/Filter/Encrypt/Openssl.php
@@ -362,7 +362,7 @@ class Zend_Filter_Encrypt_Openssl implements Zend_Filter_Encrypt_Interface
      */
     public function setPackage($package)
     {
-        $this->_package = (boolean) $package;
+        $this->_package = (bool) $package;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/File/Rename.php
+++ b/packages/zend-filter/library/Zend/Filter/File/Rename.php
@@ -223,7 +223,7 @@ class Zend_Filter_File_Rename implements Zend_Filter_Interface
                     break;
 
                 case 'overwrite' :
-                    $files['overwrite'] = (boolean) $value;
+                    $files['overwrite'] = (bool) $value;
                     break;
 
                 default:

--- a/packages/zend-filter/library/Zend/Filter/HtmlEntities.php
+++ b/packages/zend-filter/library/Zend/Filter/HtmlEntities.php
@@ -182,7 +182,7 @@ class Zend_Filter_HtmlEntities implements Zend_Filter_Interface
      */
     public function setDoubleQuote($doubleQuote)
     {
-        $this->_doubleQuote = (boolean) $doubleQuote;
+        $this->_doubleQuote = (bool) $doubleQuote;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/Input.php
+++ b/packages/zend-filter/library/Zend/Filter/Input.php
@@ -850,7 +850,7 @@ class Zend_Filter_Input
                     
                     if (is_array($rule)) {
                         $keys      = array_keys($rule);
-                        $classKey  = array_shift($keys);
+                        $classKey  = array_shift($keys) ?? '';
                         if (isset($rule[$classKey])) {
                             $ruleClass = $rule[$classKey];
                             if ($ruleClass === 'NotEmpty') {

--- a/packages/zend-filter/library/Zend/Filter/RealPath.php
+++ b/packages/zend-filter/library/Zend/Filter/RealPath.php
@@ -73,11 +73,11 @@ class Zend_Filter_RealPath implements Zend_Filter_Interface
 
         if (is_array($exists)) {
             if (isset($exists['exists'])) {
-                $exists = (boolean) $exists['exists'];
+                $exists = (bool) $exists['exists'];
             }
         }
 
-        $this->_exists = (boolean) $exists;
+        $this->_exists = (bool) $exists;
         return $this;
     }
 

--- a/packages/zend-filter/library/Zend/Filter/StripTags.php
+++ b/packages/zend-filter/library/Zend/Filter/StripTags.php
@@ -136,7 +136,7 @@ class Zend_Filter_StripTags implements Zend_Filter_Interface
      */
     public function setCommentsAllowed($commentsAllowed)
     {
-       $this->commentsAllowed = (boolean) $commentsAllowed;
+       $this->commentsAllowed = (bool) $commentsAllowed;
        return $this;
     }
 

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -2123,8 +2123,10 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _dissolveArrayValue($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
+
         // As long as we have more levels
-        while ($arrayPos = strpos((string) $arrayPath, '[')) {
+        while ($arrayPos = strpos($arrayPath, '[')) {
             // Get the next key in the path
             $arrayKey = trim(substr($arrayPath, 0, $arrayPos), ']');
 
@@ -2181,6 +2183,8 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _attachToArray($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
+
         // As long as we have more levels
         while ($arrayPos = strrpos($arrayPath, '[')) {
             // Get the next key in the path

--- a/packages/zend-form/library/Zend/Form/Element/File.php
+++ b/packages/zend-form/library/Zend/Form/Element/File.php
@@ -562,12 +562,12 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
      */
     public function setMultiFile($count)
     {
-        if ((integer) $count < 2) {
+        if ((int) $count < 2) {
             $this->setIsArray(false);
             $this->_counter = 1;
         } else {
             $this->setIsArray(true);
-            $this->_counter = (integer) $count;
+            $this->_counter = (int) $count;
         }
 
         return $this;
@@ -643,7 +643,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
     {
         if (!is_numeric($setting)) {
             $type = strtoupper(substr($setting, -1));
-            $setting = (integer) substr($setting, 0, -1);
+            $setting = (int) substr($setting, 0, -1);
 
             switch ($type) {
                 case 'K' :
@@ -663,7 +663,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
             }
         }
 
-        return (integer) $setting;
+        return (int) $setting;
     }
 
     /**

--- a/packages/zend-gdata/library/Zend/Gdata/Analytics/AccountEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Analytics/AccountEntry.php
@@ -79,17 +79,17 @@ class Zend_Gdata_Analytics_AccountEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName){
-            case $this->lookupNamespace('analytics') . ':' . 'property';
+            case $this->lookupNamespace('analytics') . ':' . 'property':
                 $property = new Zend_Gdata_Analytics_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->{$property->getName()} = $property;
                 break;
-            case $this->lookupNamespace('analytics') . ':' . 'tableId';
+            case $this->lookupNamespace('analytics') . ':' . 'tableId':
                 $tableId = new Zend_Gdata_Analytics_Extension_TableId();
                 $tableId->transferFromDOM($child);
                 $this->_tableId = $tableId;
                 break;
-            case $this->lookupNamespace('ga') . ':' . 'goal';
+            case $this->lookupNamespace('ga') . ':' . 'goal':
                 $goal = new Zend_Gdata_Analytics_Extension_Goal();
                 $goal->transferFromDOM($child);
                 $this->_goal = $goal;

--- a/packages/zend-gdata/library/Zend/Gdata/Analytics/DataEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Analytics/DataEntry.php
@@ -58,12 +58,12 @@ class Zend_Gdata_Analytics_DataEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('analytics') . ':' . 'dimension';
+            case $this->lookupNamespace('analytics') . ':' . 'dimension':
                 $dimension = new Zend_Gdata_Analytics_Extension_Dimension();
                 $dimension->transferFromDOM($child);
                 $this->_dimensions[] = $dimension;
                 break;
-            case $this->lookupNamespace('analytics') . ':' . 'metric';
+            case $this->lookupNamespace('analytics') . ':' . 'metric':
                 $metric = new Zend_Gdata_Analytics_Extension_Metric();
                 $metric->transferFromDOM($child);
                 $this->_metrics[] = $metric;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/EventEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/EventEntry.php
@@ -94,22 +94,22 @@ class Zend_Gdata_Calendar_EventEntry extends Zend_Gdata_Kind_EventEntry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gCal') . ':' . 'sendEventNotifications';
+            case $this->lookupNamespace('gCal') . ':' . 'sendEventNotifications':
                 $sendEventNotifications = new Zend_Gdata_Calendar_Extension_SendEventNotifications();
                 $sendEventNotifications->transferFromDOM($child);
                 $this->_sendEventNotifications = $sendEventNotifications;
                 break;
-            case $this->lookupNamespace('gCal') . ':' . 'timezone';
+            case $this->lookupNamespace('gCal') . ':' . 'timezone':
                 $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
                 $timezone->transferFromDOM($child);
                 $this->_timezone = $timezone;
                 break;
-            case $this->lookupNamespace('atom') . ':' . 'link';
+            case $this->lookupNamespace('atom') . ':' . 'link':
                 $link = new Zend_Gdata_Calendar_Extension_Link();
                 $link->transferFromDOM($child);
                 $this->_link[] = $link;
                 break;
-            case $this->lookupNamespace('gCal') . ':' . 'quickadd';
+            case $this->lookupNamespace('gCal') . ':' . 'quickadd':
                 $quickadd = new Zend_Gdata_Calendar_Extension_QuickAdd();
                 $quickadd->transferFromDOM($child);
                 $this->_quickadd = $quickadd;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/EventFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/EventFeed.php
@@ -80,7 +80,7 @@ class Zend_Gdata_Calendar_EventFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gCal') . ':' . 'timezone';
+            case $this->lookupNamespace('gCal') . ':' . 'timezone':
                 $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
                 $timezone->transferFromDOM($child);
                 $this->_timezone = $timezone;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/ListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/ListEntry.php
@@ -118,32 +118,32 @@ class Zend_Gdata_Calendar_ListEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gCal') . ':' . 'accesslevel';
+        case $this->lookupNamespace('gCal') . ':' . 'accesslevel':
             $accessLevel = new Zend_Gdata_Calendar_Extension_AccessLevel();
             $accessLevel->transferFromDOM($child);
             $this->_accessLevel = $accessLevel;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'color';
+        case $this->lookupNamespace('gCal') . ':' . 'color':
             $color = new Zend_Gdata_Calendar_Extension_Color();
             $color->transferFromDOM($child);
             $this->_color = $color;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'hidden';
+        case $this->lookupNamespace('gCal') . ':' . 'hidden':
             $hidden = new Zend_Gdata_Calendar_Extension_Hidden();
             $hidden->transferFromDOM($child);
             $this->_hidden = $hidden;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'selected';
+        case $this->lookupNamespace('gCal') . ':' . 'selected':
             $selected = new Zend_Gdata_Calendar_Extension_Selected();
             $selected->transferFromDOM($child);
             $this->_selected = $selected;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'timezone';
+        case $this->lookupNamespace('gCal') . ':' . 'timezone':
             $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
             $timezone->transferFromDOM($child);
             $this->_timezone = $timezone;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'where';
+        case $this->lookupNamespace('gd') . ':' . 'where':
             $where = new Zend_Gdata_Extension_Where();
             $where->transferFromDOM($child);
             $this->_where[] = $where;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/ListFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/ListFeed.php
@@ -77,7 +77,7 @@ class Zend_Gdata_Calendar_ListFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gCal') . ':' . 'timezone';
+        case $this->lookupNamespace('gCal') . ':' . 'timezone':
             $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
             $timezone->transferFromDOM($child);
             $this->_timezone = $timezone;

--- a/packages/zend-gdata/library/Zend/Gdata/Exif/Extension/Tags.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Exif/Extension/Tags.php
@@ -264,52 +264,52 @@ class Zend_Gdata_Exif_Extension_Tags extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('exif') . ':' . 'distance';
+            case $this->lookupNamespace('exif') . ':' . 'distance':
                 $distance = new Zend_Gdata_Exif_Extension_Distance();
                 $distance->transferFromDOM($child);
                 $this->_distance = $distance;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'exposure';
+            case $this->lookupNamespace('exif') . ':' . 'exposure':
                 $exposure = new Zend_Gdata_Exif_Extension_Exposure();
                 $exposure->transferFromDOM($child);
                 $this->_exposure = $exposure;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'flash';
+            case $this->lookupNamespace('exif') . ':' . 'flash':
                 $flash = new Zend_Gdata_Exif_Extension_Flash();
                 $flash->transferFromDOM($child);
                 $this->_flash = $flash;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'focallength';
+            case $this->lookupNamespace('exif') . ':' . 'focallength':
                 $focalLength = new Zend_Gdata_Exif_Extension_FocalLength();
                 $focalLength->transferFromDOM($child);
                 $this->_focalLength = $focalLength;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'fstop';
+            case $this->lookupNamespace('exif') . ':' . 'fstop':
                 $fStop = new Zend_Gdata_Exif_Extension_FStop();
                 $fStop->transferFromDOM($child);
                 $this->_fStop = $fStop;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'imageUniqueID';
+            case $this->lookupNamespace('exif') . ':' . 'imageUniqueID':
                 $imageUniqueId = new Zend_Gdata_Exif_Extension_ImageUniqueId();
                 $imageUniqueId->transferFromDOM($child);
                 $this->_imageUniqueId = $imageUniqueId;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'iso';
+            case $this->lookupNamespace('exif') . ':' . 'iso':
                 $iso = new Zend_Gdata_Exif_Extension_Iso();
                 $iso->transferFromDOM($child);
                 $this->_iso = $iso;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'make';
+            case $this->lookupNamespace('exif') . ':' . 'make':
                 $make = new Zend_Gdata_Exif_Extension_Make();
                 $make->transferFromDOM($child);
                 $this->_make = $make;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'model';
+            case $this->lookupNamespace('exif') . ':' . 'model':
                 $model = new Zend_Gdata_Exif_Extension_Model();
                 $model->transferFromDOM($child);
                 $this->_model = $model;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'time';
+            case $this->lookupNamespace('exif') . ':' . 'time':
                 $time = new Zend_Gdata_Exif_Extension_Time();
                 $time->transferFromDOM($child);
                 $this->_time = $time;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/Comments.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/Comments.php
@@ -70,7 +70,7 @@ class Zend_Gdata_Extension_Comments extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/EntryLink.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/EntryLink.php
@@ -81,7 +81,7 @@ class Zend_Gdata_Extension_EntryLink extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('atom') . ':' . 'entry';
+            case $this->lookupNamespace('atom') . ':' . 'entry':
                 $entry = new Zend_Gdata_Entry();
                 $entry->transferFromDOM($child);
                 $this->_entry = $entry;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/FeedLink.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/FeedLink.php
@@ -86,7 +86,7 @@ class Zend_Gdata_Extension_FeedLink extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('atom') . ':' . 'feed';
+            case $this->lookupNamespace('atom') . ':' . 'feed':
                 $feed = new Zend_Gdata_Feed();
                 $feed->transferFromDOM($child);
                 $this->_feed = $feed;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/OriginalEvent.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/OriginalEvent.php
@@ -94,7 +94,7 @@ class Zend_Gdata_Extension_OriginalEvent extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'when';
+            case $this->lookupNamespace('gd') . ':' . 'when':
                 $when = new Zend_Gdata_Extension_When();
                 $when->transferFromDOM($child);
                 $this->_when = $when;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/When.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/When.php
@@ -84,7 +84,7 @@ class Zend_Gdata_Extension_When extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'reminder';
+            case $this->lookupNamespace('gd') . ':' . 'reminder':
                 $reminder = new Zend_Gdata_Extension_Reminder();
                 $reminder->transferFromDOM($child);
                 $this->_reminders[] = $reminder;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListEntry.php
@@ -121,12 +121,12 @@ class Zend_Gdata_Gapps_EmailListEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'emailList';
+            case $this->lookupNamespace('apps') . ':' . 'emailList':
                 $emailList = new Zend_Gdata_Gapps_Extension_EmailList();
                 $emailList->transferFromDOM($child);
                 $this->_emailList = $emailList;
                 break;
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink[] = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListRecipientEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListRecipientEntry.php
@@ -107,7 +107,7 @@ class Zend_Gdata_Gapps_EmailListRecipientEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'who';
+            case $this->lookupNamespace('gd') . ':' . 'who':
                 $who = new Zend_Gdata_Extension_Who();
                 $who->transferFromDOM($child);
                 $this->_who = $who;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/GroupEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/GroupEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_GroupEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/MemberEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/MemberEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_MemberEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/NicknameEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/NicknameEntry.php
@@ -120,12 +120,12 @@ class Zend_Gdata_Gapps_NicknameEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'login';
+            case $this->lookupNamespace('apps') . ':' . 'login':
                 $login = new Zend_Gdata_Gapps_Extension_Login();
                 $login->transferFromDOM($child);
                 $this->_login = $login;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'nickname';
+            case $this->lookupNamespace('apps') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Gapps_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_nickname = $nickname;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/OwnerEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/OwnerEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_OwnerEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/UserEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/UserEntry.php
@@ -150,22 +150,22 @@ class Zend_Gdata_Gapps_UserEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'login';
+            case $this->lookupNamespace('apps') . ':' . 'login':
                 $login = new Zend_Gdata_Gapps_Extension_Login();
                 $login->transferFromDOM($child);
                 $this->_login = $login;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'name';
+            case $this->lookupNamespace('apps') . ':' . 'name':
                 $name = new Zend_Gdata_Gapps_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_name = $name;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'quota';
+            case $this->lookupNamespace('apps') . ':' . 'quota':
                 $quota = new Zend_Gdata_Gapps_Extension_Quota();
                 $quota->transferFromDOM($child);
                 $this->_quota = $quota;
                 break;
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink[] = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GeoRssWhere.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GeoRssWhere.php
@@ -101,7 +101,7 @@ class Zend_Gdata_Geo_Extension_GeoRssWhere extends Zend_Gdata_Extension
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gml') . ':' . 'Point';
+            case $this->lookupNamespace('gml') . ':' . 'Point':
                 $point = new Zend_Gdata_Geo_Extension_GmlPoint();
                 $point->transferFromDOM($child);
                 $this->_point = $point;

--- a/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GmlPoint.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GmlPoint.php
@@ -101,7 +101,7 @@ class Zend_Gdata_Geo_Extension_GmlPoint extends Zend_Gdata_Extension
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gml') . ':' . 'pos';
+            case $this->lookupNamespace('gml') . ':' . 'pos':
                 $pos = new Zend_Gdata_Geo_Extension_GmlPos();
                 $pos->transferFromDOM($child);
                 $this->_pos = $pos;

--- a/packages/zend-gdata/library/Zend/Gdata/Kind/EventEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Kind/EventEntry.php
@@ -169,58 +169,58 @@ class Zend_Gdata_Kind_EventEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gd') . ':' . 'where';
+        case $this->lookupNamespace('gd') . ':' . 'where':
             $where = new Zend_Gdata_Extension_Where();
             $where->transferFromDOM($child);
             $this->_where[] = $where;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'when';
+        case $this->lookupNamespace('gd') . ':' . 'when':
             $when = new Zend_Gdata_Extension_When();
             $when->transferFromDOM($child);
             $this->_when[] = $when;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'who';
+        case $this->lookupNamespace('gd') . ':' . 'who':
             $who = new Zend_Gdata_Extension_Who();
             $who ->transferFromDOM($child);
             $this->_who[] = $who;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'recurrence';
+        case $this->lookupNamespace('gd') . ':' . 'recurrence':
             $recurrence = new Zend_Gdata_Extension_Recurrence();
             $recurrence->transferFromDOM($child);
             $this->_recurrence = $recurrence;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'eventStatus';
+        case $this->lookupNamespace('gd') . ':' . 'eventStatus':
             $eventStatus = new Zend_Gdata_Extension_EventStatus();
             $eventStatus->transferFromDOM($child);
             $this->_eventStatus = $eventStatus;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'comments';
+        case $this->lookupNamespace('gd') . ':' . 'comments':
             $comments = new Zend_Gdata_Extension_Comments();
             $comments->transferFromDOM($child);
             $this->_comments = $comments;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'transparency';
+        case $this->lookupNamespace('gd') . ':' . 'transparency':
             $transparency = new Zend_Gdata_Extension_Transparency();
             $transparency ->transferFromDOM($child);
             $this->_transparency = $transparency;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'visibility';
+        case $this->lookupNamespace('gd') . ':' . 'visibility':
             $visiblity = new Zend_Gdata_Extension_Visibility();
             $visiblity ->transferFromDOM($child);
             $this->_visibility = $visiblity;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'recurrenceException';
+        case $this->lookupNamespace('gd') . ':' . 'recurrenceException':
             // require_once 'Zend/Gdata/Extension/RecurrenceException.php';
             $recurrenceException = new Zend_Gdata_Extension_RecurrenceException();
             $recurrenceException ->transferFromDOM($child);
             $this->_recurrenceException[] = $recurrenceException;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'originalEvent';
+        case $this->lookupNamespace('gd') . ':' . 'originalEvent':
             $originalEvent = new Zend_Gdata_Extension_OriginalEvent();
             $originalEvent ->transferFromDOM($child);
             $this->_originalEvent = $originalEvent;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'extendedProperty';
+        case $this->lookupNamespace('gd') . ':' . 'extendedProperty':
             $extProp = new Zend_Gdata_Extension_ExtendedProperty();
             $extProp->transferFromDOM($child);
             $this->_extendedProperty[] = $extProp;

--- a/packages/zend-gdata/library/Zend/Gdata/Media/Extension/MediaGroup.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Media/Extension/MediaGroup.php
@@ -258,67 +258,67 @@ class Zend_Gdata_Media_Extension_MediaGroup extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('media') . ':' . 'content';
+            case $this->lookupNamespace('media') . ':' . 'content':
                 $content = new Zend_Gdata_Media_Extension_MediaContent();
                 $content->transferFromDOM($child);
                 $this->_content[] = $content;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'category';
+            case $this->lookupNamespace('media') . ':' . 'category':
                 $category = new Zend_Gdata_Media_Extension_MediaCategory();
                 $category->transferFromDOM($child);
                 $this->_category[] = $category;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'copyright';
+            case $this->lookupNamespace('media') . ':' . 'copyright':
                 $copyright = new Zend_Gdata_Media_Extension_MediaCopyright();
                 $copyright->transferFromDOM($child);
                 $this->_copyright = $copyright;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'credit';
+            case $this->lookupNamespace('media') . ':' . 'credit':
                 $credit = new Zend_Gdata_Media_Extension_MediaCredit();
                 $credit->transferFromDOM($child);
                 $this->_credit[] = $credit;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'description';
+            case $this->lookupNamespace('media') . ':' . 'description':
                 $description = new Zend_Gdata_Media_Extension_MediaDescription();
                 $description->transferFromDOM($child);
                 $this->_description = $description;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'hash';
+            case $this->lookupNamespace('media') . ':' . 'hash':
                 $hash = new Zend_Gdata_Media_Extension_MediaHash();
                 $hash->transferFromDOM($child);
                 $this->_hash[] = $hash;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'keywords';
+            case $this->lookupNamespace('media') . ':' . 'keywords':
                 $keywords = new Zend_Gdata_Media_Extension_MediaKeywords();
                 $keywords->transferFromDOM($child);
                 $this->_keywords = $keywords;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'player';
+            case $this->lookupNamespace('media') . ':' . 'player':
                 $player = new Zend_Gdata_Media_Extension_MediaPlayer();
                 $player->transferFromDOM($child);
                 $this->_player[] = $player;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'rating';
+            case $this->lookupNamespace('media') . ':' . 'rating':
                 $rating = new Zend_Gdata_Media_Extension_MediaRating();
                 $rating->transferFromDOM($child);
                 $this->_rating[] = $rating;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'restriction';
+            case $this->lookupNamespace('media') . ':' . 'restriction':
                 $restriction = new Zend_Gdata_Media_Extension_MediaRestriction();
                 $restriction->transferFromDOM($child);
                 $this->_restriction[] = $restriction;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'text';
+            case $this->lookupNamespace('media') . ':' . 'text':
                 $text = new Zend_Gdata_Media_Extension_MediaText();
                 $text->transferFromDOM($child);
                 $this->_mediaText[] = $text;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'thumbnail';
+            case $this->lookupNamespace('media') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Media_Extension_MediaThumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_thumbnail[] = $thumbnail;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'title';
+            case $this->lookupNamespace('media') . ':' . 'title':
                 $title = new Zend_Gdata_Media_Extension_MediaTitle();
                 $title->transferFromDOM($child);
                 $this->_title = $title;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumEntry.php
@@ -266,62 +266,62 @@ class Zend_Gdata_Photos_AlbumEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'access';
+            case $this->lookupNamespace('gphoto') . ':' . 'access':
                 $access = new Zend_Gdata_Photos_Extension_Access();
                 $access->transferFromDOM($child);
                 $this->_gphotoAccess = $access;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'location';
+            case $this->lookupNamespace('gphoto') . ':' . 'location':
                 $location = new Zend_Gdata_Photos_Extension_Location();
                 $location->transferFromDOM($child);
                 $this->_gphotoLocation = $location;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'name';
+            case $this->lookupNamespace('gphoto') . ':' . 'name':
                 $name = new Zend_Gdata_Photos_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_gphotoName = $name;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'numphotos';
+            case $this->lookupNamespace('gphoto') . ':' . 'numphotos':
                 $numPhotos = new Zend_Gdata_Photos_Extension_NumPhotos();
                 $numPhotos->transferFromDOM($child);
                 $this->_gphotoNumPhotos = $numPhotos;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('georss') . ':' . 'where';
+            case $this->lookupNamespace('georss') . ':' . 'where':
                 $geoRssWhere = new Zend_Gdata_Geo_Extension_GeoRssWhere();
                 $geoRssWhere->transferFromDOM($child);
                 $this->_geoRssWhere = $geoRssWhere;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'group';
+            case $this->lookupNamespace('media') . ':' . 'group':
                 $mediaGroup = new Zend_Gdata_Media_Extension_MediaGroup();
                 $mediaGroup->transferFromDOM($child);
                 $this->_mediaGroup = $mediaGroup;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumFeed.php
@@ -178,52 +178,52 @@ class Zend_Gdata_Photos_AlbumFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'name';
+            case $this->lookupNamespace('gphoto') . ':' . 'name':
                 $name = new Zend_Gdata_Photos_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_gphotoName = $name;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'location';
+            case $this->lookupNamespace('gphoto') . ':' . 'location':
                 $location = new Zend_Gdata_Photos_Extension_Location();
                 $location->transferFromDOM($child);
                 $this->_gphotoLocation = $location;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'access';
+            case $this->lookupNamespace('gphoto') . ':' . 'access':
                 $access = new Zend_Gdata_Photos_Extension_Access();
                 $access->transferFromDOM($child);
                 $this->_gphotoAccess = $access;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'numphotos';
+            case $this->lookupNamespace('gphoto') . ':' . 'numphotos':
                 $numphotos = new Zend_Gdata_Photos_Extension_NumPhotos();
                 $numphotos->transferFromDOM($child);
                 $this->_gphotoNumPhotos = $numphotos;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/CommentEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/CommentEntry.php
@@ -131,12 +131,12 @@ class Zend_Gdata_Photos_CommentEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'photoid';
+            case $this->lookupNamespace('gphoto') . ':' . 'photoid':
                 $photoid = new Zend_Gdata_Photos_Extension_PhotoId();
                 $photoid->transferFromDOM($child);
                 $this->_gphotoPhotoId = $photoid;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoEntry.php
@@ -294,67 +294,67 @@ class Zend_Gdata_Photos_PhotoEntry extends Zend_Gdata_Media_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'albumid';
+            case $this->lookupNamespace('gphoto') . ':' . 'albumid':
                 $albumId = new Zend_Gdata_Photos_Extension_AlbumId();
                 $albumId->transferFromDOM($child);
                 $this->_gphotoAlbumId = $albumId;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'version';
+            case $this->lookupNamespace('gphoto') . ':' . 'version':
                 $version = new Zend_Gdata_Photos_Extension_Version();
                 $version->transferFromDOM($child);
                 $this->_gphotoVersion = $version;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'width';
+            case $this->lookupNamespace('gphoto') . ':' . 'width':
                 $width = new Zend_Gdata_Photos_Extension_Width();
                 $width->transferFromDOM($child);
                 $this->_gphotoWidth = $width;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'height';
+            case $this->lookupNamespace('gphoto') . ':' . 'height':
                 $height = new Zend_Gdata_Photos_Extension_Height();
                 $height->transferFromDOM($child);
                 $this->_gphotoHeight = $height;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'size';
+            case $this->lookupNamespace('gphoto') . ':' . 'size':
                 $size = new Zend_Gdata_Photos_Extension_Size();
                 $size->transferFromDOM($child);
                 $this->_gphotoSize = $size;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'client';
+            case $this->lookupNamespace('gphoto') . ':' . 'client':
                 $client = new Zend_Gdata_Photos_Extension_Client();
                 $client->transferFromDOM($child);
                 $this->_gphotoClient = $client;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'checksum';
+            case $this->lookupNamespace('gphoto') . ':' . 'checksum':
                 $checksum = new Zend_Gdata_Photos_Extension_Checksum();
                 $checksum->transferFromDOM($child);
                 $this->_gphotoChecksum = $checksum;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'tags';
+            case $this->lookupNamespace('exif') . ':' . 'tags':
                 $exifTags = new Zend_Gdata_Exif_Extension_Tags();
                 $exifTags->transferFromDOM($child);
                 $this->_exifTags = $exifTags;
                 break;
-            case $this->lookupNamespace('georss') . ':' . 'where';
+            case $this->lookupNamespace('georss') . ':' . 'where':
                 $geoRssWhere = new Zend_Gdata_Geo_Extension_GeoRssWhere();
                 $geoRssWhere->transferFromDOM($child);
                 $this->_geoRssWhere = $geoRssWhere;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoFeed.php
@@ -195,62 +195,62 @@ class Zend_Gdata_Photos_PhotoFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'version';
+            case $this->lookupNamespace('gphoto') . ':' . 'version':
                 $version = new Zend_Gdata_Photos_Extension_Version();
                 $version->transferFromDOM($child);
                 $this->_gphotoVersion = $version;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'albumid';
+            case $this->lookupNamespace('gphoto') . ':' . 'albumid':
                 $albumid = new Zend_Gdata_Photos_Extension_AlbumId();
                 $albumid->transferFromDOM($child);
                 $this->_gphotoAlbumId = $albumid;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'width';
+            case $this->lookupNamespace('gphoto') . ':' . 'width':
                 $width = new Zend_Gdata_Photos_Extension_Width();
                 $width->transferFromDOM($child);
                 $this->_gphotoWidth = $width;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'height';
+            case $this->lookupNamespace('gphoto') . ':' . 'height':
                 $height = new Zend_Gdata_Photos_Extension_Height();
                 $height->transferFromDOM($child);
                 $this->_gphotoHeight = $height;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'size';
+            case $this->lookupNamespace('gphoto') . ':' . 'size':
                 $size = new Zend_Gdata_Photos_Extension_Size();
                 $size->transferFromDOM($child);
                 $this->_gphotoSize = $size;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'client';
+            case $this->lookupNamespace('gphoto') . ':' . 'client':
                 $client = new Zend_Gdata_Photos_Extension_Client();
                 $client->transferFromDOM($child);
                 $this->_gphotoClient = $client;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'checksum';
+            case $this->lookupNamespace('gphoto') . ':' . 'checksum':
                 $checksum = new Zend_Gdata_Photos_Extension_Checksum();
                 $checksum->transferFromDOM($child);
                 $this->_gphotoChecksum = $checksum;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'group';
+            case $this->lookupNamespace('media') . ':' . 'group':
                 $mediaGroup = new Zend_Gdata_Media_Extension_MediaGroup();
                 $mediaGroup->transferFromDOM($child);
                 $this->_mediaGroup = $mediaGroup;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/TagEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/TagEntry.php
@@ -104,7 +104,7 @@ class Zend_Gdata_Photos_TagEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'weight';
+            case $this->lookupNamespace('gphoto') . ':' . 'weight':
                 $weight = new Zend_Gdata_Photos_Extension_Weight();
                 $weight->transferFromDOM($child);
                 $this->_gphotoWeight = $weight;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/UserEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/UserEntry.php
@@ -189,32 +189,32 @@ class Zend_Gdata_Photos_UserEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail';
+            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Photos_Extension_Thumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_gphotoThumbnail = $thumbnail;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'quotacurrent';
+            case $this->lookupNamespace('gphoto') . ':' . 'quotacurrent':
                 $quotaCurrent = new Zend_Gdata_Photos_Extension_QuotaCurrent();
                 $quotaCurrent->transferFromDOM($child);
                 $this->_gphotoQuotaCurrent = $quotaCurrent;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'quotalimit';
+            case $this->lookupNamespace('gphoto') . ':' . 'quotalimit':
                 $quotaLimit = new Zend_Gdata_Photos_Extension_QuotaLimit();
                 $quotaLimit->transferFromDOM($child);
                 $this->_gphotoQuotaLimit = $quotaLimit;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'maxPhotosPerAlbum';
+            case $this->lookupNamespace('gphoto') . ':' . 'maxPhotosPerAlbum':
                 $maxPhotosPerAlbum = new Zend_Gdata_Photos_Extension_MaxPhotosPerAlbum();
                 $maxPhotosPerAlbum->transferFromDOM($child);
                 $this->_gphotoMaxPhotosPerAlbum = $maxPhotosPerAlbum;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/UserFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/UserFeed.php
@@ -119,17 +119,17 @@ class Zend_Gdata_Photos_UserFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail';
+            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Photos_Extension_Thumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_gphotoThumbnail = $thumbnail;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellEntry.php
@@ -70,7 +70,7 @@ class Zend_Gdata_Spreadsheets_CellEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gs') . ':' . 'cell';
+        case $this->lookupNamespace('gs') . ':' . 'cell':
             $cell = new Zend_Gdata_Spreadsheets_Extension_Cell();
             $cell->transferFromDOM($child);
             $this->_cell = $cell;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellFeed.php
@@ -101,12 +101,12 @@ class Zend_Gdata_Spreadsheets_CellFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gs') . ':' . 'rowCount';
+            case $this->lookupNamespace('gs') . ':' . 'rowCount':
                 $rowCount = new Zend_Gdata_Spreadsheets_Extension_RowCount();
                 $rowCount->transferFromDOM($child);
                 $this->_rowCount = $rowCount;
                 break;
-            case $this->lookupNamespace('gs') . ':' . 'colCount';
+            case $this->lookupNamespace('gs') . ':' . 'colCount':
                 $colCount = new Zend_Gdata_Spreadsheets_Extension_ColCount();
                 $colCount->transferFromDOM($child);
                 $this->_colCount = $colCount;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/ListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/ListEntry.php
@@ -83,7 +83,7 @@ class Zend_Gdata_Spreadsheets_ListEntry extends Zend_Gdata_Entry
     protected function takeChildFromDOM($child)
     {
         switch ($child->namespaceURI) {
-        case $this->lookupNamespace('gsx');
+        case $this->lookupNamespace('gsx'):
             $custom = new Zend_Gdata_Spreadsheets_Extension_Custom($child->localName);
             $custom->transferFromDOM($child);
             $this->addCustom($custom);

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/WorksheetEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/WorksheetEntry.php
@@ -96,12 +96,12 @@ class Zend_Gdata_Spreadsheets_WorksheetEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gs') . ':' . 'rowCount';
+            case $this->lookupNamespace('gs') . ':' . 'rowCount':
                 $rowCount = new Zend_Gdata_Spreadsheets_Extension_RowCount();
                 $rowCount->transferFromDOM($child);
                 $this->_rowCount = $rowCount;
                 break;
-            case $this->lookupNamespace('gs') . ':' . 'colCount';
+            case $this->lookupNamespace('gs') . ':' . 'colCount':
                 $colCount = new Zend_Gdata_Spreadsheets_Extension_ColCount();
                 $colCount->transferFromDOM($child);
                 $this->_colCount = $colCount;

--- a/packages/zend-http/library/Zend/Http/Client.php
+++ b/packages/zend-http/library/Zend/Http/Client.php
@@ -539,6 +539,7 @@ class Zend_Http_Client
     protected function _setParameter($type, $name, $value)
     {
         $parray = array();
+        $name = $name ?? '';
         $type = strtolower($type);
         switch ($type) {
             case 'get':

--- a/packages/zend-locale/library/Zend/Locale/Data.php
+++ b/packages/zend-locale/library/Zend/Locale/Data.php
@@ -1575,7 +1575,7 @@ class Zend_Locale_Data
      */
     public static function disableCache($flag)
     {
-        self::$_cacheDisabled = (boolean) $flag;
+        self::$_cacheDisabled = (bool) $flag;
     }
 
     /**

--- a/packages/zend-memory/library/Zend/Memory/Manager.php
+++ b/packages/zend-memory/library/Zend/Memory/Manager.php
@@ -169,7 +169,7 @@ class Zend_Memory_Manager
 
         $memoryLimitStr = trim(ini_get('memory_limit'));
         if ($memoryLimitStr != ''  &&  $memoryLimitStr != -1) {
-            $this->_memoryLimit = (integer)$memoryLimitStr;
+            $this->_memoryLimit = (int)$memoryLimitStr;
             switch (strtolower($memoryLimitStr[strlen($memoryLimitStr)-1])) {
                 case 'g':
                     $this->_memoryLimit *= 1024;

--- a/packages/zend-navigation/library/Zend/Navigation/Container.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Container.php
@@ -516,6 +516,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
         current($this->_index);
         $hash = key($this->_index);
 
+        $hash = $hash ?? '';
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];
         } else {
@@ -607,6 +608,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
     {
         $hash = key($this->_index);
 
+        $hash = $hash ?? '';
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];
         }

--- a/packages/zend-paginator/library/Zend/Paginator.php
+++ b/packages/zend-paginator/library/Zend/Paginator.php
@@ -648,7 +648,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     public function setCurrentPageNumber($pageNumber)
     {
-        $this->_currentPageNumber = (integer) $pageNumber;
+        $this->_currentPageNumber = (int) $pageNumber;
         $this->_currentItems      = null;
         $this->_currentItemCount  = null;
 
@@ -747,7 +747,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     public function setItemCountPerPage($itemCountPerPage = -1)
     {
-        $this->_itemCountPerPage = (integer) $itemCountPerPage;
+        $this->_itemCountPerPage = (int) $itemCountPerPage;
         if ($this->_itemCountPerPage < 1) {
             $this->_itemCountPerPage = $this->getTotalItemCount();
         }
@@ -847,7 +847,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     public function setPageRange($pageRange)
     {
-        $this->_pageRange = (integer) $pageRange;
+        $this->_pageRange = (int) $pageRange;
 
         return $this;
     }
@@ -951,7 +951,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     public function normalizeItemNumber($itemNumber)
     {
-        $itemNumber = (integer) $itemNumber;
+        $itemNumber = (int) $itemNumber;
 
         if ($itemNumber < 1) {
             $itemNumber = 1;
@@ -972,7 +972,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     public function normalizePageNumber($pageNumber)
     {
-        $pageNumber = (integer) $pageNumber;
+        $pageNumber = (int) $pageNumber;
 
         if ($pageNumber < 1) {
             $pageNumber = 1;
@@ -1080,7 +1080,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      */
     protected function _calculatePageCount()
     {
-        return (integer) ceil($this->getTotalItemCount() / $this->getItemCountPerPage());
+        return (int) ceil($this->getTotalItemCount() / $this->getItemCountPerPage());
     }
 
     /**

--- a/packages/zend-pdf/library/Zend/Pdf.php
+++ b/packages/zend-pdf/library/Zend/Pdf.php
@@ -578,8 +578,8 @@ class Zend_Pdf
 
         $outlineDictionary = $root->Outlines->First;
         $processedDictionaries = new SplObjectStorage();
-        while ($outlineDictionary !== null  &&  !$processedDictionaries->contains($outlineDictionary)) {
-            $processedDictionaries->attach($outlineDictionary);
+        while ($outlineDictionary !== null  &&  !$processedDictionaries->offsetExists($outlineDictionary)) {
+            $processedDictionaries->offsetSet($outlineDictionary);
 
             // require_once 'Zend/Pdf/Outline/Loaded.php';
             $this->outlines[] = new Zend_Pdf_Outline_Loaded($outlineDictionary);

--- a/packages/zend-pdf/library/Zend/Pdf/Action.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Action.php
@@ -87,15 +87,15 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
         if ($dictionary->Next !== null) {
             if ($dictionary->Next instanceof Zend_Pdf_Element_Dictionary) {
                 // Check if dictionary object is not already processed
-                if (!$processedActions->contains($dictionary->Next)) {
-                    $processedActions->attach($dictionary->Next);
+                if (!$processedActions->offsetExists($dictionary->Next)) {
+                    $processedActions->offsetSet($dictionary->Next);
                     $this->next[] = Zend_Pdf_Action::load($dictionary->Next, $processedActions);
                 }
             } else if ($dictionary->Next instanceof Zend_Pdf_Element_Array) {
                 foreach ($dictionary->Next->items as $chainedActionDictionary) {
                     // Check if dictionary object is not already processed
-                    if (!$processedActions->contains($chainedActionDictionary)) {
-                        $processedActions->attach($chainedActionDictionary);
+                    if (!$processedActions->offsetExists($chainedActionDictionary)) {
+                        $processedActions->offsetSet($chainedActionDictionary);
                         $this->next[] = Zend_Pdf_Action::load($chainedActionDictionary, $processedActions);
                     }
                 }
@@ -262,11 +262,11 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();
         }
-        if ($processedActions->contains($this)) {
+        if ($processedActions->offsetExists($this)) {
             // require_once 'Zend/Pdf/Exception.php';
             throw new Zend_Pdf_Exception('Action chain cyclyc reference is detected.');
         }
-        $processedActions->attach($this);
+        $processedActions->offsetSet($this);
 
         $childListUpdated = false;
         if (count($this->_originalNextList) != count($this->next)) {

--- a/packages/zend-pdf/library/Zend/Pdf/ElementFactory.php
+++ b/packages/zend-pdf/library/Zend/Pdf/ElementFactory.php
@@ -318,7 +318,7 @@ class Zend_Pdf_ElementFactory implements Zend_Pdf_ElementFactory_Interface
         }
 
         $this->_modifiedObjects[$obj->getObjNum()] = $obj;
-        $this->_removedObjects->attach($obj);
+        $this->_removedObjects->offsetSet($obj);
     }
 
 
@@ -376,7 +376,7 @@ class Zend_Pdf_ElementFactory implements Zend_Pdf_ElementFactory_Interface
         $result = array();
         // require_once 'Zend/Pdf/UpdateInfoContainer.php';
         foreach ($this->_modifiedObjects as $objNum => $obj) {
-            if ($this->_removedObjects->contains($obj)) {
+            if ($this->_removedObjects->offsetExists($obj)) {
                             $result[$objNum+$shift] = new Zend_Pdf_UpdateInfoContainer($objNum + $shift,
                                                                            $obj->getGenNum()+1,
                                                                            true);

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
@@ -252,7 +252,7 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }
-        $processedOutlines->attach($this);
+        $processedOutlines->offsetSet($this);
 
         $outlineDictionary = $factory->newObject(new Zend_Pdf_Element_Dictionary());
 
@@ -290,7 +290,7 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
 
         $lastChild = null;
         foreach ($this->childOutlines as $childOutline) {
-            if ($processedOutlines->contains($childOutline)) {
+            if ($processedOutlines->offsetExists($childOutline)) {
                 // require_once 'Zend/Pdf/Exception.php';
                 throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
             }

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
@@ -318,7 +318,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
         if ($processedDictionaries === null) {
             $processedDictionaries = new SplObjectStorage();
         }
-        $processedDictionaries->attach($dictionary);
+        $processedDictionaries->offsetSet($dictionary);
 
         $this->_outlineDictionary = $dictionary;
 
@@ -339,12 +339,12 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             $children = new SplObjectStorage();
             while ($childDictionary !== null) {
                 // Check children structure for cyclic references
-                if ($children->contains($childDictionary)) {
+                if ($children->offsetExists($childDictionary)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outline childs load error.');
                 }
 
-                if (!$processedDictionaries->contains($childDictionary)) {
+                if (!$processedDictionaries->offsetExists($childDictionary)) {
                     $this->childOutlines[] = new Zend_Pdf_Outline_Loaded($childDictionary, $processedDictionaries);
                 }
 
@@ -378,7 +378,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }
-        $processedOutlines->attach($this);
+        $processedOutlines->offsetSet($this);
 
         if ($updateNavigation) {
             $this->_outlineDictionary->touch();
@@ -410,7 +410,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             $this->_outlineDictionary->First = null;
 
             foreach ($this->childOutlines as $childOutline) {
-                if ($processedOutlines->contains($childOutline)) {
+                if ($processedOutlines->offsetExists($childOutline)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
                 }
@@ -436,7 +436,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             }
         } else {
             foreach ($this->childOutlines as $childOutline) {
-                if ($processedOutlines->contains($childOutline)) {
+                if ($processedOutlines->offsetExists($childOutline)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
                 }

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Image/Png.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Image/Png.php
@@ -190,7 +190,7 @@ class Zend_Pdf_Resource_Image_Png extends Zend_Pdf_Resource_Image
                     fseek($imageFile, 4, SEEK_CUR); //4 Byte Ending Sequence
                     break;
 
-                case 'IEND';
+                case 'IEND':
                     break 2; //End the loop too
 
                 default:

--- a/packages/zend-rest/library/Zend/Rest/Server.php
+++ b/packages/zend-rest/library/Zend/Rest/Server.php
@@ -478,8 +478,9 @@ class Zend_Rest_Server implements Zend_Server_Interface
      */
     public function fault($exception = null, $code = null)
     {
-        if (isset($this->_functions[$this->_method])) {
-            $function = $this->_functions[$this->_method];
+        $method = $this->_method ?? '';
+        if (isset($this->_functions[$method])) {
+            $function = $this->_functions[$method];
         } elseif (isset($this->_method)) {
             $function = $this->_method;
         } else {

--- a/packages/zend-search-lucene/library/Zend/Search/Lucene/Document/Xlsx.php
+++ b/packages/zend-search-lucene/library/Zend/Search/Lucene/Document/Xlsx.php
@@ -194,7 +194,7 @@ class Zend_Search_Lucene_Document_Xlsx extends Zend_Search_Lucene_Document_OpenX
                             if (is_numeric($value) && $dataType != 's') {
                                 if ($value == (int)$value) $value = (int)$value;
                                 elseif ($value == (float)$value) $value = (float)$value;
-                                elseif ($value == (double)$value) $value = (double)$value;
+                                elseif ($value == (float)$value) $value = (float)$value;
                             }
                     }
 

--- a/packages/zend-service-livedocx/library/Zend/Service/LiveDocx/MailMerge.php
+++ b/packages/zend-service-livedocx/library/Zend/Service/LiveDocx/MailMerge.php
@@ -393,12 +393,12 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
 
         $ret    = array();
         $result = $this->getSoapClient()->GetMetafiles(array(
-            'fromPage' => (integer) $fromPage,
-            'toPage'   => (integer) $toPage,
+            'fromPage' => (int) $fromPage,
+            'toPage'   => (int) $toPage,
         ));
 
         if (isset($result->GetMetafilesResult->string)) {
-            $pageCounter = (integer) $fromPage;
+            $pageCounter = (int) $fromPage;
             if (is_array($result->GetMetafilesResult->string)) {
                 foreach ($result->GetMetafilesResult->string as $string) {
                     $ret[$pageCounter] = base64_decode($string);
@@ -459,14 +459,14 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
         $ret = array();
 
         $result = $this->getSoapClient()->GetBitmaps(array(
-            'fromPage'   => (integer) $fromPage,
-            'toPage'     => (integer) $toPage,
-            'zoomFactor' => (integer) $zoomFactor,
+            'fromPage'   => (int) $fromPage,
+            'toPage'     => (int) $toPage,
+            'zoomFactor' => (int) $zoomFactor,
             'format'     => (string)  $format,
         ));
 
         if (isset($result->GetBitmapsResult->string)) {
-            $pageCounter = (integer) $fromPage;
+            $pageCounter = (int) $fromPage;
             if (is_array($result->GetBitmapsResult->string)) {
                 foreach ($result->GetBitmapsResult->string as $string) {
                     $ret[$pageCounter] = base64_decode($string);
@@ -495,7 +495,7 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
 
         $ret    = array();
         $result = $this->getSoapClient()->GetAllBitmaps(array(
-            'zoomFactor' => (integer) $zoomFactor,
+            'zoomFactor' => (int) $zoomFactor,
             'format'     => (string)  $format,
         ));
 
@@ -692,7 +692,7 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
             'filename' => basename($filename),
         ));
 
-        return (boolean) $result->TemplateExistsResult;
+        return (bool) $result->TemplateExistsResult;
     }
 
     /**
@@ -1054,7 +1054,7 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
             'filename' => basename($filename),
         ));
 
-        return (boolean) $result->ImageExistsResult;
+        return (bool) $result->ImageExistsResult;
     }
 
     /**
@@ -1085,9 +1085,9 @@ class Zend_Service_LiveDocx_MailMerge extends Zend_Service_LiveDocx
 
                    $ret[] = array (
                         'filename'   => $o->string[0],
-                        'fileSize'   => (integer) $o->string[2],
-                        'createTime' => (integer) $date1->get(Zend_Date::TIMESTAMP),
-                        'modifyTime' => (integer) $date2->get(Zend_Date::TIMESTAMP),
+                        'fileSize'   => (int) $o->string[2],
+                        'createTime' => (int) $date1->get(Zend_Date::TIMESTAMP),
+                        'modifyTime' => (int) $date2->get(Zend_Date::TIMESTAMP),
                    );
                }
            }

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers.php
@@ -159,8 +159,8 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
         if (!empty($metadata)) {
             $data['metadata']= $metadata;
         }
-        $data['flavorId']= (integer) $data['flavorId'];
-        $data['imageId']= (integer) $data['imageId'];
+        $data['flavorId']= (int) $data['flavorId'];
+        $data['imageId']= (int) $data['imageId'];
         if (!empty($files)) {
             foreach ($files as $serverPath => $filePath) {
                 if (!file_exists($filePath)) {
@@ -409,7 +409,7 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
             throw new Zend_Service_Rackspace_Exception('You didn\'t specified the group id to use');
         }
         $data= array (
-            'sharedIpGroupId' => (integer) $groupId,
+            'sharedIpGroupId' => (int) $groupId,
             'configureServer' => $configure
         );
         $result = $this->httpCall($this->getManagementUrl().'/servers/'.rawurlencode($id).'/ips/public/'.rawurlencode($ip),'PUT',
@@ -561,7 +561,7 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
         }
         $data= array (
             'rebuild' => array (
-                'imageId' => (integer) $imageId
+                'imageId' => (int) $imageId
             )
         );
         $result = $this->httpCall($this->getManagementUrl().'/servers/'.rawurlencode($id).'/action',
@@ -617,7 +617,7 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
         }
         $data= array (
             'resize' => array (
-                'flavorId' => (integer) $flavorId
+                'flavorId' => (int) $flavorId
             )
         );
         $result = $this->httpCall($this->getManagementUrl().'/servers/'.rawurlencode($id).'/action',
@@ -915,7 +915,7 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
         }
         $data = array(
             'image' => array (
-                'serverId' => (integer) $serverId,
+                'serverId' => (int) $serverId,
                 'name'     => $name
             )
         );
@@ -1216,7 +1216,7 @@ class Zend_Service_Rackspace_Servers extends Zend_Service_Rackspace_Abstract
         $data = array (
             'sharedIpGroup' => array (
                 'name'   => $name,
-                'server' => (integer) $serverId
+                'server' => (int) $serverId
             )
         );
         $result= $this->httpCall($this->getManagementUrl().'/shared_ip_groups',

--- a/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/SharedIpGroup.php
+++ b/packages/zend-service-rackspace/library/Zend/Service/Rackspace/Servers/SharedIpGroup.php
@@ -146,7 +146,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroup
      */
     public function createServer(array $data, $metadata=array(),$files=array()) 
     {
-        $data['sharedIpGroupId']= (integer) $this->id;
+        $data['sharedIpGroupId']= (int) $this->id;
         return $this->service->createServer($data,$metadata,$files);
     }
     /**

--- a/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
+++ b/packages/zend-session/library/Zend/Session/SaveHandler/DbTable.php
@@ -266,7 +266,7 @@ class Zend_Session_SaveHandler_DbTable
      */
     public function setOverrideLifetime($overrideLifetime)
     {
-        $this->_overrideLifetime = (boolean) $overrideLifetime;
+        $this->_overrideLifetime = (bool) $overrideLifetime;
 
         return $this;
     }

--- a/packages/zend-soap/library/Zend/Soap/Client/Common.php
+++ b/packages/zend-soap/library/Zend/Soap/Client/Common.php
@@ -62,7 +62,8 @@ class Zend_Soap_Client_Common extends SoapClient
      * @param int    $one_way
      * @return mixed
      */
-    function __doRequest($request, $location, $action, $version, $one_way = null)
+    #[\ReturnTypeWillChange]
+    function __doRequest($request, $location, $action, $version, $one_way = null, $uriParserClass = null)
     {
         if ($one_way === null) {
             return call_user_func($this->_doRequestCallback, $this, $request, $location, $action, $version);

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -141,6 +141,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  array $data
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -102,9 +102,10 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
 
     /**
      * Serialize
-     * 
+     *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function __serialize()
     {
         $data = array();

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
@@ -55,7 +55,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet extends PHPUnit_Extensions_Dat
      */
     public function addTable(Zend_Db_Table_Abstract $table, $where = null, $order = null, $count = null, $offset = null)
     {
-        $tableName = $table->info('name');
+        $tableName = $table->info('name') ?? '';
         $this->tables[$tableName] = new Zend_Test_PHPUnit_Db_DataSet_DbTable($table, $where, $order, $count, $offset);
     }
 

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
@@ -55,7 +55,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet extends PHPUnit_Extensions_Dat
      */
     public function addTable(Zend_Db_Table_Abstract $table, $where = null, $order = null, $count = null, $offset = null)
     {
-        $tableName = $table->info('name') ?? '';
+        $tableName = $table->info('name');
         $this->tables[$tableName] = new Zend_Test_PHPUnit_Db_DataSet_DbTable($table, $where, $order, $count, $offset);
     }
 

--- a/packages/zend-timesync/library/Zend/TimeSync.php
+++ b/packages/zend-timesync/library/Zend/TimeSync.php
@@ -264,8 +264,6 @@ class Zend_TimeSync implements IteratorAggregate
      */
     protected function _addServer($target, $alias)
     {
-        $alias = $alias ?? '';
-
         if ($pos = strpos($target, '://')) {
             $protocol = substr($target, 0, $pos);
             $adress = substr($target, $pos + 3);
@@ -302,6 +300,6 @@ class Zend_TimeSync implements IteratorAggregate
         }
         $timeServerObj = new $className($adress, $port);
 
-        $this->_timeservers[$alias] = $timeServerObj;
+        $this->_timeservers[$alias ?? ''] = $timeServerObj;
     }
 }

--- a/packages/zend-timesync/library/Zend/TimeSync.php
+++ b/packages/zend-timesync/library/Zend/TimeSync.php
@@ -264,6 +264,8 @@ class Zend_TimeSync implements IteratorAggregate
      */
     protected function _addServer($target, $alias)
     {
+        $alias = $alias ?? '';
+
         if ($pos = strpos($target, '://')) {
             $protocol = substr($target, 0, $pos);
             $adress = substr($target, $pos + 3);

--- a/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
+++ b/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
@@ -222,7 +222,10 @@ class Zend_TimeSync_Ntp extends Zend_TimeSync_Protocol
      */
     protected function _read()
     {
-        $flags = ord(fread($this->_socket, 1));
+        // fread returns "" on timeout/incomplete response; ord("") is deprecated in php 8.5
+        // (previously silently returned 0). Timeout is checked below but only after this read.
+        $byte  = fread($this->_socket, 1);
+        $flags = ($byte !== '' && $byte !== false) ? ord($byte) : 0;
         $info  = stream_get_meta_data($this->_socket);
 
         if ($info['timed_out'] === true) {

--- a/packages/zend-translate/library/Zend/Translate/Adapter.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter.php
@@ -329,7 +329,7 @@ abstract class Zend_Translate_Adapter {
             $this->_addTranslationData($options);
         }
 
-        if ((isset($this->_translate[$originate]) === true) and (count($this->_translate[$originate]) > 0)) {
+        if ((isset($this->_translate[(string) $originate]) === true) and (count($this->_translate[(string) $originate]) > 0)) {
             $this->setLocale($originate);
         }
 

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
@@ -91,7 +91,9 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
@@ -86,7 +86,9 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -68,7 +68,7 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
         }
 
         if (isset($options['useId'])) {
-            $this->_useId = (boolean) $options['useId'];
+            $this->_useId = (bool) $options['useId'];
         }
 
         $encoding = $this->_findEncoding($filename);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -91,7 +91,9 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -196,8 +196,10 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
                         $this->_tu = $this->_content;
                     }
 
-                    if (!empty($this->_content) or (!isset($this->_data[$this->_tuv][$this->_tu]))) {
-                        $this->_data[$this->_tuv][$this->_tu] = $this->_content;
+                    $tuv = $this->_tuv ?? '';
+                    $tu = $this->_tu ?? '';
+                    if (!empty($this->_content) || !isset($this->_data[$tuv][$tu])) {
+                        $this->_data[$tuv][$tu] = $this->_content;
                     }
                     break;
                 default:

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
@@ -98,7 +98,9 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
@@ -86,7 +86,9 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-uri/library/Zend/Uri/Http.php
+++ b/packages/zend-uri/library/Zend/Uri/Http.php
@@ -555,7 +555,7 @@ class Zend_Uri_Http extends Zend_Uri
             throw new Zend_Uri_Exception('Internal error: path validation failed');
         }
 
-        return (boolean) $status;
+        return (bool) $status;
     }
 
     /**
@@ -741,7 +741,7 @@ class Zend_Uri_Http extends Zend_Uri
             throw new Zend_Uri_Exception('Internal error: fragment validation failed');
         }
 
-        return (boolean) $status;
+        return (bool) $status;
     }
 
     /**

--- a/packages/zend-validate/library/Zend/Validate.php
+++ b/packages/zend-validate/library/Zend/Validate.php
@@ -75,7 +75,7 @@ class Zend_Validate implements Zend_Validate_Interface
     {
         $this->_validators[] = array(
             'instance' => $validator,
-            'breakChainOnFailure' => (boolean) $breakChainOnFailure
+            'breakChainOnFailure' => (bool) $breakChainOnFailure
             );
         return $this;
     }

--- a/packages/zend-validate/library/Zend/Validate/Alnum.php
+++ b/packages/zend-validate/library/Zend/Validate/Alnum.php
@@ -81,7 +81,7 @@ class Zend_Validate_Alnum extends Zend_Validate_Abstract
             }
         }
 
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
     }
 
     /**
@@ -102,7 +102,7 @@ class Zend_Validate_Alnum extends Zend_Validate_Abstract
      */
     public function setAllowWhiteSpace($allowWhiteSpace)
     {
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/Alpha.php
+++ b/packages/zend-validate/library/Zend/Validate/Alpha.php
@@ -81,7 +81,7 @@ class Zend_Validate_Alpha extends Zend_Validate_Abstract
             }
         }
 
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
     }
 
     /**
@@ -102,7 +102,7 @@ class Zend_Validate_Alpha extends Zend_Validate_Abstract
      */
     public function setAllowWhiteSpace($allowWhiteSpace)
     {
-        $this->allowWhiteSpace = (boolean) $allowWhiteSpace;
+        $this->allowWhiteSpace = (bool) $allowWhiteSpace;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/Barcode/AdapterAbstract.php
+++ b/packages/zend-validate/library/Zend/Validate/Barcode/AdapterAbstract.php
@@ -193,7 +193,7 @@ abstract class Zend_Validate_Barcode_AdapterAbstract
      */
     public function setCheck($check)
     {
-        $this->_hasChecksum = (boolean) $check;
+        $this->_hasChecksum = (bool) $check;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/EmailAddress.php
+++ b/packages/zend-validate/library/Zend/Validate/EmailAddress.php
@@ -337,7 +337,7 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
      */
     public function setDomainCheck($domain = true)
     {
-        $this->_options['domain'] = (boolean) $domain;
+        $this->_options['domain'] = (bool) $domain;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/File/Count.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Count.php
@@ -156,7 +156,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception ('Invalid options to validator provided');
         }
 
-        $min = (integer) $min;
+        $min = (int) $min;
         if (($this->_max !== null) && ($min > $this->_max)) {
             // require_once 'Zend/Validate/Exception.php';
             throw new Zend_Validate_Exception("The minimum must be less than or equal to the maximum file count, but $min >"
@@ -195,7 +195,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception ('Invalid options to validator provided');
         }
 
-        $max = (integer) $max;
+        $max = (int) $max;
         if (($this->_min !== null) && ($max < $this->_min)) {
             // require_once 'Zend/Validate/Exception.php';
             throw new Zend_Validate_Exception("The maximum must be greater than or equal to the minimum file count, but "

--- a/packages/zend-validate/library/Zend/Validate/File/Extension.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Extension.php
@@ -110,7 +110,7 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      */
     public function setCase($case)
     {
-        $this->_case = (boolean) $case;
+        $this->_case = (bool) $case;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/File/MimeType.php
+++ b/packages/zend-validate/library/Zend/Validate/File/MimeType.php
@@ -215,7 +215,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      */
     public function setTryCommonMagicFilesFlag($flag = true)
     {
-        $this->_tryCommonMagicFiles = (boolean) $flag;
+        $this->_tryCommonMagicFiles = (bool) $flag;
 
         return $this;
     }
@@ -250,7 +250,7 @@ class Zend_Validate_File_MimeType extends Zend_Validate_Abstract
      */
     public function enableHeaderCheck($headerCheck = true)
     {
-        $this->_headerCheck = (boolean) $headerCheck;
+        $this->_headerCheck = (bool) $headerCheck;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/File/Size.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Size.php
@@ -186,7 +186,7 @@ class Zend_Validate_File_Size extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception ('Invalid options to validator provided');
         }
 
-        $min = (integer) $this->_fromByteString($min);
+        $min = (int) $this->_fromByteString($min);
         $max = $this->getMax(true);
         if (($max !== null) && ($min > $max)) {
             // require_once 'Zend/Validate/Exception.php';
@@ -228,7 +228,7 @@ class Zend_Validate_File_Size extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception ('Invalid options to validator provided');
         }
 
-        $max = (integer) $this->_fromByteString($max);
+        $max = (int) $this->_fromByteString($max);
         $min = $this->getMin(true);
         if (($min !== null) && ($max < $min)) {
             // require_once 'Zend/Validate/Exception.php';
@@ -344,7 +344,7 @@ class Zend_Validate_File_Size extends Zend_Validate_Abstract
     protected function _fromByteString($size)
     {
         if (is_numeric($size)) {
-            return (integer) $size;
+            return (int) $size;
         }
 
         $type  = trim(substr($size, -2, 1));

--- a/packages/zend-validate/library/Zend/Validate/File/Upload.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Upload.php
@@ -162,6 +162,7 @@ class Zend_Validate_File_Upload extends Zend_Validate_Abstract
     public function isValid($value, $file = null)
     {
         $this->_messages = array();
+        $value = $value ?? '';
         if (array_key_exists($value, $this->_files)) {
             $files[$value] = $this->_files[$value];
         } else {

--- a/packages/zend-validate/library/Zend/Validate/Identical.php
+++ b/packages/zend-validate/library/Zend/Validate/Identical.php
@@ -124,7 +124,7 @@ class Zend_Validate_Identical extends Zend_Validate_Abstract
      */
     public function setStrict($strict)
     {
-        $this->_strict = (boolean) $strict;
+        $this->_strict = (bool) $strict;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/InArray.php
+++ b/packages/zend-validate/library/Zend/Validate/InArray.php
@@ -143,7 +143,7 @@ class Zend_Validate_InArray extends Zend_Validate_Abstract
      */
     public function setStrict($strict)
     {
-        $this->_strict = (boolean) $strict;
+        $this->_strict = (bool) $strict;
         return $this;
     }
 
@@ -165,7 +165,7 @@ class Zend_Validate_InArray extends Zend_Validate_Abstract
      */
     public function setRecursive($recursive)
     {
-        $this->_recursive = (boolean) $recursive;
+        $this->_recursive = (bool) $recursive;
         return $this;
     }
 

--- a/packages/zend-validate/library/Zend/Validate/Ip.php
+++ b/packages/zend-validate/library/Zend/Validate/Ip.php
@@ -96,11 +96,11 @@ class Zend_Validate_Ip extends Zend_Validate_Abstract
     public function setOptions($options)
     {
         if (array_key_exists('allowipv6', $options)) {
-            $this->_options['allowipv6'] = (boolean) $options['allowipv6'];
+            $this->_options['allowipv6'] = (bool) $options['allowipv6'];
         }
 
         if (array_key_exists('allowipv4', $options)) {
-            $this->_options['allowipv4'] = (boolean) $options['allowipv4'];
+            $this->_options['allowipv4'] = (bool) $options['allowipv4'];
         }
 
         if (!$this->_options['allowipv4'] && !$this->_options['allowipv6']) {

--- a/packages/zend-validate/library/Zend/Validate/StringLength.php
+++ b/packages/zend-validate/library/Zend/Validate/StringLength.php
@@ -140,7 +140,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception("The minimum must be less than or equal to the maximum length, but $min >"
                                             . " $this->_max");
         }
-        $this->_min = max(0, (integer) $min);
+        $this->_min = max(0, (int) $min);
         return $this;
     }
 
@@ -173,7 +173,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             throw new Zend_Validate_Exception("The maximum must be greater than or equal to the minimum length, but "
                                             . "$max < $this->_min");
         } else {
-            $this->_max = (integer) $max;
+            $this->_max = (int) $max;
         }
 
         return $this;

--- a/packages/zend-wildfire/library/Zend/Wildfire/Channel/HttpHeaders.php
+++ b/packages/zend-wildfire/library/Zend/Wildfire/Channel/HttpHeaders.php
@@ -165,7 +165,7 @@ class Zend_Wildfire_Channel_HttpHeaders extends Zend_Controller_Plugin_Abstract 
     protected function _initProtocol($uri)
     {
         switch ($uri) {
-            case Zend_Wildfire_Protocol_JsonStream::PROTOCOL_URI;
+            case Zend_Wildfire_Protocol_JsonStream::PROTOCOL_URI:
                 return new Zend_Wildfire_Protocol_JsonStream();
         }
         // require_once 'Zend/Wildfire/Exception.php';

--- a/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -722,7 +722,9 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 
                     } else {
                         if (method_exists($property,'setAccessible')) {
-                            $property->setAccessible(true);
+                            if (PHP_VERSION_ID < 80100) {
+                                $property->setAccessible(true);
+                            }
                             $return[$name] = $this->_encodeObject($property->getValue($object), $objectDepth + 1, 1);
                         } else
                         if ($property->isPublic()) {

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -5045,16 +5045,30 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
 
     public function testTimesync()
     {
-        try {
-            $server = new Zend_TimeSync('ntp://pool.ntp.org', 'alias');
-            $date = $server->getDate();
-            $info = $server->getInfo();
+        // pool.ntp.org is unreachable from GitHub Actions runners,
+        // try multiple servers to avoid marking test incomplete unnecessarily
+        $servers = array(
+            'ntp://time.windows.com',
+            'ntp://pool.ntp.org',
+        );
 
-            // verify the NTP offset was correctly passed through to Zend_Date
-            $this->assertEquals((int) round($info['offset']), $date->getTimeSyncOffset());
-        } catch (Zend_TimeSync_Exception $e) {
-            $this->markTestIncomplete('NTP timeserver not available.');
+        $lastException = null;
+        foreach ($servers as $serverUri) {
+            try {
+                $server = new Zend_TimeSync($serverUri, 'alias');
+                $server->setOptions(array('timeout' => 5));
+                $date = $server->getDate();
+                $info = $server->getInfo();
+
+                // verify the NTP offset was correctly passed through to Zend_Date
+                $this->assertEquals((int) round($info['offset']), $date->getTimeSyncOffset());
+                return;
+            } catch (Zend_TimeSync_Exception $e) {
+                $lastException = $e;
+            }
         }
+
+        $this->markTestIncomplete('NTP timeservers not available: ' . $lastException->getMessage());
     }
 
     public function testUsePhpDateFormat()

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -116,13 +116,13 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
 
         $db = Zend_Db::factory($this->getDriver(), $params);
 
-        $this->assertTrue((boolean) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
+        $this->assertTrue((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
 
         $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false);
 
         $db = Zend_Db::factory($this->getDriver(), $params);
 
-        $this->assertFalse((boolean) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
+        $this->assertFalse((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
     }
 
     public function testAdapterInsertSequence()

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -111,18 +111,21 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
     public function testAdapterDriverOptions()
     {
         $params = $this->_util->getParams();
+        $attr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
 
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true);
-
-        $db = Zend_Db::factory($this->getDriver(), $params);
-
-        $this->assertTrue((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
-
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false);
+        $params['driver_options'] = array($attr => true);
 
         $db = Zend_Db::factory($this->getDriver(), $params);
 
-        $this->assertFalse((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
+        $this->assertTrue((bool) $db->getConnection()->getAttribute($attr));
+
+        $params['driver_options'] = array($attr => false);
+
+        $db = Zend_Db::factory($this->getDriver(), $params);
+
+        $this->assertFalse((bool) $db->getConnection()->getAttribute($attr));
     }
 
     public function testAdapterInsertSequence()
@@ -283,7 +286,10 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
     public function testZF2101()
     {
         $params = $this->_util->getParams();
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true);
+        $attr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+        $params['driver_options'] = array($attr => true);
         $db = Zend_Db::factory($this->getDriver(), $params);
 
         // Set default bound value

--- a/tests/Zend/Db/Adapter/Static.php
+++ b/tests/Zend/Db/Adapter/Static.php
@@ -64,7 +64,7 @@ class Zend_Db_Adapter_Static extends Zend_Db_Adapter_Abstract
      */
     public function setOnQuerySleep($seconds = 0)
     {
-        $this->_onQuerySleep = (integer) $seconds;
+        $this->_onQuerySleep = (int) $seconds;
 
         return $this;
     }

--- a/tests/Zend/Db/TestUtil/Pdo/Mysql.php
+++ b/tests/Zend/Db/TestUtil/Pdo/Mysql.php
@@ -56,8 +56,11 @@ class Zend_Db_TestUtil_Pdo_Mysql extends Zend_Db_TestUtil_Mysqli
             $constants['driver_options'] = array();
         }
 
-        if (!isset($constants['driver_options'][PDO::MYSQL_ATTR_USE_BUFFERED_QUERY])) {
-            $constants['driver_options'][PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = true;
+        $bufferedQueryAttr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+        if (!isset($constants['driver_options'][$bufferedQueryAttr])) {
+            $constants['driver_options'][$bufferedQueryAttr] = true;
         }
 
         return $constants;

--- a/tests/Zend/Form/Decorator/FileTest.php
+++ b/tests/Zend/Form/Decorator/FileTest.php
@@ -205,7 +205,7 @@ class Zend_Form_Decorator_FileTest extends PHPUnit_Framework_TestCase
     {
         if (!is_numeric($setting)) {
             $type = strtoupper(substr($setting, -1));
-            $setting = (integer) substr($setting, 0, -1);
+            $setting = (int) substr($setting, 0, -1);
 
             switch ($type) {
                 case 'M' :
@@ -221,7 +221,7 @@ class Zend_Form_Decorator_FileTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        return (integer) $setting;
+        return (int) $setting;
     }
 }
 

--- a/tests/Zend/Form/Element/FileTest.php
+++ b/tests/Zend/Form/Element/FileTest.php
@@ -455,7 +455,7 @@ class Zend_Form_Element_FileTest extends PHPUnit_Framework_TestCase
     {
         if (!is_numeric($setting)) {
             $type = strtoupper(substr($setting, -1));
-            $setting = (integer) substr($setting, 0, -1);
+            $setting = (int) substr($setting, 0, -1);
 
             switch ($type) {
                 case 'M' :
@@ -471,7 +471,7 @@ class Zend_Form_Element_FileTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        return (integer) $setting;
+        return (int) $setting;
     }
 
     /**

--- a/tests/Zend/Ldap/SortTest.php
+++ b/tests/Zend/Ldap/SortTest.php
@@ -59,7 +59,9 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
         $iterator->setSortFunction($sortFunction);
         $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
@@ -83,11 +85,15 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
 
         $reflectionProperty = $reflectionObject->getProperty('_entries');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $iterator->sort('l');
 
@@ -128,11 +134,15 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
 
         $reflectionProperty = $reflectionObject->getProperty('_entries');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $iterator->sort('l');
 

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -752,8 +752,8 @@ class Zend_Locale_FormatTest extends PHPUnit_Framework_TestCase
      */
     public function testToNumberFormat2()
     {
-        $this->assertEquals((double) 1.7, (double) Zend_Locale_Format::toNumber(1.7, array('locale' => 'en')));
-        $this->assertEquals((double) 2.3, (double) Zend_Locale_Format::toNumber(2.3, array('locale' => 'en')));
+        $this->assertEquals((float) 1.7, (float) Zend_Locale_Format::toNumber(1.7, array('locale' => 'en')));
+        $this->assertEquals((float) 2.3, (float) Zend_Locale_Format::toNumber(2.3, array('locale' => 'en')));
     }
 
     /**

--- a/tests/Zend/LocaleTest.php
+++ b/tests/Zend/LocaleTest.php
@@ -952,7 +952,9 @@ class Zend_LocaleTest extends PHPUnit_Framework_TestCase
 
         $class    = new ReflectionClass('Zend_Locale');
         $property = $class->getProperty('_localeData');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $locale     = new Zend_Locale();
         $localeData = $property->getValue($locale);

--- a/tests/Zend/Log/Writer/StreamTest.php
+++ b/tests/Zend/Log/Writer/StreamTest.php
@@ -56,7 +56,9 @@ class Zend_Log_Writer_StreamTest extends PHPUnit_Framework_TestCase
             $this->assertTrue($e instanceof Zend_Log_Exception);
             $this->assertRegExp('/not a stream/i', $e->getMessage());
         }
-        xml_parser_free($resource);
+        if (PHP_VERSION_ID < 80000) {
+            xml_parser_free($resource);
+        }
     }
 
     public function testConstructorWithValidStream()

--- a/tests/Zend/Memory/AccessControllerTest.php
+++ b/tests/Zend/Memory/AccessControllerTest.php
@@ -146,13 +146,13 @@ class Zend_Memory_Container_AccessControllerTest extends PHPUnit_Framework_TestC
         $memoryManager  = $this->_getMemoryManager();
         $memObject      = $memoryManager->create('012345678');
 
-        $this->assertFalse((boolean)$memObject->isLocked());
+        $this->assertFalse((bool)$memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((boolean)$memObject->isLocked());
+        $this->assertTrue((bool)$memObject->isLocked());
 
         $memObject->unlock();
-        $this->assertFalse((boolean)$memObject->isLocked());
+        $this->assertFalse((bool)$memObject->isLocked());
     }
 }
 

--- a/tests/Zend/Memory/LockedTest.php
+++ b/tests/Zend/Memory/LockedTest.php
@@ -77,14 +77,14 @@ class Zend_Memory_Container_LockedTest extends PHPUnit_Framework_TestCase
         $memObject = new Zend_Memory_Container_Locked('0123456789');
 
         // It's always locked
-        $this->assertTrue((boolean)$memObject->isLocked());
+        $this->assertTrue((bool)$memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((boolean)$memObject->isLocked());
+        $this->assertTrue((bool)$memObject->isLocked());
 
         $memObject->unlock();
         // It's always locked
-        $this->assertTrue((boolean)$memObject->isLocked());
+        $this->assertTrue((bool)$memObject->isLocked());
     }
 
     /**

--- a/tests/Zend/Memory/MovableTest.php
+++ b/tests/Zend/Memory/MovableTest.php
@@ -122,13 +122,13 @@ class Zend_Memory_Container_MovableTest extends PHPUnit_Framework_TestCase
         $memoryManager = new Zend_Memory_Manager_Dummy();
         $memObject = new Zend_Memory_Container_Movable($memoryManager, 10, '0123456789');
 
-        $this->assertFalse((boolean)$memObject->isLocked());
+        $this->assertFalse((bool)$memObject->isLocked());
 
         $memObject->lock();
-        $this->assertTrue((boolean)$memObject->isLocked());
+        $this->assertTrue((bool)$memObject->isLocked());
 
         $memObject->unlock();
-        $this->assertFalse((boolean)$memObject->isLocked());
+        $this->assertFalse((bool)$memObject->isLocked());
     }
 
     /**

--- a/tests/Zend/Pdf/Element/BooleanTest.php
+++ b/tests/Zend/Pdf/Element/BooleanTest.php
@@ -54,7 +54,7 @@ class Zend_Pdf_Element_BooleanTest extends PHPUnit_Framework_TestCase
 
     public function testGetType()
     {
-        $boolObj = new Zend_Pdf_Element_Boolean((boolean) 100);
+        $boolObj = new Zend_Pdf_Element_Boolean((bool) 100);
         $this->assertEquals($boolObj->getType(), Zend_Pdf_Element::TYPE_BOOL);
     }
 

--- a/tests/Zend/Search/Lucene/Index/SegmentInfoTest.php
+++ b/tests/Zend/Search/Lucene/Index/SegmentInfoTest.php
@@ -88,9 +88,9 @@ class Zend_Search_Lucene_Index_SegmentInfoTest extends PHPUnit_Framework_TestCas
         $fieldInfo = $segmentInfo->getField(2);
 
         $this->assertEquals($fieldInfo->name, 'contents');
-        $this->assertTrue((boolean)$fieldInfo->isIndexed);
+        $this->assertTrue((bool)$fieldInfo->isIndexed);
         $this->assertEquals($fieldInfo->number, 2);
-        $this->assertFalse((boolean)$fieldInfo->storeTermVector);
+        $this->assertFalse((bool)$fieldInfo->storeTermVector);
     }
 
     public function testGetFields()
@@ -110,19 +110,19 @@ class Zend_Search_Lucene_Index_SegmentInfoTest extends PHPUnit_Framework_TestCas
         $fieldInfos = $segmentInfo->getFieldInfos();
 
         $this->assertEquals($fieldInfos[0]->name, 'path');
-        $this->assertTrue((boolean)$fieldInfos[0]->isIndexed);
+        $this->assertTrue((bool)$fieldInfos[0]->isIndexed);
         $this->assertEquals($fieldInfos[0]->number, 0);
-        $this->assertFalse((boolean)$fieldInfos[0]->storeTermVector);
+        $this->assertFalse((bool)$fieldInfos[0]->storeTermVector);
 
         $this->assertEquals($fieldInfos[1]->name, 'modified');
-        $this->assertTrue((boolean)$fieldInfos[1]->isIndexed);
+        $this->assertTrue((bool)$fieldInfos[1]->isIndexed);
         $this->assertEquals($fieldInfos[1]->number, 1);
-        $this->assertFalse((boolean)$fieldInfos[1]->storeTermVector);
+        $this->assertFalse((bool)$fieldInfos[1]->storeTermVector);
 
         $this->assertEquals($fieldInfos[2]->name, 'contents');
-        $this->assertTrue((boolean)$fieldInfos[2]->isIndexed);
+        $this->assertTrue((bool)$fieldInfos[2]->isIndexed);
         $this->assertEquals($fieldInfos[2]->number, 2);
-        $this->assertFalse((boolean)$fieldInfos[2]->storeTermVector);
+        $this->assertFalse((bool)$fieldInfos[2]->storeTermVector);
     }
 
     public function testCount()

--- a/tests/Zend/Service/Amazon/S3/OnlineTest.php
+++ b/tests/Zend/Service/Amazon/S3/OnlineTest.php
@@ -239,7 +239,7 @@ class Zend_Service_Amazon_S3_OnlineTest extends PHPUnit_Framework_TestCase
         
         $this->assertFalse($this->_amazon->isBucketAvailable($this->_bucket));
         $this->assertFalse($this->_amazon->isObjectAvailable($this->_bucket."/zftest"));
-        $this->assertFalse((boolean)$this->_amazon->getObjectsByBucket($this->_bucket));
+        $this->assertFalse((bool)$this->_amazon->getObjectsByBucket($this->_bucket));
         $list = $this->_amazon->getBuckets();
         $this->assertNotContains($this->_bucket, $list);
     }

--- a/tests/Zend/Session/SessionHelper.php
+++ b/tests/Zend/Session/SessionHelper.php
@@ -29,7 +29,9 @@ class Zend_Session_SessionHelper
                 ) as $prop => $value) {
             list($class, $property) = explode('::', $prop);
             $reflection = new ReflectionProperty($class, $property);
-            $reflection->setAccessible(true);
+            if (PHP_VERSION_ID < 80100) {
+                $reflection->setAccessible(true);
+            }
             $reflection->setValue(null, $value);
         }
     }

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -1040,8 +1040,8 @@ class Zend_Soap_Server_TestLocalSoapClient extends SoapClient
         parent::__construct($wsdl, $options);
     }
 
-    #[ReturnTypeWillChange]
-    function __doRequest($request, $location, $action, $version, $one_way = 0)
+    #[\ReturnTypeWillChange]
+    function __doRequest($request, $location, $action, $version, $one_way = 0, $uriParserClass = null)
     {
         ob_start();
         $this->server->handle($request);

--- a/tests/Zend/Soap/TestAsset/commontypes.php
+++ b/tests/Zend/Soap/TestAsset/commontypes.php
@@ -621,8 +621,8 @@ class Zend_Soap_TestAsset_TestLocalSoapClient extends SoapClient
         parent::__construct($wsdl, $options);
     }
 
-    #[ReturnTypeWillChange]
-    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    #[\ReturnTypeWillChange]
+    public function __doRequest($request, $location, $action, $version, $one_way = 0, $uriParserClass = null)
     {
         ob_start();
         $this->server->handle($request);

--- a/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
@@ -91,6 +91,7 @@ class Zend_Test_PHPUnit_Db_TestCaseTest extends Zend_Test_PHPUnit_DatabaseTestCa
     public function testCreateDbTableDataSetConvenienceMethodReturnType()
     {
         $tableMock = $this->getMock('Zend_Db_Table', array(), array(), "", false);
+        $tableMock->expects($this->any())->method('info')->will($this->returnValue('test_table'));
         $tableDataSet = $this->createDbTableDataSet(array($tableMock));
         $this->assertTrue($tableDataSet instanceof Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet);
     }


### PR DESCRIPTION
PHP 8.5 compatibility fixes. All changes are backward-compatible with PHP 7.1+ (why 7.1+? see #218).

### non-canonical casts and syntax
- replace `(boolean)` → `(bool)`, `(integer)` → `(int)`, `(double)` → `(float)` across 51 files
- [zend-soap] fix `SoapClient::__doRequest()` signature for new `$uriParserClass` parameter
- [zend-translate] cast `$originate` to string when used as array key

### #226 - guard deprecated functions, methods, and syntax
- guard no-op `xml_parser_free()` and `imagedestroy()` with `PHP_VERSION_ID < 80000`
- guard deprecated `ReflectionProperty::setAccessible()` on php 8.1+
- [zend-pdf] replace `SplObjectStorage::contains()` → `offsetExists()`, `attach()` → `offsetSet()`
- [zend-stdlib] add `#[ReturnTypeWillChange]` to `SplPriorityQueue::__serialize()`
- [zend-db] use `Pdo\Mysql::ATTR_USE_BUFFERED_QUERY` on php 8.5+ (test-only)
- replace semicolons with colons in `case` statements across 38 files

### #227 - null as array offset / `array_key_exists()` key
- fixes across 10 packages: zend-form, zend-rest, zend-timesync, zend-http, zend-navigation, zend-translate, zend-file-transfer, zend-filter, zend-db, zend-validate
- [zend-test] fix mock in `TestCaseTest` to provide table name

### #228 - remaining deprecations
- [zend-codegenerator] replace `RecursiveArrayIterator` with simple recursive walk in `DefaultValue::generate()`
- [zend-stdlib] add `#[ReturnTypeWillChange]` to `SplPriorityQueue::__unserialize()`
- [zend-timesync] guard `ord()` against empty string from `fread()` in `Ntp::_read()`
- guard `xml_parser_free()` in `Zend_Log_Writer_StreamTest`
- try multiple NTP servers in `testTimesync` - `pool.ntp.org` unreachable from GitHub Actions