### PR TITLE
Fix Zend_Db::FETCH_* modifier-flag drift from PDO on PHP 8.5

### DIFF
--- a/packages/zend-db/library/Zend/Db/Statement/Pdo.php
+++ b/packages/zend-db/library/Zend/Db/Statement/Pdo.php
@@ -254,7 +254,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             $cursor = PDO::FETCH_ORI_NEXT;
         }
         try {
-            return $this->_stmt->fetch($style, $cursor, $offset);
+            return $this->_stmt->fetch(self::_normalizeFetchMode($style), $cursor, $offset);
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
@@ -262,6 +262,59 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);
         }
+    }
+
+    /**
+     * Translate Zend_Db fetch-mode modifier flags to their native PDO values.
+     *
+     * The Zend_Db::FETCH_* constants are integer literals frozen from an old
+     * PDO snapshot (see the generator note in Zend_Db). PHP 8.5 renumbered the
+     * PDO fetch *modifier* flags (FETCH_GROUP, FETCH_UNIQUE, FETCH_CLASSTYPE,
+     * FETCH_SERIALIZE), so the frozen literals no longer equal PDO's runtime
+     * constants and PDO rejects them with a ValueError ("must be a bitmask of
+     * PDO::FETCH_* constants"). Remap the drifted flag bits before handing the
+     * mode to the native PDOStatement. On PHP < 8.5 every mapping is the
+     * identity, so this is a no-op there.
+     *
+     * The base fetch mode (FETCH_ASSOC, FETCH_NUM, FETCH_COLUMN, ...) is
+     * unchanged across versions and passes through untouched. Flags are
+     * remapped widest-first because the legacy literals overlap in their bit
+     * patterns (legacy FETCH_UNIQUE embeds the legacy FETCH_GROUP bit).
+     *
+     * @param  mixed $mode
+     * @return mixed
+     */
+    protected static function _normalizeFetchMode($mode)
+    {
+        if (!is_int($mode)) {
+            return $mode;
+        }
+
+        // legacy Zend_Db literal => native PDO runtime value; widest flag first
+        $flags = array(
+            Zend_Db::FETCH_UNIQUE    => PDO::FETCH_UNIQUE,
+            Zend_Db::FETCH_GROUP     => PDO::FETCH_GROUP,
+            Zend_Db::FETCH_CLASSTYPE => PDO::FETCH_CLASSTYPE,
+            Zend_Db::FETCH_SERIALIZE => PDO::FETCH_SERIALIZE,
+        );
+
+        $allFlags = 0;
+        foreach ($flags as $legacy => $native) {
+            $allFlags |= $legacy;
+        }
+
+        // Keep the base fetch mode, drop any legacy modifier-flag bits...
+        $result = $mode & ~$allFlags;
+        // ...then re-add the modifier flags using PDO's runtime values.
+        $remaining = $mode;
+        foreach ($flags as $legacy => $native) {
+            if (($remaining & $legacy) === $legacy) {
+                $result |= $native;
+                $remaining &= ~$legacy;
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -293,9 +346,9 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
                 if ($col === null) {
                     $col = 0;
                 }
-                return $this->_stmt->fetchAll($style, $col);
+                return $this->_stmt->fetchAll(self::_normalizeFetchMode($style), $col);
             } else {
-                return $this->_stmt->fetchAll($style);
+                return $this->_stmt->fetchAll(self::_normalizeFetchMode($style));
             }
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
@@ -440,7 +493,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
     {
         $this->_fetchMode = $mode;
         try {
-            return $this->_stmt->setFetchMode($mode);
+            return $this->_stmt->setFetchMode(self::_normalizeFetchMode($mode));
         } catch (ValueError $e) {
             // PHP 8.0+ throws ValueError on invalid arguments
             throw new Zend_Db_Statement_Exception($e->getMessage(), $e->getCode(), $e);

--- a/tests/Zend/Db/Statement/PdoFetchModeTest.php
+++ b/tests/Zend/Db/Statement/PdoFetchModeTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Db
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+
+/**
+ * Regression coverage for the drift between the frozen Zend_Db::FETCH_*
+ * literals and the native PDO::FETCH_* constants, which PHP 8.5 renumbered.
+ *
+ * @category   Zend
+ * @package    Zend_Db
+ * @subpackage UnitTests
+ * @group      Zend_Db
+ * @group      Zend_Db_Statement
+ */
+class Zend_Db_Statement_PdoFetchModeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @param  mixed $mode
+     * @return mixed
+     */
+    private function normalize($mode)
+    {
+        $method = new ReflectionMethod('Zend_Db_Statement_Pdo', '_normalizeFetchMode');
+        $method->setAccessible(true);
+        return $method->invoke(null, $mode);
+    }
+
+    public function testBaseFetchModesPassThroughUnchanged()
+    {
+        $this->assertSame(PDO::FETCH_ASSOC, $this->normalize(Zend_Db::FETCH_ASSOC));
+        $this->assertSame(PDO::FETCH_NUM, $this->normalize(Zend_Db::FETCH_NUM));
+        $this->assertSame(PDO::FETCH_BOTH, $this->normalize(Zend_Db::FETCH_BOTH));
+        $this->assertSame(PDO::FETCH_OBJ, $this->normalize(Zend_Db::FETCH_OBJ));
+        $this->assertSame(PDO::FETCH_COLUMN, $this->normalize(Zend_Db::FETCH_COLUMN));
+    }
+
+    public function testModifierFlagsMapToNativePdoValues()
+    {
+        $this->assertSame(PDO::FETCH_GROUP, $this->normalize(Zend_Db::FETCH_GROUP));
+        $this->assertSame(PDO::FETCH_UNIQUE, $this->normalize(Zend_Db::FETCH_UNIQUE));
+        $this->assertSame(PDO::FETCH_CLASSTYPE, $this->normalize(Zend_Db::FETCH_CLASSTYPE));
+        $this->assertSame(PDO::FETCH_SERIALIZE, $this->normalize(Zend_Db::FETCH_SERIALIZE));
+    }
+
+    public function testCombinedFetchModesMapToNativePdoBitmask()
+    {
+        $this->assertSame(
+            PDO::FETCH_GROUP | PDO::FETCH_COLUMN,
+            $this->normalize(Zend_Db::FETCH_GROUP | Zend_Db::FETCH_COLUMN)
+        );
+        $this->assertSame(
+            PDO::FETCH_UNIQUE | PDO::FETCH_COLUMN,
+            $this->normalize(Zend_Db::FETCH_UNIQUE | Zend_Db::FETCH_COLUMN)
+        );
+    }
+
+    /**
+     * Regression guard: the legacy FETCH_UNIQUE literal (0x30000) embeds the
+     * legacy FETCH_GROUP bit (0x10000). The remap must yield exactly
+     * PDO::FETCH_UNIQUE and must not spuriously OR in PDO::FETCH_GROUP.
+     */
+    public function testOverlappingUniqueFlagRemapsExactly()
+    {
+        $this->assertSame(PDO::FETCH_UNIQUE, $this->normalize(Zend_Db::FETCH_UNIQUE));
+    }
+
+    public function testNonIntegerModeIsReturnedUnchanged()
+    {
+        $this->assertNull($this->normalize(null));
+    }
+}


### PR DESCRIPTION

## What

Remap the `Zend_Db::FETCH_*` fetch-mode **modifier flags** to their native
`PDO::FETCH_*` values inside `Zend_Db_Statement_Pdo` before forwarding a fetch
mode to the underlying `PDOStatement`.

Fixes the `ValueError: ... must be a bitmask of PDO::FETCH_* constants` thrown
on **PHP 8.5** by `fetch()` / `fetchAll()` / `setFetchMode()` whenever
`FETCH_GROUP`, `FETCH_UNIQUE`, `FETCH_CLASSTYPE` or `FETCH_SERIALIZE` is used.

## Why

`Zend_Db::FETCH_*` are integer literals frozen from an old PDO snapshot
(`FETCH_GROUP = 65536`, `FETCH_UNIQUE = 196608`, …). PHP 8.5 renumbered the PDO
fetch modifier flags (`FETCH_GROUP` `65536 → 32`, `FETCH_UNIQUE` `196608 → 64`,
etc.), so the frozen literals no longer equal PDO's runtime constants and PDO
rejects them. Base fetch modes (`ASSOC`/`NUM`/`COLUMN`/…) are unchanged and
unaffected.

## Approach

Translate at the adapter boundary (`ext-pdo` guaranteed there) instead of
redefining the `Zend_Db::FETCH_*` constants — the latter would fatal at class
load on non-PDO adapters (Mysqli/Oracle/Db2/Sqlsrv) without `ext-pdo`, and would
change a public API surface that external code compares against.

The remap strips the legacy flag bits and re-adds PDO's runtime values
widest-flag-first, because the legacy literals overlap
(`FETCH_UNIQUE` `0x30000` embeds the `FETCH_GROUP` bit `0x10000`) — a naive
per-bit swap would leak `FETCH_GROUP` into a `FETCH_UNIQUE`-only request.

On **PHP < 8.5** every mapping is the identity, so this is a no-op there.

## Tests

`tests/Zend/Db/Statement/PdoFetchModeTest.php` — DB-less, exercises the
translation via reflection: base modes pass through, each modifier flag maps to
its `PDO::FETCH_*` equivalent, combined bitmasks (`FETCH_GROUP | FETCH_COLUMN`)
remap correctly, and the `FETCH_UNIQUE ⊃ FETCH_GROUP` overlap is guarded.
Meaningful on every version in the CI matrix (identity on ≤ 8.4, real remap on 8.5).

Fixes #231