### PR TITLE
php 8.5: guard no-op functions xml_parser_free() and imagedestroy()

### DIFF
--- a/packages/zend-amf/library/Zend/Amf/Parse/Amf3/Serializer.php
+++ b/packages/zend-amf/library/Zend/Amf/Parse/Amf3/Serializer.php
@@ -115,7 +115,7 @@ class Zend_Amf_Parse_Amf3_Serializer extends Zend_Amf_Parse_Serializer
                 case Zend_Amf_Constants::AMF3_BYTEARRAY:
                     $this->writeByteArray($data);
                     break;
-                case Zend_Amf_Constants::AMF3_XMLSTRING;
+                case Zend_Amf_Constants::AMF3_XMLSTRING:
                     $this->writeXml($data);
                     break;
                 default:

--- a/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
+++ b/packages/zend-barcode/library/Zend/Barcode/Renderer/Image.php
@@ -346,7 +346,9 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
         header("Content-Type: image/" . $this->_imageType);
         $functionName = 'image' . $this->_imageType;
         call_user_func($functionName, $this->_resource);
-        @imagedestroy($this->_resource);
+        if (PHP_VERSION_ID < 80000) {
+            @imagedestroy($this->_resource);
+        }
     }
 
     /**

--- a/packages/zend-captcha/library/Zend/Captcha/Image.php
+++ b/packages/zend-captcha/library/Zend/Captcha/Image.php
@@ -581,8 +581,10 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
         }
 
         imagepng($img2, $img_file);
-        imagedestroy($img);
-        imagedestroy($img2);
+        if (PHP_VERSION_ID < 80000) {
+            imagedestroy($img);
+            imagedestroy($img2);
+        }
     }
 
     /**

--- a/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Adapter/Mysqli/Exception.php
@@ -40,7 +40,9 @@ class Zend_Db_Adapter_Mysqli_Exception extends Zend_Db_Adapter_Exception
     public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
         $sqlstate = $p->getValue($exception);
 
         return new self(

--- a/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Mysqli/Exception.php
@@ -37,7 +37,9 @@ class Zend_Db_Statement_Mysqli_Exception extends Zend_Db_Statement_Exception
     public static function fromMysqliException(mysqli_sql_exception $exception)
     {
         $p = new ReflectionProperty('mysqli_sql_exception', 'sqlstate');
-        $p->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $p->setAccessible(true);
+        }
         $sqlstate = $p->getValue($exception);
 
         return new self(

--- a/packages/zend-gdata/library/Zend/Gdata/Analytics/AccountEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Analytics/AccountEntry.php
@@ -79,17 +79,17 @@ class Zend_Gdata_Analytics_AccountEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName){
-            case $this->lookupNamespace('analytics') . ':' . 'property';
+            case $this->lookupNamespace('analytics') . ':' . 'property':
                 $property = new Zend_Gdata_Analytics_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->{$property->getName()} = $property;
                 break;
-            case $this->lookupNamespace('analytics') . ':' . 'tableId';
+            case $this->lookupNamespace('analytics') . ':' . 'tableId':
                 $tableId = new Zend_Gdata_Analytics_Extension_TableId();
                 $tableId->transferFromDOM($child);
                 $this->_tableId = $tableId;
                 break;
-            case $this->lookupNamespace('ga') . ':' . 'goal';
+            case $this->lookupNamespace('ga') . ':' . 'goal':
                 $goal = new Zend_Gdata_Analytics_Extension_Goal();
                 $goal->transferFromDOM($child);
                 $this->_goal = $goal;

--- a/packages/zend-gdata/library/Zend/Gdata/Analytics/DataEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Analytics/DataEntry.php
@@ -58,12 +58,12 @@ class Zend_Gdata_Analytics_DataEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('analytics') . ':' . 'dimension';
+            case $this->lookupNamespace('analytics') . ':' . 'dimension':
                 $dimension = new Zend_Gdata_Analytics_Extension_Dimension();
                 $dimension->transferFromDOM($child);
                 $this->_dimensions[] = $dimension;
                 break;
-            case $this->lookupNamespace('analytics') . ':' . 'metric';
+            case $this->lookupNamespace('analytics') . ':' . 'metric':
                 $metric = new Zend_Gdata_Analytics_Extension_Metric();
                 $metric->transferFromDOM($child);
                 $this->_metrics[] = $metric;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/EventEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/EventEntry.php
@@ -94,22 +94,22 @@ class Zend_Gdata_Calendar_EventEntry extends Zend_Gdata_Kind_EventEntry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gCal') . ':' . 'sendEventNotifications';
+            case $this->lookupNamespace('gCal') . ':' . 'sendEventNotifications':
                 $sendEventNotifications = new Zend_Gdata_Calendar_Extension_SendEventNotifications();
                 $sendEventNotifications->transferFromDOM($child);
                 $this->_sendEventNotifications = $sendEventNotifications;
                 break;
-            case $this->lookupNamespace('gCal') . ':' . 'timezone';
+            case $this->lookupNamespace('gCal') . ':' . 'timezone':
                 $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
                 $timezone->transferFromDOM($child);
                 $this->_timezone = $timezone;
                 break;
-            case $this->lookupNamespace('atom') . ':' . 'link';
+            case $this->lookupNamespace('atom') . ':' . 'link':
                 $link = new Zend_Gdata_Calendar_Extension_Link();
                 $link->transferFromDOM($child);
                 $this->_link[] = $link;
                 break;
-            case $this->lookupNamespace('gCal') . ':' . 'quickadd';
+            case $this->lookupNamespace('gCal') . ':' . 'quickadd':
                 $quickadd = new Zend_Gdata_Calendar_Extension_QuickAdd();
                 $quickadd->transferFromDOM($child);
                 $this->_quickadd = $quickadd;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/EventFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/EventFeed.php
@@ -80,7 +80,7 @@ class Zend_Gdata_Calendar_EventFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gCal') . ':' . 'timezone';
+            case $this->lookupNamespace('gCal') . ':' . 'timezone':
                 $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
                 $timezone->transferFromDOM($child);
                 $this->_timezone = $timezone;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/ListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/ListEntry.php
@@ -118,32 +118,32 @@ class Zend_Gdata_Calendar_ListEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gCal') . ':' . 'accesslevel';
+        case $this->lookupNamespace('gCal') . ':' . 'accesslevel':
             $accessLevel = new Zend_Gdata_Calendar_Extension_AccessLevel();
             $accessLevel->transferFromDOM($child);
             $this->_accessLevel = $accessLevel;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'color';
+        case $this->lookupNamespace('gCal') . ':' . 'color':
             $color = new Zend_Gdata_Calendar_Extension_Color();
             $color->transferFromDOM($child);
             $this->_color = $color;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'hidden';
+        case $this->lookupNamespace('gCal') . ':' . 'hidden':
             $hidden = new Zend_Gdata_Calendar_Extension_Hidden();
             $hidden->transferFromDOM($child);
             $this->_hidden = $hidden;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'selected';
+        case $this->lookupNamespace('gCal') . ':' . 'selected':
             $selected = new Zend_Gdata_Calendar_Extension_Selected();
             $selected->transferFromDOM($child);
             $this->_selected = $selected;
             break;
-        case $this->lookupNamespace('gCal') . ':' . 'timezone';
+        case $this->lookupNamespace('gCal') . ':' . 'timezone':
             $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
             $timezone->transferFromDOM($child);
             $this->_timezone = $timezone;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'where';
+        case $this->lookupNamespace('gd') . ':' . 'where':
             $where = new Zend_Gdata_Extension_Where();
             $where->transferFromDOM($child);
             $this->_where[] = $where;

--- a/packages/zend-gdata/library/Zend/Gdata/Calendar/ListFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Calendar/ListFeed.php
@@ -77,7 +77,7 @@ class Zend_Gdata_Calendar_ListFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gCal') . ':' . 'timezone';
+        case $this->lookupNamespace('gCal') . ':' . 'timezone':
             $timezone = new Zend_Gdata_Calendar_Extension_Timezone();
             $timezone->transferFromDOM($child);
             $this->_timezone = $timezone;

--- a/packages/zend-gdata/library/Zend/Gdata/Exif/Extension/Tags.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Exif/Extension/Tags.php
@@ -264,52 +264,52 @@ class Zend_Gdata_Exif_Extension_Tags extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('exif') . ':' . 'distance';
+            case $this->lookupNamespace('exif') . ':' . 'distance':
                 $distance = new Zend_Gdata_Exif_Extension_Distance();
                 $distance->transferFromDOM($child);
                 $this->_distance = $distance;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'exposure';
+            case $this->lookupNamespace('exif') . ':' . 'exposure':
                 $exposure = new Zend_Gdata_Exif_Extension_Exposure();
                 $exposure->transferFromDOM($child);
                 $this->_exposure = $exposure;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'flash';
+            case $this->lookupNamespace('exif') . ':' . 'flash':
                 $flash = new Zend_Gdata_Exif_Extension_Flash();
                 $flash->transferFromDOM($child);
                 $this->_flash = $flash;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'focallength';
+            case $this->lookupNamespace('exif') . ':' . 'focallength':
                 $focalLength = new Zend_Gdata_Exif_Extension_FocalLength();
                 $focalLength->transferFromDOM($child);
                 $this->_focalLength = $focalLength;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'fstop';
+            case $this->lookupNamespace('exif') . ':' . 'fstop':
                 $fStop = new Zend_Gdata_Exif_Extension_FStop();
                 $fStop->transferFromDOM($child);
                 $this->_fStop = $fStop;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'imageUniqueID';
+            case $this->lookupNamespace('exif') . ':' . 'imageUniqueID':
                 $imageUniqueId = new Zend_Gdata_Exif_Extension_ImageUniqueId();
                 $imageUniqueId->transferFromDOM($child);
                 $this->_imageUniqueId = $imageUniqueId;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'iso';
+            case $this->lookupNamespace('exif') . ':' . 'iso':
                 $iso = new Zend_Gdata_Exif_Extension_Iso();
                 $iso->transferFromDOM($child);
                 $this->_iso = $iso;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'make';
+            case $this->lookupNamespace('exif') . ':' . 'make':
                 $make = new Zend_Gdata_Exif_Extension_Make();
                 $make->transferFromDOM($child);
                 $this->_make = $make;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'model';
+            case $this->lookupNamespace('exif') . ':' . 'model':
                 $model = new Zend_Gdata_Exif_Extension_Model();
                 $model->transferFromDOM($child);
                 $this->_model = $model;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'time';
+            case $this->lookupNamespace('exif') . ':' . 'time':
                 $time = new Zend_Gdata_Exif_Extension_Time();
                 $time->transferFromDOM($child);
                 $this->_time = $time;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/Comments.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/Comments.php
@@ -70,7 +70,7 @@ class Zend_Gdata_Extension_Comments extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/EntryLink.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/EntryLink.php
@@ -81,7 +81,7 @@ class Zend_Gdata_Extension_EntryLink extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('atom') . ':' . 'entry';
+            case $this->lookupNamespace('atom') . ':' . 'entry':
                 $entry = new Zend_Gdata_Entry();
                 $entry->transferFromDOM($child);
                 $this->_entry = $entry;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/FeedLink.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/FeedLink.php
@@ -86,7 +86,7 @@ class Zend_Gdata_Extension_FeedLink extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('atom') . ':' . 'feed';
+            case $this->lookupNamespace('atom') . ':' . 'feed':
                 $feed = new Zend_Gdata_Feed();
                 $feed->transferFromDOM($child);
                 $this->_feed = $feed;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/OriginalEvent.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/OriginalEvent.php
@@ -94,7 +94,7 @@ class Zend_Gdata_Extension_OriginalEvent extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'when';
+            case $this->lookupNamespace('gd') . ':' . 'when':
                 $when = new Zend_Gdata_Extension_When();
                 $when->transferFromDOM($child);
                 $this->_when = $when;

--- a/packages/zend-gdata/library/Zend/Gdata/Extension/When.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Extension/When.php
@@ -84,7 +84,7 @@ class Zend_Gdata_Extension_When extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'reminder';
+            case $this->lookupNamespace('gd') . ':' . 'reminder':
                 $reminder = new Zend_Gdata_Extension_Reminder();
                 $reminder->transferFromDOM($child);
                 $this->_reminders[] = $reminder;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListEntry.php
@@ -121,12 +121,12 @@ class Zend_Gdata_Gapps_EmailListEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'emailList';
+            case $this->lookupNamespace('apps') . ':' . 'emailList':
                 $emailList = new Zend_Gdata_Gapps_Extension_EmailList();
                 $emailList->transferFromDOM($child);
                 $this->_emailList = $emailList;
                 break;
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink[] = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListRecipientEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/EmailListRecipientEntry.php
@@ -107,7 +107,7 @@ class Zend_Gdata_Gapps_EmailListRecipientEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gd') . ':' . 'who';
+            case $this->lookupNamespace('gd') . ':' . 'who':
                 $who = new Zend_Gdata_Extension_Who();
                 $who->transferFromDOM($child);
                 $this->_who = $who;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/GroupEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/GroupEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_GroupEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/MemberEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/MemberEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_MemberEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/NicknameEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/NicknameEntry.php
@@ -120,12 +120,12 @@ class Zend_Gdata_Gapps_NicknameEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'login';
+            case $this->lookupNamespace('apps') . ':' . 'login':
                 $login = new Zend_Gdata_Gapps_Extension_Login();
                 $login->transferFromDOM($child);
                 $this->_login = $login;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'nickname';
+            case $this->lookupNamespace('apps') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Gapps_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_nickname = $nickname;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/OwnerEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/OwnerEntry.php
@@ -105,7 +105,7 @@ class Zend_Gdata_Gapps_OwnerEntry extends Zend_Gdata_Entry
 
         switch ($absoluteNodeName) {
 
-            case $this->lookupNamespace('apps') . ':' . 'property';
+            case $this->lookupNamespace('apps') . ':' . 'property':
                 $property = new Zend_Gdata_Gapps_Extension_Property();
                 $property->transferFromDOM($child);
                 $this->_property[] = $property;

--- a/packages/zend-gdata/library/Zend/Gdata/Gapps/UserEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Gapps/UserEntry.php
@@ -150,22 +150,22 @@ class Zend_Gdata_Gapps_UserEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('apps') . ':' . 'login';
+            case $this->lookupNamespace('apps') . ':' . 'login':
                 $login = new Zend_Gdata_Gapps_Extension_Login();
                 $login->transferFromDOM($child);
                 $this->_login = $login;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'name';
+            case $this->lookupNamespace('apps') . ':' . 'name':
                 $name = new Zend_Gdata_Gapps_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_name = $name;
                 break;
-            case $this->lookupNamespace('apps') . ':' . 'quota';
+            case $this->lookupNamespace('apps') . ':' . 'quota':
                 $quota = new Zend_Gdata_Gapps_Extension_Quota();
                 $quota->transferFromDOM($child);
                 $this->_quota = $quota;
                 break;
-            case $this->lookupNamespace('gd') . ':' . 'feedLink';
+            case $this->lookupNamespace('gd') . ':' . 'feedLink':
                 $feedLink = new Zend_Gdata_Extension_FeedLink();
                 $feedLink->transferFromDOM($child);
                 $this->_feedLink[] = $feedLink;

--- a/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GeoRssWhere.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GeoRssWhere.php
@@ -101,7 +101,7 @@ class Zend_Gdata_Geo_Extension_GeoRssWhere extends Zend_Gdata_Extension
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gml') . ':' . 'Point';
+            case $this->lookupNamespace('gml') . ':' . 'Point':
                 $point = new Zend_Gdata_Geo_Extension_GmlPoint();
                 $point->transferFromDOM($child);
                 $this->_point = $point;

--- a/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GmlPoint.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Geo/Extension/GmlPoint.php
@@ -101,7 +101,7 @@ class Zend_Gdata_Geo_Extension_GmlPoint extends Zend_Gdata_Extension
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gml') . ':' . 'pos';
+            case $this->lookupNamespace('gml') . ':' . 'pos':
                 $pos = new Zend_Gdata_Geo_Extension_GmlPos();
                 $pos->transferFromDOM($child);
                 $this->_pos = $pos;

--- a/packages/zend-gdata/library/Zend/Gdata/Kind/EventEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Kind/EventEntry.php
@@ -169,58 +169,58 @@ class Zend_Gdata_Kind_EventEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gd') . ':' . 'where';
+        case $this->lookupNamespace('gd') . ':' . 'where':
             $where = new Zend_Gdata_Extension_Where();
             $where->transferFromDOM($child);
             $this->_where[] = $where;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'when';
+        case $this->lookupNamespace('gd') . ':' . 'when':
             $when = new Zend_Gdata_Extension_When();
             $when->transferFromDOM($child);
             $this->_when[] = $when;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'who';
+        case $this->lookupNamespace('gd') . ':' . 'who':
             $who = new Zend_Gdata_Extension_Who();
             $who ->transferFromDOM($child);
             $this->_who[] = $who;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'recurrence';
+        case $this->lookupNamespace('gd') . ':' . 'recurrence':
             $recurrence = new Zend_Gdata_Extension_Recurrence();
             $recurrence->transferFromDOM($child);
             $this->_recurrence = $recurrence;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'eventStatus';
+        case $this->lookupNamespace('gd') . ':' . 'eventStatus':
             $eventStatus = new Zend_Gdata_Extension_EventStatus();
             $eventStatus->transferFromDOM($child);
             $this->_eventStatus = $eventStatus;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'comments';
+        case $this->lookupNamespace('gd') . ':' . 'comments':
             $comments = new Zend_Gdata_Extension_Comments();
             $comments->transferFromDOM($child);
             $this->_comments = $comments;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'transparency';
+        case $this->lookupNamespace('gd') . ':' . 'transparency':
             $transparency = new Zend_Gdata_Extension_Transparency();
             $transparency ->transferFromDOM($child);
             $this->_transparency = $transparency;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'visibility';
+        case $this->lookupNamespace('gd') . ':' . 'visibility':
             $visiblity = new Zend_Gdata_Extension_Visibility();
             $visiblity ->transferFromDOM($child);
             $this->_visibility = $visiblity;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'recurrenceException';
+        case $this->lookupNamespace('gd') . ':' . 'recurrenceException':
             // require_once 'Zend/Gdata/Extension/RecurrenceException.php';
             $recurrenceException = new Zend_Gdata_Extension_RecurrenceException();
             $recurrenceException ->transferFromDOM($child);
             $this->_recurrenceException[] = $recurrenceException;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'originalEvent';
+        case $this->lookupNamespace('gd') . ':' . 'originalEvent':
             $originalEvent = new Zend_Gdata_Extension_OriginalEvent();
             $originalEvent ->transferFromDOM($child);
             $this->_originalEvent = $originalEvent;
             break;
-        case $this->lookupNamespace('gd') . ':' . 'extendedProperty';
+        case $this->lookupNamespace('gd') . ':' . 'extendedProperty':
             $extProp = new Zend_Gdata_Extension_ExtendedProperty();
             $extProp->transferFromDOM($child);
             $this->_extendedProperty[] = $extProp;

--- a/packages/zend-gdata/library/Zend/Gdata/Media/Extension/MediaGroup.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Media/Extension/MediaGroup.php
@@ -258,67 +258,67 @@ class Zend_Gdata_Media_Extension_MediaGroup extends Zend_Gdata_Extension
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('media') . ':' . 'content';
+            case $this->lookupNamespace('media') . ':' . 'content':
                 $content = new Zend_Gdata_Media_Extension_MediaContent();
                 $content->transferFromDOM($child);
                 $this->_content[] = $content;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'category';
+            case $this->lookupNamespace('media') . ':' . 'category':
                 $category = new Zend_Gdata_Media_Extension_MediaCategory();
                 $category->transferFromDOM($child);
                 $this->_category[] = $category;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'copyright';
+            case $this->lookupNamespace('media') . ':' . 'copyright':
                 $copyright = new Zend_Gdata_Media_Extension_MediaCopyright();
                 $copyright->transferFromDOM($child);
                 $this->_copyright = $copyright;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'credit';
+            case $this->lookupNamespace('media') . ':' . 'credit':
                 $credit = new Zend_Gdata_Media_Extension_MediaCredit();
                 $credit->transferFromDOM($child);
                 $this->_credit[] = $credit;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'description';
+            case $this->lookupNamespace('media') . ':' . 'description':
                 $description = new Zend_Gdata_Media_Extension_MediaDescription();
                 $description->transferFromDOM($child);
                 $this->_description = $description;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'hash';
+            case $this->lookupNamespace('media') . ':' . 'hash':
                 $hash = new Zend_Gdata_Media_Extension_MediaHash();
                 $hash->transferFromDOM($child);
                 $this->_hash[] = $hash;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'keywords';
+            case $this->lookupNamespace('media') . ':' . 'keywords':
                 $keywords = new Zend_Gdata_Media_Extension_MediaKeywords();
                 $keywords->transferFromDOM($child);
                 $this->_keywords = $keywords;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'player';
+            case $this->lookupNamespace('media') . ':' . 'player':
                 $player = new Zend_Gdata_Media_Extension_MediaPlayer();
                 $player->transferFromDOM($child);
                 $this->_player[] = $player;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'rating';
+            case $this->lookupNamespace('media') . ':' . 'rating':
                 $rating = new Zend_Gdata_Media_Extension_MediaRating();
                 $rating->transferFromDOM($child);
                 $this->_rating[] = $rating;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'restriction';
+            case $this->lookupNamespace('media') . ':' . 'restriction':
                 $restriction = new Zend_Gdata_Media_Extension_MediaRestriction();
                 $restriction->transferFromDOM($child);
                 $this->_restriction[] = $restriction;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'text';
+            case $this->lookupNamespace('media') . ':' . 'text':
                 $text = new Zend_Gdata_Media_Extension_MediaText();
                 $text->transferFromDOM($child);
                 $this->_mediaText[] = $text;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'thumbnail';
+            case $this->lookupNamespace('media') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Media_Extension_MediaThumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_thumbnail[] = $thumbnail;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'title';
+            case $this->lookupNamespace('media') . ':' . 'title':
                 $title = new Zend_Gdata_Media_Extension_MediaTitle();
                 $title->transferFromDOM($child);
                 $this->_title = $title;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumEntry.php
@@ -266,62 +266,62 @@ class Zend_Gdata_Photos_AlbumEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'access';
+            case $this->lookupNamespace('gphoto') . ':' . 'access':
                 $access = new Zend_Gdata_Photos_Extension_Access();
                 $access->transferFromDOM($child);
                 $this->_gphotoAccess = $access;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'location';
+            case $this->lookupNamespace('gphoto') . ':' . 'location':
                 $location = new Zend_Gdata_Photos_Extension_Location();
                 $location->transferFromDOM($child);
                 $this->_gphotoLocation = $location;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'name';
+            case $this->lookupNamespace('gphoto') . ':' . 'name':
                 $name = new Zend_Gdata_Photos_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_gphotoName = $name;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'numphotos';
+            case $this->lookupNamespace('gphoto') . ':' . 'numphotos':
                 $numPhotos = new Zend_Gdata_Photos_Extension_NumPhotos();
                 $numPhotos->transferFromDOM($child);
                 $this->_gphotoNumPhotos = $numPhotos;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('georss') . ':' . 'where';
+            case $this->lookupNamespace('georss') . ':' . 'where':
                 $geoRssWhere = new Zend_Gdata_Geo_Extension_GeoRssWhere();
                 $geoRssWhere->transferFromDOM($child);
                 $this->_geoRssWhere = $geoRssWhere;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'group';
+            case $this->lookupNamespace('media') . ':' . 'group':
                 $mediaGroup = new Zend_Gdata_Media_Extension_MediaGroup();
                 $mediaGroup->transferFromDOM($child);
                 $this->_mediaGroup = $mediaGroup;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/AlbumFeed.php
@@ -178,52 +178,52 @@ class Zend_Gdata_Photos_AlbumFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'name';
+            case $this->lookupNamespace('gphoto') . ':' . 'name':
                 $name = new Zend_Gdata_Photos_Extension_Name();
                 $name->transferFromDOM($child);
                 $this->_gphotoName = $name;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'location';
+            case $this->lookupNamespace('gphoto') . ':' . 'location':
                 $location = new Zend_Gdata_Photos_Extension_Location();
                 $location->transferFromDOM($child);
                 $this->_gphotoLocation = $location;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'access';
+            case $this->lookupNamespace('gphoto') . ':' . 'access':
                 $access = new Zend_Gdata_Photos_Extension_Access();
                 $access->transferFromDOM($child);
                 $this->_gphotoAccess = $access;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'numphotos';
+            case $this->lookupNamespace('gphoto') . ':' . 'numphotos':
                 $numphotos = new Zend_Gdata_Photos_Extension_NumPhotos();
                 $numphotos->transferFromDOM($child);
                 $this->_gphotoNumPhotos = $numphotos;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/CommentEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/CommentEntry.php
@@ -131,12 +131,12 @@ class Zend_Gdata_Photos_CommentEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'photoid';
+            case $this->lookupNamespace('gphoto') . ':' . 'photoid':
                 $photoid = new Zend_Gdata_Photos_Extension_PhotoId();
                 $photoid->transferFromDOM($child);
                 $this->_gphotoPhotoId = $photoid;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoEntry.php
@@ -294,67 +294,67 @@ class Zend_Gdata_Photos_PhotoEntry extends Zend_Gdata_Media_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'albumid';
+            case $this->lookupNamespace('gphoto') . ':' . 'albumid':
                 $albumId = new Zend_Gdata_Photos_Extension_AlbumId();
                 $albumId->transferFromDOM($child);
                 $this->_gphotoAlbumId = $albumId;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'version';
+            case $this->lookupNamespace('gphoto') . ':' . 'version':
                 $version = new Zend_Gdata_Photos_Extension_Version();
                 $version->transferFromDOM($child);
                 $this->_gphotoVersion = $version;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'width';
+            case $this->lookupNamespace('gphoto') . ':' . 'width':
                 $width = new Zend_Gdata_Photos_Extension_Width();
                 $width->transferFromDOM($child);
                 $this->_gphotoWidth = $width;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'height';
+            case $this->lookupNamespace('gphoto') . ':' . 'height':
                 $height = new Zend_Gdata_Photos_Extension_Height();
                 $height->transferFromDOM($child);
                 $this->_gphotoHeight = $height;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'size';
+            case $this->lookupNamespace('gphoto') . ':' . 'size':
                 $size = new Zend_Gdata_Photos_Extension_Size();
                 $size->transferFromDOM($child);
                 $this->_gphotoSize = $size;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'client';
+            case $this->lookupNamespace('gphoto') . ':' . 'client':
                 $client = new Zend_Gdata_Photos_Extension_Client();
                 $client->transferFromDOM($child);
                 $this->_gphotoClient = $client;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'checksum';
+            case $this->lookupNamespace('gphoto') . ':' . 'checksum':
                 $checksum = new Zend_Gdata_Photos_Extension_Checksum();
                 $checksum->transferFromDOM($child);
                 $this->_gphotoChecksum = $checksum;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('exif') . ':' . 'tags';
+            case $this->lookupNamespace('exif') . ':' . 'tags':
                 $exifTags = new Zend_Gdata_Exif_Extension_Tags();
                 $exifTags->transferFromDOM($child);
                 $this->_exifTags = $exifTags;
                 break;
-            case $this->lookupNamespace('georss') . ':' . 'where';
+            case $this->lookupNamespace('georss') . ':' . 'where':
                 $geoRssWhere = new Zend_Gdata_Geo_Extension_GeoRssWhere();
                 $geoRssWhere->transferFromDOM($child);
                 $this->_geoRssWhere = $geoRssWhere;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/PhotoFeed.php
@@ -195,62 +195,62 @@ class Zend_Gdata_Photos_PhotoFeed extends Zend_Gdata_Feed
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'id';
+            case $this->lookupNamespace('gphoto') . ':' . 'id':
                 $id = new Zend_Gdata_Photos_Extension_Id();
                 $id->transferFromDOM($child);
                 $this->_gphotoId = $id;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'version';
+            case $this->lookupNamespace('gphoto') . ':' . 'version':
                 $version = new Zend_Gdata_Photos_Extension_Version();
                 $version->transferFromDOM($child);
                 $this->_gphotoVersion = $version;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'albumid';
+            case $this->lookupNamespace('gphoto') . ':' . 'albumid':
                 $albumid = new Zend_Gdata_Photos_Extension_AlbumId();
                 $albumid->transferFromDOM($child);
                 $this->_gphotoAlbumId = $albumid;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'width';
+            case $this->lookupNamespace('gphoto') . ':' . 'width':
                 $width = new Zend_Gdata_Photos_Extension_Width();
                 $width->transferFromDOM($child);
                 $this->_gphotoWidth = $width;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'height';
+            case $this->lookupNamespace('gphoto') . ':' . 'height':
                 $height = new Zend_Gdata_Photos_Extension_Height();
                 $height->transferFromDOM($child);
                 $this->_gphotoHeight = $height;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'size';
+            case $this->lookupNamespace('gphoto') . ':' . 'size':
                 $size = new Zend_Gdata_Photos_Extension_Size();
                 $size->transferFromDOM($child);
                 $this->_gphotoSize = $size;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'client';
+            case $this->lookupNamespace('gphoto') . ':' . 'client':
                 $client = new Zend_Gdata_Photos_Extension_Client();
                 $client->transferFromDOM($child);
                 $this->_gphotoClient = $client;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'checksum';
+            case $this->lookupNamespace('gphoto') . ':' . 'checksum':
                 $checksum = new Zend_Gdata_Photos_Extension_Checksum();
                 $checksum->transferFromDOM($child);
                 $this->_gphotoChecksum = $checksum;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'timestamp';
+            case $this->lookupNamespace('gphoto') . ':' . 'timestamp':
                 $timestamp = new Zend_Gdata_Photos_Extension_Timestamp();
                 $timestamp->transferFromDOM($child);
                 $this->_gphotoTimestamp = $timestamp;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentingEnabled':
                 $commentingEnabled = new Zend_Gdata_Photos_Extension_CommentingEnabled();
                 $commentingEnabled->transferFromDOM($child);
                 $this->_gphotoCommentingEnabled = $commentingEnabled;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'commentCount';
+            case $this->lookupNamespace('gphoto') . ':' . 'commentCount':
                 $commentCount = new Zend_Gdata_Photos_Extension_CommentCount();
                 $commentCount->transferFromDOM($child);
                 $this->_gphotoCommentCount = $commentCount;
                 break;
-            case $this->lookupNamespace('media') . ':' . 'group';
+            case $this->lookupNamespace('media') . ':' . 'group':
                 $mediaGroup = new Zend_Gdata_Media_Extension_MediaGroup();
                 $mediaGroup->transferFromDOM($child);
                 $this->_mediaGroup = $mediaGroup;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/TagEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/TagEntry.php
@@ -104,7 +104,7 @@ class Zend_Gdata_Photos_TagEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'weight';
+            case $this->lookupNamespace('gphoto') . ':' . 'weight':
                 $weight = new Zend_Gdata_Photos_Extension_Weight();
                 $weight->transferFromDOM($child);
                 $this->_gphotoWeight = $weight;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/UserEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/UserEntry.php
@@ -189,32 +189,32 @@ class Zend_Gdata_Photos_UserEntry extends Zend_Gdata_Entry
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
 
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail';
+            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Photos_Extension_Thumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_gphotoThumbnail = $thumbnail;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'quotacurrent';
+            case $this->lookupNamespace('gphoto') . ':' . 'quotacurrent':
                 $quotaCurrent = new Zend_Gdata_Photos_Extension_QuotaCurrent();
                 $quotaCurrent->transferFromDOM($child);
                 $this->_gphotoQuotaCurrent = $quotaCurrent;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'quotalimit';
+            case $this->lookupNamespace('gphoto') . ':' . 'quotalimit':
                 $quotaLimit = new Zend_Gdata_Photos_Extension_QuotaLimit();
                 $quotaLimit->transferFromDOM($child);
                 $this->_gphotoQuotaLimit = $quotaLimit;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'maxPhotosPerAlbum';
+            case $this->lookupNamespace('gphoto') . ':' . 'maxPhotosPerAlbum':
                 $maxPhotosPerAlbum = new Zend_Gdata_Photos_Extension_MaxPhotosPerAlbum();
                 $maxPhotosPerAlbum->transferFromDOM($child);
                 $this->_gphotoMaxPhotosPerAlbum = $maxPhotosPerAlbum;

--- a/packages/zend-gdata/library/Zend/Gdata/Photos/UserFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Photos/UserFeed.php
@@ -119,17 +119,17 @@ class Zend_Gdata_Photos_UserFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gphoto') . ':' . 'user';
+            case $this->lookupNamespace('gphoto') . ':' . 'user':
                 $user = new Zend_Gdata_Photos_Extension_User();
                 $user->transferFromDOM($child);
                 $this->_gphotoUser = $user;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'nickname';
+            case $this->lookupNamespace('gphoto') . ':' . 'nickname':
                 $nickname = new Zend_Gdata_Photos_Extension_Nickname();
                 $nickname->transferFromDOM($child);
                 $this->_gphotoNickname = $nickname;
                 break;
-            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail';
+            case $this->lookupNamespace('gphoto') . ':' . 'thumbnail':
                 $thumbnail = new Zend_Gdata_Photos_Extension_Thumbnail();
                 $thumbnail->transferFromDOM($child);
                 $this->_gphotoThumbnail = $thumbnail;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellEntry.php
@@ -70,7 +70,7 @@ class Zend_Gdata_Spreadsheets_CellEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-        case $this->lookupNamespace('gs') . ':' . 'cell';
+        case $this->lookupNamespace('gs') . ':' . 'cell':
             $cell = new Zend_Gdata_Spreadsheets_Extension_Cell();
             $cell->transferFromDOM($child);
             $this->_cell = $cell;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellFeed.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/CellFeed.php
@@ -101,12 +101,12 @@ class Zend_Gdata_Spreadsheets_CellFeed extends Zend_Gdata_Feed
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gs') . ':' . 'rowCount';
+            case $this->lookupNamespace('gs') . ':' . 'rowCount':
                 $rowCount = new Zend_Gdata_Spreadsheets_Extension_RowCount();
                 $rowCount->transferFromDOM($child);
                 $this->_rowCount = $rowCount;
                 break;
-            case $this->lookupNamespace('gs') . ':' . 'colCount';
+            case $this->lookupNamespace('gs') . ':' . 'colCount':
                 $colCount = new Zend_Gdata_Spreadsheets_Extension_ColCount();
                 $colCount->transferFromDOM($child);
                 $this->_colCount = $colCount;

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/ListEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/ListEntry.php
@@ -83,7 +83,7 @@ class Zend_Gdata_Spreadsheets_ListEntry extends Zend_Gdata_Entry
     protected function takeChildFromDOM($child)
     {
         switch ($child->namespaceURI) {
-        case $this->lookupNamespace('gsx');
+        case $this->lookupNamespace('gsx'):
             $custom = new Zend_Gdata_Spreadsheets_Extension_Custom($child->localName);
             $custom->transferFromDOM($child);
             $this->addCustom($custom);

--- a/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/WorksheetEntry.php
+++ b/packages/zend-gdata/library/Zend/Gdata/Spreadsheets/WorksheetEntry.php
@@ -96,12 +96,12 @@ class Zend_Gdata_Spreadsheets_WorksheetEntry extends Zend_Gdata_Entry
     {
         $absoluteNodeName = $child->namespaceURI . ':' . $child->localName;
         switch ($absoluteNodeName) {
-            case $this->lookupNamespace('gs') . ':' . 'rowCount';
+            case $this->lookupNamespace('gs') . ':' . 'rowCount':
                 $rowCount = new Zend_Gdata_Spreadsheets_Extension_RowCount();
                 $rowCount->transferFromDOM($child);
                 $this->_rowCount = $rowCount;
                 break;
-            case $this->lookupNamespace('gs') . ':' . 'colCount';
+            case $this->lookupNamespace('gs') . ':' . 'colCount':
                 $colCount = new Zend_Gdata_Spreadsheets_Extension_ColCount();
                 $colCount->transferFromDOM($child);
                 $this->_colCount = $colCount;

--- a/packages/zend-pdf/library/Zend/Pdf.php
+++ b/packages/zend-pdf/library/Zend/Pdf.php
@@ -578,8 +578,8 @@ class Zend_Pdf
 
         $outlineDictionary = $root->Outlines->First;
         $processedDictionaries = new SplObjectStorage();
-        while ($outlineDictionary !== null  &&  !$processedDictionaries->contains($outlineDictionary)) {
-            $processedDictionaries->attach($outlineDictionary);
+        while ($outlineDictionary !== null  &&  !$processedDictionaries->offsetExists($outlineDictionary)) {
+            $processedDictionaries->offsetSet($outlineDictionary);
 
             // require_once 'Zend/Pdf/Outline/Loaded.php';
             $this->outlines[] = new Zend_Pdf_Outline_Loaded($outlineDictionary);

--- a/packages/zend-pdf/library/Zend/Pdf/Action.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Action.php
@@ -87,15 +87,15 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
         if ($dictionary->Next !== null) {
             if ($dictionary->Next instanceof Zend_Pdf_Element_Dictionary) {
                 // Check if dictionary object is not already processed
-                if (!$processedActions->contains($dictionary->Next)) {
-                    $processedActions->attach($dictionary->Next);
+                if (!$processedActions->offsetExists($dictionary->Next)) {
+                    $processedActions->offsetSet($dictionary->Next);
                     $this->next[] = Zend_Pdf_Action::load($dictionary->Next, $processedActions);
                 }
             } else if ($dictionary->Next instanceof Zend_Pdf_Element_Array) {
                 foreach ($dictionary->Next->items as $chainedActionDictionary) {
                     // Check if dictionary object is not already processed
-                    if (!$processedActions->contains($chainedActionDictionary)) {
-                        $processedActions->attach($chainedActionDictionary);
+                    if (!$processedActions->offsetExists($chainedActionDictionary)) {
+                        $processedActions->offsetSet($chainedActionDictionary);
                         $this->next[] = Zend_Pdf_Action::load($chainedActionDictionary, $processedActions);
                     }
                 }
@@ -262,11 +262,11 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
         if ($processedActions === null) {
             $processedActions = new SplObjectStorage();
         }
-        if ($processedActions->contains($this)) {
+        if ($processedActions->offsetExists($this)) {
             // require_once 'Zend/Pdf/Exception.php';
             throw new Zend_Pdf_Exception('Action chain cyclyc reference is detected.');
         }
-        $processedActions->attach($this);
+        $processedActions->offsetSet($this);
 
         $childListUpdated = false;
         if (count($this->_originalNextList) != count($this->next)) {

--- a/packages/zend-pdf/library/Zend/Pdf/ElementFactory.php
+++ b/packages/zend-pdf/library/Zend/Pdf/ElementFactory.php
@@ -318,7 +318,7 @@ class Zend_Pdf_ElementFactory implements Zend_Pdf_ElementFactory_Interface
         }
 
         $this->_modifiedObjects[$obj->getObjNum()] = $obj;
-        $this->_removedObjects->attach($obj);
+        $this->_removedObjects->offsetSet($obj);
     }
 
 
@@ -376,7 +376,7 @@ class Zend_Pdf_ElementFactory implements Zend_Pdf_ElementFactory_Interface
         $result = array();
         // require_once 'Zend/Pdf/UpdateInfoContainer.php';
         foreach ($this->_modifiedObjects as $objNum => $obj) {
-            if ($this->_removedObjects->contains($obj)) {
+            if ($this->_removedObjects->offsetExists($obj)) {
                             $result[$objNum+$shift] = new Zend_Pdf_UpdateInfoContainer($objNum + $shift,
                                                                            $obj->getGenNum()+1,
                                                                            true);

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Created.php
@@ -252,7 +252,7 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }
-        $processedOutlines->attach($this);
+        $processedOutlines->offsetSet($this);
 
         $outlineDictionary = $factory->newObject(new Zend_Pdf_Element_Dictionary());
 
@@ -290,7 +290,7 @@ class Zend_Pdf_Outline_Created extends Zend_Pdf_Outline
 
         $lastChild = null;
         foreach ($this->childOutlines as $childOutline) {
-            if ($processedOutlines->contains($childOutline)) {
+            if ($processedOutlines->offsetExists($childOutline)) {
                 // require_once 'Zend/Pdf/Exception.php';
                 throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
             }

--- a/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Outline/Loaded.php
@@ -318,7 +318,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
         if ($processedDictionaries === null) {
             $processedDictionaries = new SplObjectStorage();
         }
-        $processedDictionaries->attach($dictionary);
+        $processedDictionaries->offsetSet($dictionary);
 
         $this->_outlineDictionary = $dictionary;
 
@@ -339,12 +339,12 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             $children = new SplObjectStorage();
             while ($childDictionary !== null) {
                 // Check children structure for cyclic references
-                if ($children->contains($childDictionary)) {
+                if ($children->offsetExists($childDictionary)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outline childs load error.');
                 }
 
-                if (!$processedDictionaries->contains($childDictionary)) {
+                if (!$processedDictionaries->offsetExists($childDictionary)) {
                     $this->childOutlines[] = new Zend_Pdf_Outline_Loaded($childDictionary, $processedDictionaries);
                 }
 
@@ -378,7 +378,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
         if ($processedOutlines === null) {
             $processedOutlines = new SplObjectStorage();
         }
-        $processedOutlines->attach($this);
+        $processedOutlines->offsetSet($this);
 
         if ($updateNavigation) {
             $this->_outlineDictionary->touch();
@@ -410,7 +410,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             $this->_outlineDictionary->First = null;
 
             foreach ($this->childOutlines as $childOutline) {
-                if ($processedOutlines->contains($childOutline)) {
+                if ($processedOutlines->offsetExists($childOutline)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
                 }
@@ -436,7 +436,7 @@ class Zend_Pdf_Outline_Loaded extends Zend_Pdf_Outline
             }
         } else {
             foreach ($this->childOutlines as $childOutline) {
-                if ($processedOutlines->contains($childOutline)) {
+                if ($processedOutlines->offsetExists($childOutline)) {
                     // require_once 'Zend/Pdf/Exception.php';
                     throw new Zend_Pdf_Exception('Outlines cyclyc reference is detected.');
                 }

--- a/packages/zend-pdf/library/Zend/Pdf/Resource/Image/Png.php
+++ b/packages/zend-pdf/library/Zend/Pdf/Resource/Image/Png.php
@@ -190,7 +190,7 @@ class Zend_Pdf_Resource_Image_Png extends Zend_Pdf_Resource_Image
                     fseek($imageFile, 4, SEEK_CUR); //4 Byte Ending Sequence
                     break;
 
-                case 'IEND';
+                case 'IEND':
                     break 2; //End the loop too
 
                 default:

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -102,9 +102,10 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
 
     /**
      * Serialize
-     * 
+     *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function __serialize()
     {
         $data = array();

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Qt.php
@@ -91,7 +91,9 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tbx.php
@@ -86,7 +86,9 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -91,7 +91,9 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Xliff.php
@@ -98,7 +98,9 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/XmlTm.php
@@ -86,7 +86,9 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
                           xml_error_string(xml_get_error_code($this->_file)),
                           xml_get_current_line_number($this->_file),
                           $filename);
-            xml_parser_free($this->_file);
+            if (PHP_VERSION_ID < 80000) {
+                xml_parser_free($this->_file);
+            }
             // require_once 'Zend/Translate/Exception.php';
             throw new Zend_Translate_Exception($ex);
         }

--- a/packages/zend-wildfire/library/Zend/Wildfire/Channel/HttpHeaders.php
+++ b/packages/zend-wildfire/library/Zend/Wildfire/Channel/HttpHeaders.php
@@ -165,7 +165,7 @@ class Zend_Wildfire_Channel_HttpHeaders extends Zend_Controller_Plugin_Abstract 
     protected function _initProtocol($uri)
     {
         switch ($uri) {
-            case Zend_Wildfire_Protocol_JsonStream::PROTOCOL_URI;
+            case Zend_Wildfire_Protocol_JsonStream::PROTOCOL_URI:
                 return new Zend_Wildfire_Protocol_JsonStream();
         }
         // require_once 'Zend/Wildfire/Exception.php';

--- a/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/packages/zend-wildfire/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -722,7 +722,9 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 
                     } else {
                         if (method_exists($property,'setAccessible')) {
-                            $property->setAccessible(true);
+                            if (PHP_VERSION_ID < 80100) {
+                                $property->setAccessible(true);
+                            }
                             $return[$name] = $this->_encodeObject($property->getValue($object), $objectDepth + 1, 1);
                         } else
                         if ($property->isPublic()) {

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -111,18 +111,21 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
     public function testAdapterDriverOptions()
     {
         $params = $this->_util->getParams();
+        $attr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
 
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true);
-
-        $db = Zend_Db::factory($this->getDriver(), $params);
-
-        $this->assertTrue((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
-
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => false);
+        $params['driver_options'] = array($attr => true);
 
         $db = Zend_Db::factory($this->getDriver(), $params);
 
-        $this->assertFalse((bool) $db->getConnection()->getAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY));
+        $this->assertTrue((bool) $db->getConnection()->getAttribute($attr));
+
+        $params['driver_options'] = array($attr => false);
+
+        $db = Zend_Db::factory($this->getDriver(), $params);
+
+        $this->assertFalse((bool) $db->getConnection()->getAttribute($attr));
     }
 
     public function testAdapterInsertSequence()
@@ -283,7 +286,10 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
     public function testZF2101()
     {
         $params = $this->_util->getParams();
-        $params['driver_options'] = array(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true);
+        $attr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+        $params['driver_options'] = array($attr => true);
         $db = Zend_Db::factory($this->getDriver(), $params);
 
         // Set default bound value

--- a/tests/Zend/Db/TestUtil/Pdo/Mysql.php
+++ b/tests/Zend/Db/TestUtil/Pdo/Mysql.php
@@ -56,8 +56,11 @@ class Zend_Db_TestUtil_Pdo_Mysql extends Zend_Db_TestUtil_Mysqli
             $constants['driver_options'] = array();
         }
 
-        if (!isset($constants['driver_options'][PDO::MYSQL_ATTR_USE_BUFFERED_QUERY])) {
-            $constants['driver_options'][PDO::MYSQL_ATTR_USE_BUFFERED_QUERY] = true;
+        $bufferedQueryAttr = PHP_VERSION_ID >= 80500
+            ? Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+            : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+        if (!isset($constants['driver_options'][$bufferedQueryAttr])) {
+            $constants['driver_options'][$bufferedQueryAttr] = true;
         }
 
         return $constants;

--- a/tests/Zend/Ldap/SortTest.php
+++ b/tests/Zend/Ldap/SortTest.php
@@ -59,7 +59,9 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
         $iterator->setSortFunction($sortFunction);
         $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
@@ -83,11 +85,15 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
 
         $reflectionProperty = $reflectionObject->getProperty('_entries');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $iterator->sort('l');
 
@@ -128,11 +134,15 @@ class Zend_Ldap_SortTest extends Zend_Ldap_OnlineTestCase
 
         $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('_sortFunction');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
 
         $reflectionProperty = $reflectionObject->getProperty('_entries');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $iterator->sort('l');
 

--- a/tests/Zend/LocaleTest.php
+++ b/tests/Zend/LocaleTest.php
@@ -952,7 +952,9 @@ class Zend_LocaleTest extends PHPUnit_Framework_TestCase
 
         $class    = new ReflectionClass('Zend_Locale');
         $property = $class->getProperty('_localeData');
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $locale     = new Zend_Locale();
         $localeData = $property->getValue($locale);

--- a/tests/Zend/Session/SessionHelper.php
+++ b/tests/Zend/Session/SessionHelper.php
@@ -29,7 +29,9 @@ class Zend_Session_SessionHelper
                 ) as $prop => $value) {
             list($class, $property) = explode('::', $prop);
             $reflection = new ReflectionProperty($class, $property);
-            $reflection->setAccessible(true);
+            if (PHP_VERSION_ID < 80100) {
+                $reflection->setAccessible(true);
+            }
             $reflection->setValue(null, $value);
         }
     }


### PR DESCRIPTION
`xml_parser_free()` and `imagedestroy()` became no-ops in PHP 8.0 when their respective extensions migrated from resources to objects (`XMLParser` and `GdImage`). PHP 8.5 formally deprecates these functions.

Since we support PHP 7.1+, the calls are still needed on 7.1-7.4 where they actually free resources. Guarded with `PHP_VERSION_ID < 80000` to skip on 8.0+ where they have no effect.

Affected packages:
- **zend-translate**: `xml_parser_free()` in Tmx, Qt, Tbx, Xliff, XmlTm adapters (error path only)
- **zend-captcha**: `imagedestroy()` in `Zend_Captcha_Image`
- **zend-barcode**: `imagedestroy()` in `Zend_Barcode_Renderer_Image`

`curl_close()` in zend-http was already effectively guarded by an `is_resource()` check which returns false on PHP 8.0+ (curl handles became `CurlHandle` objects).

References:
- https://php.watch/versions/8.5/xml_parser_free-deprecated
- https://php.watch/versions/8.0/XMLParser-resource
- https://php.watch/versions/8.0/gdimage

#### Other changes

1) guard deprecated `ReflectionProperty::setAccessible()` on php 8.1+
2) [zend-pdf] replace `SplObjectStorage::contains()` → `offsetExists()`, `attach()` → `offsetSet()`
3) [zend-stdlib] add `#[ReturnTypeWillChange]` to `SplPriorityQueue::__serialize()`
4) [zend-db] use `Pdo\Mysql::ATTR_USE_BUFFERED_QUERY` on php 8.5+ (test-only)
5) replace semicolons with colons in `case` statements across 38 files