### PR TITLE
php 8.5: fix remaining deprecations

### DIFF
--- a/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
+++ b/packages/zend-codegenerator/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
@@ -228,6 +228,38 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
     }
 
     /**
+     * Wraps each array element in a DefaultValue instance for code generation.
+     *
+     * Replaces the old RecursiveArrayIterator approach which had two php 8.5
+     * incompatibilities: it mutated values via offsetSet during iteration
+     * (replacing arrays with DefaultValue objects), and then when the iterator
+     * tried to descend into those replaced values, RecursiveArrayIterator called
+     * new ArrayIterator($object) - deprecated in php 8.5. On older PHP this
+     * silently yielded no children (protected properties aren't iterable), so
+     * only the top-level array was ever processed by the iterator; nested arrays
+     * were handled later by recursive generate() calls. This method does the
+     * same thing explicitly.
+     *
+     * @param  array $array
+     * @param  int   $depth
+     * @return array
+     */
+    protected function _prepareArrayValue(array $array, $depth)
+    {
+        $result = array();
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $value = new self(array('value' => $this->_prepareArrayValue($value, $depth + 1)));
+            } elseif (!$value instanceof self) {
+                $value = new self(array('value' => $value));
+            }
+            $value->setArrayDepth($depth);
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+
+    /**
      * generate()
      *
      * @return string
@@ -246,18 +278,7 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
             $type = $this->_getAutoDeterminedType($value);
 
             if ($type == self::TYPE_ARRAY) {
-                $rii = new RecursiveIteratorIterator(
-                    $it = new RecursiveArrayIterator((array) $value),
-                    RecursiveIteratorIterator::SELF_FIRST
-                    );
-                foreach ($rii as $curKey => $curValue) {
-                    if (!$curValue instanceof Zend_CodeGenerator_Php_Property_DefaultValue) {
-                        $curValue = new self(array('value' => $curValue));
-                        $rii->getSubIterator()->offsetSet($curKey, $curValue);
-                    }
-                    $curValue->setArrayDepth($rii->getDepth());
-                }
-                $value = $rii->getSubIterator()->getArrayCopy();
+                $value = $this->_prepareArrayValue((array) $value, 0);
             }
 
         }

--- a/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/packages/zend-stdlib/library/Zend/Stdlib/SplPriorityQueue.php
@@ -141,6 +141,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  array $data
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function __unserialize($data)
     {
         foreach ($data as $item) {

--- a/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
+++ b/packages/zend-timesync/library/Zend/TimeSync/Ntp.php
@@ -222,7 +222,10 @@ class Zend_TimeSync_Ntp extends Zend_TimeSync_Protocol
      */
     protected function _read()
     {
-        $flags = ord(fread($this->_socket, 1));
+        // fread returns "" on timeout/incomplete response; ord("") is deprecated in php 8.5
+        // (previously silently returned 0). Timeout is checked below but only after this read.
+        $byte  = fread($this->_socket, 1);
+        $flags = ($byte !== '' && $byte !== false) ? ord($byte) : 0;
         $info  = stream_get_meta_data($this->_socket);
 
         if ($info['timed_out'] === true) {

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -5045,16 +5045,30 @@ class Zend_DateTest extends PHPUnit_Framework_TestCase
 
     public function testTimesync()
     {
-        try {
-            $server = new Zend_TimeSync('ntp://pool.ntp.org', 'alias');
-            $date = $server->getDate();
-            $info = $server->getInfo();
+        // pool.ntp.org is unreachable from GitHub Actions runners,
+        // try multiple servers to avoid marking test incomplete unnecessarily
+        $servers = array(
+            'ntp://time.windows.com',
+            'ntp://pool.ntp.org',
+        );
 
-            // verify the NTP offset was correctly passed through to Zend_Date
-            $this->assertEquals((int) round($info['offset']), $date->getTimeSyncOffset());
-        } catch (Zend_TimeSync_Exception $e) {
-            $this->markTestIncomplete('NTP timeserver not available.');
+        $lastException = null;
+        foreach ($servers as $serverUri) {
+            try {
+                $server = new Zend_TimeSync($serverUri, 'alias');
+                $server->setOptions(array('timeout' => 5));
+                $date = $server->getDate();
+                $info = $server->getInfo();
+
+                // verify the NTP offset was correctly passed through to Zend_Date
+                $this->assertEquals((int) round($info['offset']), $date->getTimeSyncOffset());
+                return;
+            } catch (Zend_TimeSync_Exception $e) {
+                $lastException = $e;
+            }
         }
+
+        $this->markTestIncomplete('NTP timeservers not available: ' . $lastException->getMessage());
     }
 
     public function testUsePhpDateFormat()

--- a/tests/Zend/Log/Writer/StreamTest.php
+++ b/tests/Zend/Log/Writer/StreamTest.php
@@ -56,7 +56,9 @@ class Zend_Log_Writer_StreamTest extends PHPUnit_Framework_TestCase
             $this->assertTrue($e instanceof Zend_Log_Exception);
             $this->assertRegExp('/not a stream/i', $e->getMessage());
         }
-        xml_parser_free($resource);
+        if (PHP_VERSION_ID < 80000) {
+            xml_parser_free($resource);
+        }
     }
 
     public function testConstructorWithValidStream()


### PR DESCRIPTION
fixes last 4 test errors on php 8.5 (after null offset fixes in #227):

#### 1) `RecursiveArrayIterator` with objects as backing array

replaced with simple recursive walk in `Zend_CodeGenerator_Php_Property_DefaultValue::generate()`.

The old code mutated iterator values via `offsetSet` during traversal, replacing arrays with `DefaultValue` objects. When the iterator then tried to descend into those replaced values, `RecursiveArrayIterator` called `new ArrayIterator($object)` - deprecated in php 8.5. On older PHP this silently yielded no children (protected properties aren't iterable), so only the top-level array was ever processed by the iterator; nested arrays were handled later by recursive `generate()` calls. The new `_prepareArrayValue()` does the same thing explicitly.

#### 2) `SplPriorityQueue::__unserialize()` return type mismatch

added `#[ReturnTypeWillChange]` to `Zend_Stdlib_SplPriorityQueue::__unserialize()`

#### 3) `xml_parser_free()` deprecated since 8.5 (no-op since 8.0)

guarded with `PHP_VERSION_ID < 80000` in `Zend_Log_Writer_StreamTest`

#### 4) `ord()` with empty string deprecated in 8.5

`fread($this->_socket, 1)` returns `""` when the NTP socket times out or the server sends an incomplete response. The code checks for timeout only AFTER calling `ord()` on the result, so `ord("")` fires before the timeout handler catches it. On older PHP `ord("")` silently returned 0; php 8.5 deprecates this. Guarded in `Zend_TimeSync_Ntp::_read()`.

#### 5) `testTimesync` unreliable on CI

`pool.ntp.org` is unreachable from GitHub Actions runners (UDP 123 is not blocked - other NTP servers like `time.windows.com` work fine). Changed test to try multiple servers, falling back gracefully.

followup to #227