### PR TITLE
catch Throwable in dispatch and server error boundaries

### DIFF
--- a/packages/zend-controller/library/Zend/Controller/Dispatcher/Standard.php
+++ b/packages/zend-controller/library/Zend/Controller/Dispatcher/Standard.php
@@ -306,7 +306,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
 
         try {
             $controller->dispatch($action);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             // Clean output buffer on error
             $curObLevel = ob_get_level();
             if ($curObLevel > $obLevel) {

--- a/packages/zend-controller/library/Zend/Controller/Front.php
+++ b/packages/zend-controller/library/Zend/Controller/Front.php
@@ -287,7 +287,7 @@ class Zend_Controller_Front
     {
         try{
             $dir = new DirectoryIterator($path);
-        } catch(Exception $e) {
+        } catch(Throwable $e) {
             // require_once 'Zend/Controller/Exception.php';
             throw new Zend_Controller_Exception("Directory $path not readable", 0, $e);
         }
@@ -909,11 +909,13 @@ class Zend_Controller_Front
 
             try {
                 $router->route($this->_request);
-            }  catch (Exception $e) {
+            }  catch (Throwable $e) {
                 if ($this->throwExceptions()) {
                     throw $e;
                 }
-
+                if (!$e instanceof Exception) {
+                    $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                }
                 $this->_response->setException($e);
             }
 
@@ -952,9 +954,12 @@ class Zend_Controller_Front
                  */
                 try {
                     $dispatcher->dispatch($this->_request, $this->_response);
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     if ($this->throwExceptions()) {
                         throw $e;
+                    }
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
                     }
                     $this->_response->setException($e);
                 }
@@ -964,11 +969,13 @@ class Zend_Controller_Front
                  */
                 $this->_plugins->postDispatch($this->_request);
             } while (!$this->_request->isDispatched());
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             if ($this->throwExceptions()) {
                 throw $e;
             }
-
+            if (!$e instanceof Exception) {
+                $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+            }
             $this->_response->setException($e);
         }
 
@@ -977,11 +984,13 @@ class Zend_Controller_Front
          */
         try {
             $this->_plugins->dispatchLoopShutdown();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             if ($this->throwExceptions()) {
                 throw $e;
             }
-
+            if (!$e instanceof Exception) {
+                $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+            }
             $this->_response->setException($e);
         }
 

--- a/packages/zend-controller/library/Zend/Controller/Plugin/Broker.php
+++ b/packages/zend-controller/library/Zend/Controller/Plugin/Broker.php
@@ -238,10 +238,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeStartup($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
                 }
             }
@@ -262,10 +265,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeShutdown($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
                 }
             }
@@ -290,10 +296,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->dispatchLoopStartup($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
                 }
             }
@@ -313,10 +322,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->preDispatch($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
 					// skip rendering of normal dispatch give the error handler a try
 					$this->getRequest()->setDispatched(false);
@@ -338,10 +350,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->postDispatch($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
                 }
             }
@@ -361,10 +376,13 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
        foreach ($this->_plugins as $plugin) {
            try {
                 $plugin->dispatchLoopShutdown();
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
+                    if (!$e instanceof Exception) {
+                        $e = new Zend_Controller_Exception($e->getMessage(), $e->getCode(), $e);
+                    }
                     $this->getResponse()->setException($e);
                 }
             }

--- a/packages/zend-json/library/Zend/Json/Server.php
+++ b/packages/zend-json/library/Zend/Json/Server.php
@@ -568,7 +568,7 @@ class Zend_Json_Server extends Zend_Server_Abstract
 
         try {
             $result = $this->_dispatch($invocable, $params);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return $this->fault($e->getMessage(), $e->getCode(), $e);
         }
 

--- a/packages/zend-rest/library/Zend/Rest/Server.php
+++ b/packages/zend-rest/library/Zend/Rest/Server.php
@@ -266,7 +266,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
                                 $this->_functions[$this->_method]->getName(),
                                 $callingArgs
                             );
-                        } catch (Exception $e) {
+                        } catch (Throwable $e) {
                             $result = $this->fault($e);
                         }
                     }
@@ -515,7 +515,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
         $xmlResponse = $dom->createElement('response');
         $xmlMethod->appendChild($xmlResponse);
 
-        if ($exception instanceof Exception) {
+        if ($exception instanceof Throwable) {
             $element = $dom->createElement('message');
             $element->appendChild(
                 $dom->createTextNode($exception->getMessage())
@@ -630,7 +630,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
                 ),
                 $args
             );
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $result = $this->fault($e);
         }
         return $result;
