### PR TITLE
add phpcs lint to ensure long array syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,6 +126,7 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
 
+      # runs on every PHP version to catch syntax incompatible with older versions
       - name: Lint PHP source files
         run: |
           composer lint.checkstyle | cs2pr
@@ -147,5 +148,22 @@ jobs:
       - name: "Run PHPUnit tests (Experimental: ${{ matrix.experimental }})"
         run: vendor/bin/phpunit --verbose
         continue-on-error: ${{ matrix.experimental }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          # lint only needs to run once, not per PHP version
+          php-version: "8.5"
+          tools: phpcs, cs2pr
+
+      - name: Run phpcs
+        run: phpcs --report=checkstyle -q | cs2pr
 
 # vim:ft=yaml:et:ts=2:sw=2

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 composer.lock
 vendor
 phpunit.xml
+.phpcs.cache
+.php-cs-fixer.cache
 tests/Zend/Paginator/_files/test-write-tmp.sqlite
 tests/TestConfiguration.php

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="zf1s">
+    <description>zf1s coding standard</description>
+
+    <arg name="cache" value=".phpcs.cache"/>
+
+    <file>packages</file>
+    <file>tests</file>
+
+    <exclude-pattern>tests/Zend/Loader/_files/ParseError.php</exclude-pattern>
+    <exclude-pattern>tests/Zend/Http/Client/_files</exclude-pattern>
+
+    <!--
+        keep long array syntax - the original ZF1 convention.
+        we don't modernize the codebase for its own sake
+        (see https://github.com/zf1s/zf1/pull/199,
+             https://github.com/zf1s/zf1/pull/138#issuecomment-1275759257).
+    -->
+    <rule ref="Generic.Arrays.DisallowShortArraySyntax"/>
+</ruleset>


### PR DESCRIPTION
adds phpcs to ensure we stay with `array()` long syntax convention
(we don't intend to modernize ancient zf1 code just for the sake of it - see [#199](https://github.com/zf1s/zf1/pull/199), [#138 comment](https://github.com/zf1s/zf1/pull/138#issuecomment-1275759257)).

- `.phpcs.xml.dist` config with `DisallowShortArraySyntax` rule
- separate CI lint job with PR annotations via `cs2pr`