### PR TITLE
php 8.5: fix deprecation of null as array key

### DIFF
--- a/packages/zend-db/library/Zend/Db/Select.php
+++ b/packages/zend-db/library/Zend/Db/Select.php
@@ -268,7 +268,7 @@ class Zend_Db_Select
             $correlationName = current($correlationNameKeys);
         }
 
-        if (!array_key_exists($correlationName, $this->_parts[self::FROM])) {
+        if (!array_key_exists($correlationName ?? '', $this->_parts[self::FROM])) {
             /**
              * @see Zend_Db_Select_Exception
              */

--- a/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Http.php
+++ b/packages/zend-file-transfer/library/Zend/File/Transfer/Adapter/Http.php
@@ -141,7 +141,8 @@ class Zend_File_Transfer_Adapter_Http extends Zend_File_Transfer_Adapter_Abstrac
                 $files = current($files);
             }
 
-            $temp = array($files => array(
+            $fileKey = $files ?? '';
+            $temp = array($fileKey => array(
                 'name'  => $files,
                 'error' => 1));
             $validator = $this->_validators['Zend_Validate_File_Upload'];

--- a/packages/zend-filter/library/Zend/Filter/Input.php
+++ b/packages/zend-filter/library/Zend/Filter/Input.php
@@ -850,7 +850,7 @@ class Zend_Filter_Input
                     
                     if (is_array($rule)) {
                         $keys      = array_keys($rule);
-                        $classKey  = array_shift($keys);
+                        $classKey  = array_shift($keys) ?? '';
                         if (isset($rule[$classKey])) {
                             $ruleClass = $rule[$classKey];
                             if ($ruleClass === 'NotEmpty') {

--- a/packages/zend-form/library/Zend/Form.php
+++ b/packages/zend-form/library/Zend/Form.php
@@ -2123,8 +2123,10 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _dissolveArrayValue($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
+
         // As long as we have more levels
-        while ($arrayPos = strpos((string) $arrayPath, '[')) {
+        while ($arrayPos = strpos($arrayPath, '[')) {
             // Get the next key in the path
             $arrayKey = trim(substr($arrayPath, 0, $arrayPos), ']');
 
@@ -2181,6 +2183,8 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _attachToArray($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
+
         // As long as we have more levels
         while ($arrayPos = strrpos($arrayPath, '[')) {
             // Get the next key in the path

--- a/packages/zend-http/library/Zend/Http/Client.php
+++ b/packages/zend-http/library/Zend/Http/Client.php
@@ -539,6 +539,7 @@ class Zend_Http_Client
     protected function _setParameter($type, $name, $value)
     {
         $parray = array();
+        $name = $name ?? '';
         $type = strtolower($type);
         switch ($type) {
             case 'get':

--- a/packages/zend-navigation/library/Zend/Navigation/Container.php
+++ b/packages/zend-navigation/library/Zend/Navigation/Container.php
@@ -516,6 +516,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
         current($this->_index);
         $hash = key($this->_index);
 
+        $hash = $hash ?? '';
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];
         } else {
@@ -607,6 +608,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
     {
         $hash = key($this->_index);
 
+        $hash = $hash ?? '';
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];
         }

--- a/packages/zend-rest/library/Zend/Rest/Server.php
+++ b/packages/zend-rest/library/Zend/Rest/Server.php
@@ -478,8 +478,9 @@ class Zend_Rest_Server implements Zend_Server_Interface
      */
     public function fault($exception = null, $code = null)
     {
-        if (isset($this->_functions[$this->_method])) {
-            $function = $this->_functions[$this->_method];
+        $method = $this->_method ?? '';
+        if (isset($this->_functions[$method])) {
+            $function = $this->_functions[$method];
         } elseif (isset($this->_method)) {
             $function = $this->_method;
         } else {

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
@@ -55,7 +55,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet extends PHPUnit_Extensions_Dat
      */
     public function addTable(Zend_Db_Table_Abstract $table, $where = null, $order = null, $count = null, $offset = null)
     {
-        $tableName = $table->info('name');
+        $tableName = $table->info('name') ?? '';
         $this->tables[$tableName] = new Zend_Test_PHPUnit_Db_DataSet_DbTable($table, $where, $order, $count, $offset);
     }
 

--- a/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
+++ b/packages/zend-test/library/Zend/Test/PHPUnit/Db/DataSet/DbTableDataSet.php
@@ -55,7 +55,7 @@ class Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet extends PHPUnit_Extensions_Dat
      */
     public function addTable(Zend_Db_Table_Abstract $table, $where = null, $order = null, $count = null, $offset = null)
     {
-        $tableName = $table->info('name') ?? '';
+        $tableName = $table->info('name');
         $this->tables[$tableName] = new Zend_Test_PHPUnit_Db_DataSet_DbTable($table, $where, $order, $count, $offset);
     }
 

--- a/packages/zend-timesync/library/Zend/TimeSync.php
+++ b/packages/zend-timesync/library/Zend/TimeSync.php
@@ -264,8 +264,6 @@ class Zend_TimeSync implements IteratorAggregate
      */
     protected function _addServer($target, $alias)
     {
-        $alias = $alias ?? '';
-
         if ($pos = strpos($target, '://')) {
             $protocol = substr($target, 0, $pos);
             $adress = substr($target, $pos + 3);
@@ -302,6 +300,6 @@ class Zend_TimeSync implements IteratorAggregate
         }
         $timeServerObj = new $className($adress, $port);
 
-        $this->_timeservers[$alias] = $timeServerObj;
+        $this->_timeservers[$alias ?? ''] = $timeServerObj;
     }
 }

--- a/packages/zend-timesync/library/Zend/TimeSync.php
+++ b/packages/zend-timesync/library/Zend/TimeSync.php
@@ -264,6 +264,8 @@ class Zend_TimeSync implements IteratorAggregate
      */
     protected function _addServer($target, $alias)
     {
+        $alias = $alias ?? '';
+
         if ($pos = strpos($target, '://')) {
             $protocol = substr($target, 0, $pos);
             $adress = substr($target, $pos + 3);

--- a/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
+++ b/packages/zend-translate/library/Zend/Translate/Adapter/Tmx.php
@@ -196,8 +196,10 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
                         $this->_tu = $this->_content;
                     }
 
-                    if (!empty($this->_content) or (!isset($this->_data[$this->_tuv][$this->_tu]))) {
-                        $this->_data[$this->_tuv][$this->_tu] = $this->_content;
+                    $tuv = $this->_tuv ?? '';
+                    $tu = $this->_tu ?? '';
+                    if (!empty($this->_content) || !isset($this->_data[$tuv][$tu])) {
+                        $this->_data[$tuv][$tu] = $this->_content;
                     }
                     break;
                 default:

--- a/packages/zend-validate/library/Zend/Validate/File/Upload.php
+++ b/packages/zend-validate/library/Zend/Validate/File/Upload.php
@@ -162,6 +162,7 @@ class Zend_Validate_File_Upload extends Zend_Validate_Abstract
     public function isValid($value, $file = null)
     {
         $this->_messages = array();
+        $value = $value ?? '';
         if (array_key_exists($value, $this->_files)) {
             $files[$value] = $this->_files[$value];
         } else {

--- a/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
@@ -91,6 +91,7 @@ class Zend_Test_PHPUnit_Db_TestCaseTest extends Zend_Test_PHPUnit_DatabaseTestCa
     public function testCreateDbTableDataSetConvenienceMethodReturnType()
     {
         $tableMock = $this->getMock('Zend_Db_Table', array(), array(), "", false);
+        $tableMock->expects($this->any())->method('info')->will($this->returnValue('test_table'));
         $tableDataSet = $this->createDbTableDataSet(array($tableMock));
         $this->assertTrue($tableDataSet instanceof Zend_Test_PHPUnit_Db_DataSet_DbTableDataSet);
     }


### PR DESCRIPTION
> [!NOTE]
> Using `null` as an array key (e.g. `$array[$nullValue]`) was a widely common pattern in older PHP codebases, so this initially looked like a possible breaking change for downstream projects.
> However, PHP has always silently cast `null` to `""` (empty string) in this context - `$array[null]` and `$array[""]` are fully equivalent - so replacing one with the other is a no-op behavior change. If your project has the same pattern, the fix is straightforward: `$var ?? ''` wherever a nullable variable is used as array offset.

PHP 8.5 deprecates using `null` as an array offset and as the key parameter for `array_key_exists()`. This was a widely used pattern in ZF1 where `null` gets passed as array key through various code paths.

#### approach

Since `$array[null]` was always equivalent to `$array['']`, the fix is to make the implicit cast explicit using null coalescing (`$var ?? ''`) at the point where the variable is used as array offset. This preserves backward compatibility exactly.

#### changes by package

| package | file | fix |
|---------|------|-----|
| zend-form | `Form.php` | `$arrayPath ?? ''` in `_dissolveArrayValue()` and `_attachToArray()` |
| zend-db | `Db/Select.php` | `$correlationName ?? ''` in `array_key_exists()` call in `columns()` |
| zend-rest | `Rest/Server.php` | `$this->_method ?? ''` in `fault()` |
| zend-timesync | `TimeSync.php` | `$alias ?? ''` in `_addServer()` |
| zend-http | `Http/Client.php` | `$name ?? ''` in `_setParameter()` |
| zend-navigation | `Navigation/Container.php` | `$hash ?? ''` in `current()` and `getChildren()` |
| zend-translate | `Translate/Adapter/Tmx.php` | `$this->_tuv ?? ''` and `$this->_tu ?? ''` in `_endElement()` |
| zend-file-transfer | `File/Transfer/Adapter/Http.php` | `$files ?? ''` for array key in `isValid()` |
| zend-filter | `Filter/Input.php` | `array_shift($keys) ?? ''` in NotEmpty validator check |
| zend-test | `Test/PHPUnit/Db/DataSet/DbTableDataSet.php` | `$table->info('name') ?? ''` in `addTable()` |

followup to #225