@@ -652,7 +652,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
             } else {
                 $object = $this->_functions[$this->_method]->getDeclaringClass()->newInstance();
             }
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             // require_once 'Zend/Rest/Server/Exception.php';
             throw new Zend_Rest_Server_Exception(
                 'Error instantiating class ' . $class .
@@ -669,7 +669,7 @@ class Zend_Rest_Server implements Zend_Server_Interface
                 $object,
                 $args
             );
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $result = $this->fault($e);
         }
 

--- a/packages/zend-soap/library/Zend/Soap/Server.php
+++ b/packages/zend-soap/library/Zend/Soap/Server.php
@@ -887,7 +887,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
         } else {
             try {
                 $soap->handle($this->_request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $fault = $this->fault($e);
             }
         }
@@ -978,7 +978,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
      */
     public function fault($fault = null, $code = "Receiver")
     {
-        if ($fault instanceof Exception) {
+        if ($fault instanceof Throwable) {
             $class = get_class($fault);
             if (in_array($class, $this->_faultExceptions)) {
                 $message = $fault->getMessage();

--- a/packages/zend-tool/library/Zend/Tool/Framework/Client/Abstract.php
+++ b/packages/zend-tool/library/Zend/Tool/Framework/Client/Abstract.php
@@ -242,7 +242,10 @@ abstract class Zend_Tool_Framework_Client_Abstract implements Zend_Tool_Framewor
 
             }
 
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
+            if (!$exception instanceof Exception) {
+                $exception = new Zend_Tool_Framework_Client_Exception($exception->getMessage(), $exception->getCode(), $exception);
+            }
             $this->_registry->getResponse()->setException($exception);
         }
 

--- a/packages/zend-xmlrpc/library/Zend/XmlRpc/Server.php
+++ b/packages/zend-xmlrpc/library/Zend/XmlRpc/Server.php
@@ -304,7 +304,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
      */
     public function fault($fault = null, $code = 404)
     {
-        if (!$fault instanceof Exception) {
+        if (!$fault instanceof Throwable) {
             $fault = (string) $fault;
             if (empty($fault)) {
                 $fault = 'Unknown Error';
@@ -340,7 +340,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         } else {
             try {
                 $response = $this->_handle($request);
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 $response = $this->fault($e);
             }
         }

--- a/packages/zend-xmlrpc/library/Zend/XmlRpc/Server/System.php
+++ b/packages/zend-xmlrpc/library/Zend/XmlRpc/Server/System.php
@@ -144,7 +144,7 @@ class Zend_XmlRpc_Server_System
                     } else {
                         $responses[] = $response->getReturnValue();
                     }
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     $fault = $this->_server->fault($e);
                 }
             }

--- a/tests/Zend/Controller/FrontTest.php
+++ b/tests/Zend/Controller/FrontTest.php
@@ -705,6 +705,34 @@ class Zend_Controller_FrontTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse(Zend_Controller_Action_HelperBroker::hasHelper('viewRenderer'));
     }
+
+    public function testDispatchCatchesPhpErrorFromControllerAction()
+    {
+        $this->_controller->throwExceptions(false);
+
+        $request  = new Zend_Controller_Request_Http('http://example.com/error-throwing/index');
+        $response = $this->_controller->dispatch($request);
+
+        $exceptions = $response->getException();
+        $this->assertNotEmpty($exceptions);
+        $this->assertInstanceOf('Zend_Controller_Exception', $exceptions[0]);
+        $this->assertInstanceOf('TypeError', $exceptions[0]->getPrevious());
+    }
+
+    public function testDispatchRethrowsPhpErrorFromControllerAction()
+    {
+        $this->_controller->throwExceptions(true);
+
+        $request = new Zend_Controller_Request_Http('http://example.com/error-throwing/index');
+
+        try {
+            $this->_controller->dispatch($request);
+            $this->fail('Dispatch should throw when throwExceptions is true');
+        } catch (Throwable $e) {
+            $this->assertInstanceOf('TypeError', $e);
+            $this->assertEquals('controller action triggered a type error', $e->getMessage());
+        }
+    }
 }
 
 // Call Zend_Controller_FrontTest::main() if this source file is executed directly.

--- a/tests/Zend/Controller/Plugin/BrokerTest.php
+++ b/tests/Zend/Controller/Plugin/BrokerTest.php
@@ -207,6 +207,47 @@ class Zend_Controller_Plugin_BrokerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->hasExceptionOfMessage('dispatchLoopShutdown triggered exception'));
     }
 
+    public function testBrokerCatchesPhpErrors()
+    {
+        $request  = new Zend_Controller_Request_Http('http://framework.zend.com/empty');
+        $response = new Zend_Controller_Response_Cli();
+        $broker   = new Zend_Controller_Plugin_Broker();
+        $broker->setRequest($request);
+        $broker->setResponse($response);
+        $broker->registerPlugin(new Zend_Controller_Plugin_BrokerTest_ErrorTestPlugin());
+        try {
+            $broker->routeStartup($request);
+        } catch (Throwable $e) {
+            $this->fail('Broker should catch PHP errors: ' . $e->getMessage());
+        }
+
+        $exceptions = $response->getException();
+        $this->assertCount(1, $exceptions);
+        $this->assertInstanceOf('Zend_Controller_Exception', $exceptions[0]);
+        $this->assertInstanceOf('TypeError', $exceptions[0]->getPrevious());
+        $this->assertEquals('routeStartup triggered error', $exceptions[0]->getMessage());
+    }
+
+    public function testBrokerWrapsPhpErrorsWhenThrowExceptions()
+    {
+        $this->controller->throwExceptions(true);
+
+        $request  = new Zend_Controller_Request_Http('http://framework.zend.com/empty');
+        $response = new Zend_Controller_Response_Cli();
+        $broker   = new Zend_Controller_Plugin_Broker();
+        $broker->setRequest($request);
+        $broker->setResponse($response);
+        $broker->registerPlugin(new Zend_Controller_Plugin_BrokerTest_ErrorTestPlugin());
+
+        try {
+            $broker->routeStartup($request);
+            $this->fail('Broker should throw when throwExceptions is true');
+        } catch (Throwable $e) {
+            $this->assertInstanceOf('Zend_Controller_Exception', $e);
+            $this->assertInstanceOf('TypeError', $e->getPrevious());
+        }
+    }
+
     public function testRegisterPluginStackOrderIsSane()
     {
         $broker   = new Zend_Controller_Plugin_Broker();
@@ -337,6 +378,14 @@ class Zend_Controller_Plugin_BrokerTest_ExceptionTestPlugin extends Zend_Control
     public function dispatchLoopShutdown()
     {
         throw new Exception('dispatchLoopShutdown triggered exception');
+    }
+}
+
+class Zend_Controller_Plugin_BrokerTest_ErrorTestPlugin extends Zend_Controller_Plugin_Abstract
+{
+    public function routeStartup(Zend_Controller_Request_Abstract $request)
+    {
+        throw new TypeError('routeStartup triggered error');
     }
 }
 

--- a/tests/Zend/Controller/_files/ErrorThrowingController.php
+++ b/tests/Zend/Controller/_files/ErrorThrowingController.php
@@ -1,0 +1,8 @@
+<?php
+class ErrorThrowingController extends Zend_Controller_Action
+{
+    public function indexAction()
+    {
+        throw new TypeError('controller action triggered a type error');
+    }
+}


### PR DESCRIPTION
closes #201

Since PHP 7, `Error` classes (`TypeError`, `DivisionByZeroError`, etc.) extend `Throwable` but not `Exception`. The framework's `catch (Exception)` blocks in dispatch chains and server handlers let these slip through as unhandled crashes.

Mainly affects `zend-controller` (front controller, dispatcher, plugin broker). The same pattern is also fixed in server components (`zend-rest`, `zend-soap`, `zend-json`, `zend-xmlrpc`) and `zend-tool`.

Now that PHP 7.1 is the minimum (#218), all error boundary catch blocks are widened to `catch (Throwable)`.

#### `setException()` compatibility

`Zend_Controller_Response_Abstract::setException()` and `Zend_Tool_Framework_Client_Response::setException()` type-hint `Exception`. To avoid a BC break in the method signature, non-Exception throwables are wrapped in the appropriate framework exception class before being passed, with the original preserved as `$previous`.

Wrapping means that e.g. a `DivisionByZeroError` will appear in the response as `Zend_Controller_Exception`, so `hasExceptionOfType('DivisionByZeroError')` won't match - but the original is accessible via `getPrevious()`. This is a non-issue in practice: nobody can be checking for `Error` subtypes in the response because they were never caught before. Any existing `hasExceptionOfType()` usage checks for `Exception` subclasses, which still pass through unwrapped.

If you need to handle a specific error type, catch it directly in your controller action before it reaches the dispatch boundary.

#### server `fault()` methods

`instanceof Exception` checks in `Zend_Rest_Server::fault()`, `Zend_Soap_Server::fault()`, and `Zend_XmlRpc_Server::fault()` are updated to `instanceof Throwable` so error details (message, code) are properly extracted instead of falling through to generic "Unknown error" messages.